### PR TITLE
Pwa cache version workflow

### DIFF
--- a/.github/workflows/bump-pwa-cache-version.yml
+++ b/.github/workflows/bump-pwa-cache-version.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout default branch
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.repository.default_branch }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Resolve version
         id: version


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix the "Bump PWA cache version" GitHub action by correcting invalid YAML indentation and updating the input variable reference for non-dispatch events.

<div><a href="https://cursor.com/agents/bc-9bf9e376-91c1-4bf8-9620-5afea6c5433d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bf9e376-91c1-4bf8-9620-5afea6c5433d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->