### PR TITLE
Set puzzleContainer div to use full width

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -404,4 +404,5 @@ nav.pagination ul.page-numbers li {
   align-items: center;
   margin-top: 20px;
   width: 100%; /* P4d0f */
+  background-color: #ffffff; /* P28b2 */
 }


### PR DESCRIPTION
Update `css/main.css` to set the `#puzzleContainer` div to use full width and have a white background.

* Set the `width` property of `#puzzleContainer` to `100%`.
* Add the `background-color` property to `#puzzleContainer` and set it to `#ffffff`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jorgecensi/jorgecensi.github.io/pull/40?shareId=99f8c753-9c7b-48ed-a086-006f053f7157).