### PR TITLE
feat: add PWA update notification banners to all apps

### DIFF
--- a/.github/workflows/bump-pwa-cache-version.yml
+++ b/.github/workflows/bump-pwa-cache-version.yml
@@ -2,6 +2,8 @@ name: Bump PWA cache version
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
   workflow_dispatch:
@@ -16,48 +18,98 @@ permissions:
 jobs:
   bump-cache-version:
     runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
     steps:
       - name: Checkout default branch
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 2
 
       - name: Resolve version
         id: version
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             VERSION="${{ github.event.inputs.version }}"
-          else
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ] && [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF_NAME}"
+          else
+            VERSION="$(git rev-parse --short HEAD)"
           fi
           VERSION="${VERSION#v}"
           echo "value=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Detect changed PWA files
+        id: changed
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+
+          check() {
+            local files="$1"
+            for f in $files; do
+              if echo "$CHANGED" | grep -qF "$f"; then
+                echo "true"
+                return
+              fi
+            done
+            echo "false"
+          }
+
+          echo "binary=$(check 'binary-sw.js binary.js binary.html binary-manifest.json')" >> "${GITHUB_OUTPUT}"
+          echo "binary_ptbr=$(check 'pt-BR/binary-sw.js pt-BR/binary.html binary.js binary-pt-BR-manifest.json')" >> "${GITHUB_OUTPUT}"
+          echo "flappy=$(check 'flappy-sw.js flappy.html flappyBird.js flappy-manifest.json')" >> "${GITHUB_OUTPUT}"
+          echo "crossfit=$(check 'crossfit-sw.js crossfit-timer.html manifest.json')" >> "${GITHUB_OUTPUT}"
+          echo "curator=$(check 'curator/sw.js curator/index.html curator/manifest.json')" >> "${GITHUB_OUTPUT}"
 
       - name: Update PWA version constants
         run: |
           python3 - <<'PY'
           import pathlib
           import re
+          import os
 
           version = "${{ steps.version.outputs.value }}"
-          repo = pathlib.Path(".")
-
-          files_and_patterns = {
-              "crossfit-sw.js": r"const CACHE_VERSION = '[^']*';",
-              "flappy-sw.js": r"const CACHE_VERSION = '[^']*';",
-              "crossfit-timer.html": r"const SW_VERSION = '[^']*';",
-              "flappy.html": r"const SW_VERSION = '[^']*';",
+          is_tag_or_dispatch = "${{ github.event_name }}" in ("workflow_dispatch",) or "${{ github.ref }}".startswith("refs/tags/")
+          changed = {
+              "binary":       "${{ steps.changed.outputs.binary }}" == "true",
+              "binary_ptbr":  "${{ steps.changed.outputs.binary_ptbr }}" == "true",
+              "flappy":       "${{ steps.changed.outputs.flappy }}" == "true",
+              "crossfit":     "${{ steps.changed.outputs.crossfit }}" == "true",
+              "curator":      "${{ steps.changed.outputs.curator }}" == "true",
           }
 
-          for relative_path, pattern in files_and_patterns.items():
+          # On tag/dispatch, bump everything; on push to main, only bump changed PWAs
+          bump_all = is_tag_or_dispatch
+
+          repo = pathlib.Path(".")
+
+          # Files with separate CACHE_VERSION + SW_VERSION constants (flappy, crossfit)
+          versioned_files = {}
+          if bump_all or changed["flappy"]:
+              versioned_files["flappy-sw.js"] = ("CACHE_VERSION", version)
+              versioned_files["flappy.html"] = ("SW_VERSION", version)
+          if bump_all or changed["crossfit"]:
+              versioned_files["crossfit-sw.js"] = ("CACHE_VERSION", version)
+              versioned_files["crossfit-timer.html"] = ("SW_VERSION", version)
+
+          # Files with only CACHE_VERSION (binary, curator)
+          if bump_all or changed["binary"]:
+              versioned_files["binary-sw.js"] = ("CACHE_VERSION", version)
+          if bump_all or changed["binary_ptbr"]:
+              versioned_files["pt-BR/binary-sw.js"] = ("CACHE_VERSION", version)
+          if bump_all or changed["curator"]:
+              versioned_files["curator/sw.js"] = ("CACHE_VERSION", version)
+
+          for relative_path, (const_name, ver) in versioned_files.items():
               path = repo / relative_path
               content = path.read_text(encoding="utf-8")
-              replacement = "const CACHE_VERSION = '{}'".format(version) if "sw.js" in relative_path else "const SW_VERSION = '{}'".format(version)
-              replacement = replacement + ";"
+              pattern = rf"const {const_name} = '[^']*';"
+              replacement = f"const {const_name} = '{ver}';"
               updated, count = re.subn(pattern, replacement, content, count=1)
               if count != 1:
-                  raise RuntimeError(f"Expected to update one version constant in {relative_path}, found {count}.")
+                  raise RuntimeError(f"Expected to update one {const_name} in {relative_path}, found {count}.")
               path.write_text(updated, encoding="utf-8")
+              print(f"Updated {const_name} in {relative_path} -> {ver}")
           PY
 
       - name: Commit and push
@@ -69,6 +121,13 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add crossfit-sw.js flappy-sw.js crossfit-timer.html flappy.html
-          git commit -m "chore: bump PWA cache version to ${{ steps.version.outputs.value }}"
+          git add \
+            binary-sw.js \
+            pt-BR/binary-sw.js \
+            crossfit-sw.js \
+            flappy-sw.js \
+            curator/sw.js \
+            crossfit-timer.html \
+            flappy.html
+          git commit -m "chore: bump PWA cache version to ${{ steps.version.outputs.value }} [skip ci]"
           git push origin "HEAD:${{ github.event.repository.default_branch }}"

--- a/binary-sw.js
+++ b/binary-sw.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = "binary-puzzle-en-v3";
+const CACHE_VERSION = 'dev';
+const CACHE_NAME = `binary-puzzle-en-${CACHE_VERSION}`;
 const OFFLINE_URL = "/binary/";
 const PRECACHE_URLS = [
   "/binary/",
@@ -14,7 +15,12 @@ self.addEventListener("install", (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
   );
-  self.skipWaiting();
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
 });
 
 self.addEventListener("activate", (event) => {
@@ -23,7 +29,7 @@ self.addEventListener("activate", (event) => {
       const cacheNames = await caches.keys();
       await Promise.all(
         cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME && cacheName.startsWith("binary-puzzle-")) {
+          if (cacheName !== CACHE_NAME && cacheName.startsWith("binary-puzzle-en-")) {
             return caches.delete(cacheName);
           }
           return Promise.resolve();

--- a/binary.js
+++ b/binary.js
@@ -533,8 +533,59 @@ document.addEventListener("DOMContentLoaded", () => {
         const serviceWorkerUrl = isPortugueseRoute ? "/pt-BR/binary-sw.js" : "/binary-sw.js";
         const scope = isPortugueseRoute ? "/pt-BR/binary/" : "/binary/";
 
+        function showUpdateBanner(registration) {
+            if (document.getElementById("sw-update-banner")) {
+                return;
+            }
+            const banner = document.createElement("div");
+            banner.id = "sw-update-banner";
+            banner.style.cssText = [
+                "position:fixed", "bottom:0", "left:0", "right:0",
+                "background:#1e1d3a", "color:#e2e8f0", "padding:12px 16px",
+                "display:flex", "align-items:center", "justify-content:space-between",
+                "z-index:9999", "font-family:inherit", "font-size:14px",
+                "border-top:1px solid #6366f1"
+            ].join(";");
+            banner.innerHTML = [
+                "<span>A new version is available.</span>",
+                "<button style=\"background:#6366f1;color:#fff;border:none;padding:6px 14px;",
+                "border-radius:4px;cursor:pointer;font-size:14px\">Refresh</button>"
+            ].join("");
+            banner.querySelector("button").addEventListener("click", () => {
+                if (registration.waiting) {
+                    registration.waiting.postMessage({ type: "SKIP_WAITING" });
+                }
+            });
+            document.body.appendChild(banner);
+        }
+
+        let hasRefreshedForUpdate = false;
+
         window.addEventListener("load", () => {
-            navigator.serviceWorker.register(serviceWorkerUrl, { scope }).catch(() => {
+            navigator.serviceWorker.register(serviceWorkerUrl, { scope }).then((registration) => {
+                if (registration.waiting) {
+                    showUpdateBanner(registration);
+                }
+
+                registration.addEventListener("updatefound", () => {
+                    const newWorker = registration.installing;
+                    if (!newWorker) return;
+                    newWorker.addEventListener("statechange", () => {
+                        if (newWorker.state === "installed" && navigator.serviceWorker.controller) {
+                            showUpdateBanner(registration);
+                        }
+                    });
+                });
+
+                navigator.serviceWorker.addEventListener("controllerchange", () => {
+                    if (hasRefreshedForUpdate) return;
+                    hasRefreshedForUpdate = true;
+                    window.location.reload();
+                });
+
+                window.addEventListener("focus", () => registration.update());
+                setInterval(() => registration.update(), 60 * 60 * 1000);
+            }).catch(() => {
                 // Keep gameplay functional if service worker registration fails.
             });
         });

--- a/crossfit-timer.html
+++ b/crossfit-timer.html
@@ -2331,10 +2331,27 @@ if ('serviceWorker' in navigator) {
     let hasRefreshedForUpdate = false;
 
     const askToUpdate = (registration) => {
-        const shouldUpdate = window.confirm('A new CrossFit Timer update is ready. Update now?');
-        if (shouldUpdate && registration.waiting) {
-            registration.waiting.postMessage({ type: 'SKIP_WAITING' });
-        }
+        if (document.getElementById('sw-update-banner')) return;
+        const banner = document.createElement('div');
+        banner.id = 'sw-update-banner';
+        banner.style.cssText = [
+            'position:fixed', 'bottom:0', 'left:0', 'right:0',
+            'background:#1e293b', 'color:#e2e8f0', 'padding:12px 16px',
+            'display:flex', 'align-items:center', 'justify-content:space-between',
+            'z-index:9999', 'font-family:inherit', 'font-size:14px',
+            'border-top:2px solid #2563eb'
+        ].join(';');
+        banner.innerHTML = [
+            '<span>A new version is available.</span>',
+            '<button style="background:#2563eb;color:#fff;border:none;padding:6px 14px;',
+            'border-radius:4px;cursor:pointer;font-size:14px">Refresh</button>'
+        ].join('');
+        banner.querySelector('button').addEventListener('click', () => {
+            if (registration.waiting) {
+                registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+            }
+        });
+        document.body.appendChild(banner);
     };
 
     window.addEventListener('load', async () => {

--- a/curator/index.html
+++ b/curator/index.html
@@ -945,7 +945,58 @@ function hideBanner() {
 
 // ── Service Worker ────────────────────────────────────────────────────────────
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('./sw.js').catch(console.error);
+  let hasRefreshedForUpdate = false;
+
+  function showUpdateBanner(registration) {
+    if (document.getElementById('sw-update-banner')) return;
+    const banner = document.createElement('div');
+    banner.id = 'sw-update-banner';
+    banner.style.cssText = [
+      'position:fixed', 'bottom:0', 'left:0', 'right:0',
+      'background:#1a1a1a', 'color:#e5e5e5', 'padding:12px 16px',
+      'display:flex', 'align-items:center', 'justify-content:space-between',
+      'z-index:9999', 'font-family:inherit', 'font-size:14px',
+      'border-top:1px solid #333'
+    ].join(';');
+    banner.innerHTML = [
+      '<span>A new version is available.</span>',
+      '<button style="background:#e5e5e5;color:#0a0a0a;border:none;padding:6px 14px;',
+      'border-radius:4px;cursor:pointer;font-size:14px">Refresh</button>'
+    ].join('');
+    banner.querySelector('button').addEventListener('click', () => {
+      if (registration.waiting) {
+        registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+      }
+    });
+    document.body.appendChild(banner);
+  }
+
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('./sw.js').then(registration => {
+      if (registration.waiting) {
+        showUpdateBanner(registration);
+      }
+
+      registration.addEventListener('updatefound', () => {
+        const newWorker = registration.installing;
+        if (!newWorker) return;
+        newWorker.addEventListener('statechange', () => {
+          if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+            showUpdateBanner(registration);
+          }
+        });
+      });
+
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (hasRefreshedForUpdate) return;
+        hasRefreshedForUpdate = true;
+        window.location.reload();
+      });
+
+      window.addEventListener('focus', () => registration.update());
+      setInterval(() => registration.update(), 60 * 60 * 1000);
+    }).catch(console.error);
+  });
 }
 </script>
 </body>

--- a/curator/sw.js
+++ b/curator/sw.js
@@ -1,4 +1,5 @@
-const CACHE = 'curator-v1';
+const CACHE_VERSION = 'dev';
+const CACHE = `curator-${CACHE_VERSION}`;
 const SHELL = [
   './',
   './index.html',
@@ -13,7 +14,12 @@ self.addEventListener('install', e => {
   e.waitUntil(
     caches.open(CACHE).then(cache => cache.addAll(SHELL))
   );
-  self.skipWaiting();
+});
+
+self.addEventListener('message', e => {
+  if (e.data && e.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
 });
 
 // Activate: clean old caches

--- a/flappy.html
+++ b/flappy.html
@@ -96,10 +96,27 @@ permalink: /flappy/
             let hasRefreshedForUpdate = false;
 
             const askToUpdate = (registration) => {
-                const shouldUpdate = window.confirm('A new Flappy Bird update is ready. Update now?');
-                if (shouldUpdate && registration.waiting) {
-                    registration.waiting.postMessage({ type: 'SKIP_WAITING' });
-                }
+                if (document.getElementById('sw-update-banner')) return;
+                const banner = document.createElement('div');
+                banner.id = 'sw-update-banner';
+                banner.style.cssText = [
+                    'position:fixed', 'bottom:0', 'left:0', 'right:0',
+                    'background:#1a3a3f', 'color:#fff', 'padding:12px 16px',
+                    'display:flex', 'align-items:center', 'justify-content:space-between',
+                    'z-index:9999', 'font-family:inherit', 'font-size:14px',
+                    'border-top:2px solid #70c5ce'
+                ].join(';');
+                banner.innerHTML = [
+                    '<span>A new version is available.</span>',
+                    '<button style="background:#70c5ce;color:#1a3a3f;border:none;padding:6px 14px;',
+                    'border-radius:4px;cursor:pointer;font-size:14px;font-weight:bold">Refresh</button>'
+                ].join('');
+                banner.querySelector('button').addEventListener('click', function() {
+                    if (registration.waiting) {
+                        registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+                    }
+                });
+                document.body.appendChild(banner);
             };
 
             window.addEventListener('load', async function() {

--- a/pt-BR/binary-sw.js
+++ b/pt-BR/binary-sw.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = "binary-puzzle-ptbr-v3";
+const CACHE_VERSION = 'dev';
+const CACHE_NAME = `binary-puzzle-ptbr-${CACHE_VERSION}`;
 const OFFLINE_URL = "/pt-BR/binary/";
 const PRECACHE_URLS = [
   "/pt-BR/binary/",
@@ -14,7 +15,12 @@ self.addEventListener("install", (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
   );
-  self.skipWaiting();
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
 });
 
 self.addEventListener("activate", (event) => {
@@ -23,7 +29,7 @@ self.addEventListener("activate", (event) => {
       const cacheNames = await caches.keys();
       await Promise.all(
         cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME && cacheName.startsWith("binary-puzzle-")) {
+          if (cacheName !== CACHE_NAME && cacheName.startsWith("binary-puzzle-ptbr-")) {
             return caches.delete(cacheName);
           }
           return Promise.resolve();


### PR DESCRIPTION
- Binary Puzzle (EN + PT-BR): restructured service workers to use CACHE_VERSION constant and wait for SKIP_WAITING message instead of calling skipWaiting() on install; added update detection and in-page banner to registerServiceWorker() in binary.js

- Curator: same SW restructure; added full update detection and banner to index.html (replaces bare .register() call)

- Flappy Bird + CrossFit Timer: replaced window.confirm() prompts with non-blocking in-page banners matching each app's color theme

- GitHub Actions workflow: extended to trigger on push to main (in addition to tags/dispatch), detect which PWA files changed, and only bump CACHE_VERSION for the affected apps; added Binary Puzzle and Curator to the version-bumping script

https://claude.ai/code/session_01GhFgtehLPDMZag9Q59B7Kk