### PR TITLE
Incorrect PWA icon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="{% if lang == 'pt-BR' %}Puzzle Binário{% else %}Binary Puzzle{% endif %}">
-    <link rel="apple-touch-icon" href="/img/timer-icon-192.png">
+    <link rel="apple-touch-icon" href="/img/binary-icon-192.png">
     <link rel="manifest" href="{% if lang == 'pt-BR' %}/binary-pt-BR-manifest.json{% else %}/binary-manifest.json{% endif %}">
     {% endif %}
     {% seo %}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Corrects the Binary PWA icon and manifest for iOS home screen installs.

Previously, the shared `_layouts/default.html` hard-coded the CrossFit `apple-touch-icon` and a global `rel="manifest"` link, causing iOS to display the wrong icon and potentially use incorrect PWA metadata for the Binary app. This change ensures Binary pages use their specific icon and manifest.

<div><a href="https://cursor.com/agents/bc-e006ef1a-e74c-4706-8836-91ad6c94e7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e006ef1a-e74c-4706-8836-91ad6c94e7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->