### PR TITLE
Timer navigation css

### DIFF
--- a/binary.html
+++ b/binary.html
@@ -1,3 +1,12 @@
+---
+layout: wrapper
+title: Binary Puzzle
+lang: en
+ref: binary
+hide_site_chrome: true
+permalink: /binary/
+---
+
 <div style="text-align: center;">
     <h1>Binary Puzzle</h1>
     <p>Fill the grid with 0s and 1s. Click a cell to cycle through values.</p>

--- a/crossfit-timer.html
+++ b/crossfit-timer.html
@@ -1,3 +1,8 @@
+---
+layout: null
+permalink: /crossfit-timer/
+---
+
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restore Jekyll frontmatter to `binary.html` and `crossfit-timer.html` to fix broken navigation and CSS.

<div><a href="https://cursor.com/agents/bc-ddf88848-24f0-4bda-9b2e-d3bb9700a125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddf88848-24f0-4bda-9b2e-d3bb9700a125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->