### PR TITLE
Fix puzzle rendering outside of the wrapper

### DIFF
--- a/binary.html
+++ b/binary.html
@@ -17,7 +17,9 @@ title: Binary Puzzle
             </div>
             <div id="progressIndicator" class="mt-3"></div>
             <div id="timer" class="mt-3"></div>
-            <table id="puzzleGrid" class="table table-bordered mt-3"></table>
+            <div id="puzzleContainer">
+                <table id="puzzleGrid" class="table table-bordered mt-3"></table>
+            </div>
             <div id="rules" class="mt-3">
                 <h2>Game Rules</h2>
                 <p>The goal of the binary puzzle is to fill the grid with 0s and 1s, following these rules:</p>

--- a/binary.js
+++ b/binary.js
@@ -1,7 +1,7 @@
 document.addEventListener("DOMContentLoaded", function () {
     const gridSize = 8;
     const grid = document.createElement("table");
-    const body = document.querySelector("body");
+    const puzzleContainer = document.getElementById("puzzleContainer");
 
     let solutionVisible = false;
     let solutionGrid = null;
@@ -203,6 +203,6 @@ document.addEventListener("DOMContentLoaded", function () {
 
     const puzzle = generatePuzzle();
     renderPuzzle(puzzle);
-    body.appendChild(grid);
+    puzzleContainer.appendChild(grid);
     startTimer();
 });

--- a/css/main.css
+++ b/css/main.css
@@ -392,3 +392,10 @@ nav.pagination ul.page-numbers li {
     padding: 8px 16px;
   }
 }
+
+#puzzleContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+}


### PR DESCRIPTION
Fix the puzzle rendering outside of the wrapper.

* **binary.html**
  - Add a `div` element with the id `puzzleContainer` to contain the puzzle grid.
  - Move the `puzzleGrid` table inside the new `div` element.

* **binary.js**
  - Update the `body` selector to reference the new `div` element with the id `puzzleContainer`.
  - Append the `grid` to the `puzzleContainer` instead of the `body`.

* **css/main.css**
  - Add styles for the new `#puzzleContainer` div element to center the puzzle grid and add a margin at the top.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jorgecensi/jorgecensi.github.io/pull/37?shareId=380bd1fa-4c05-4a15-b2d9-d6ebf13ca387).