### PR TITLE
Duplicate language flags

### DIFF
--- a/_includes/lang-switcher.html
+++ b/_includes/lang-switcher.html
@@ -1,4 +1,5 @@
 {% assign current_lang = page.lang | default: "en" %}
+{% if page.ref %}
 {% assign pages = site.pages | where: "ref", page.ref %}
 <div class="lang-switcher">
     {% for p in pages %}
@@ -14,3 +15,4 @@
     {% endif %}
     {% endfor %}
 </div>
+{% endif %}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix: Prevent duplicate language flags on blog posts by only rendering the language switcher if `page.ref` is set.

Blog posts lack a `ref` frontmatter field, causing `page.ref` to be nil. The Liquid `where` filter with a nil value matches *all* pages, resulting in 14 duplicate flags on blog post pages.

<div><a href="https://cursor.com/agents/bc-1c180a20-682f-4cca-96e5-e88b883e04f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c180a20-682f-4cca-96e5-e88b883e04f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->