### PR TITLE
iPhone white stripes

### DIFF
--- a/crossfit-timer.html
+++ b/crossfit-timer.html
@@ -7,7 +7,11 @@ permalink: /crossfit-timer/
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="CrossFit Timer">
+    <meta name="theme-color" content="#0f172a">
     <title>CrossFit Timer</title>
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" type="image/png" sizes="192x192" href="/img/timer-icon-192.png">
@@ -356,6 +360,10 @@ permalink: /crossfit-timer/
     padding: 0;
 }
 
+html {
+    background: #0f172a;
+}
+
 body {
     font-family: 'Inter', sans-serif;
     background:
@@ -367,6 +375,8 @@ body {
     padding: 20px;
     padding-top: max(20px, env(safe-area-inset-top));
     padding-bottom: max(20px, env(safe-area-inset-bottom));
+    padding-left: max(20px, env(safe-area-inset-left));
+    padding-right: max(20px, env(safe-area-inset-right));
     -webkit-tap-highlight-color: transparent;
 }
 
@@ -1157,6 +1167,8 @@ body {
         padding: 12px;
         padding-top: max(12px, env(safe-area-inset-top));
         padding-bottom: max(16px, env(safe-area-inset-bottom));
+        padding-left: max(12px, env(safe-area-inset-left));
+        padding-right: max(12px, env(safe-area-inset-right));
     }
 
     .cf-container {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove white stripes on iPhone by adding `viewport-fit=cover` and Apple PWA meta tags, and setting the `html` background.

The white stripes were caused by the page not extending into iOS safe areas (notch, Dynamic Island, home indicator) due to missing `viewport-fit=cover` and incorrect background styling.

<div><a href="https://cursor.com/agents/bc-ceb193ad-5ade-477e-b435-404ff683291e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceb193ad-5ade-477e-b435-404ff683291e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->