### PR TITLE
Fix binary puzzle table

### DIFF
--- a/binary.js
+++ b/binary.js
@@ -1,6 +1,6 @@
 document.addEventListener("DOMContentLoaded", function () {
     const gridSize = 8;
-    const grid = document.createElement("table");
+    const grid = document.getElementById("puzzleGrid");
     const puzzleContainer = document.getElementById("puzzleContainer");
 
     let solutionVisible = false;
@@ -203,6 +203,5 @@ document.addEventListener("DOMContentLoaded", function () {
 
     const puzzle = generatePuzzle();
     renderPuzzle(puzzle);
-    puzzleContainer.appendChild(grid);
     startTimer();
 });


### PR DESCRIPTION
Update `binary.js` to use the existing table element from `binary.html` instead of creating a new one.

* Remove the line that creates a new table element with `const grid = document.createElement("table");`.
* Add a line to get a reference to the existing table element with `const grid = document.getElementById("puzzleGrid");`.
* Remove the line that appends the new table element to the `puzzleContainer` element.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jorgecensi/jorgecensi.github.io/pull/42?shareId=cd00f803-1666-4342-8ba3-62ba07f78ef0).