### PR TITLE
Improve visibility of the puzzle table

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -304,21 +304,24 @@ nav.pagination ul.page-numbers li {
 }
 
 #puzzleGrid td {
-  width: 50px;
-  height: 50px;
+  width: 70px;
+  height: 70px;
   text-align: center;
   vertical-align: middle;
-  font-size: 1.5em;
+  font-size: 2em;
   cursor: pointer;
   transition: background-color 0.3s ease;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  color: #000;
 }
 
 #puzzleGrid td:hover {
-  background-color: #f0f0f0;
+  background-color: #e0e0e0;
 }
 
 #puzzleGrid .solution-cell {
-  background-color: #d3ffd3;
+  background-color: #a3ffa3;
 }
 
 .btn-primary {
@@ -397,5 +400,5 @@ nav.pagination ul.page-numbers li {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 20px;
+  margin-top: 40px;
 }


### PR DESCRIPTION
Increase the size and visibility of the puzzle table cells.

* Increase the size of the puzzle grid cells to 70x70 pixels.
* Increase the font size of the puzzle grid cells to 2em.
* Add a border to the puzzle grid cells with value 1px solid #ccc.
* Enhance the contrast of the puzzle grid cells by changing the background-color to #fff and the color to #000.
* Improve the visibility of the solution cells by adjusting the background-color to #a3ffa3.
* Adjust the hover effect background color to #e0e0e0.
* Increase the margin-top of the puzzle container to 40px.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jorgecensi/jorgecensi.github.io/pull/38?shareId=9361ddc3-b71e-419d-8784-7c37b28e45bc).