### PR TITLE
Display app version in PWA footer and use timestamp for cache versioning

### DIFF
--- a/.github/workflows/bump-pwa-cache-version.yml
+++ b/.github/workflows/bump-pwa-cache-version.yml
@@ -7,10 +7,6 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to set (example: 1.4.0 or v1.4.0)"
-        required: true
 
 permissions:
   contents: write
@@ -29,14 +25,7 @@ jobs:
       - name: Resolve version
         id: version
         run: |
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          elif [ "${GITHUB_EVENT_NAME}" = "push" ] && [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF_NAME}"
-          else
-            VERSION="$(git rev-parse --short HEAD)"
-          fi
-          VERSION="${VERSION#v}"
+          VERSION="$(date -u +"%y%m%d%H%M")"
           echo "value=${VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: Detect changed PWA files
@@ -95,10 +84,12 @@ jobs:
           # Files with only CACHE_VERSION (binary, curator)
           if bump_all or changed["binary"]:
               versioned_files["binary-sw.js"] = ("CACHE_VERSION", version)
+              versioned_files["binary.js"] = ("APP_VERSION", version)
           if bump_all or changed["binary_ptbr"]:
               versioned_files["pt-BR/binary-sw.js"] = ("CACHE_VERSION", version)
           if bump_all or changed["curator"]:
               versioned_files["curator/sw.js"] = ("CACHE_VERSION", version)
+              versioned_files["curator/index.html"] = ("APP_VERSION", version)
 
           for relative_path, (const_name, ver) in versioned_files.items():
               path = repo / relative_path
@@ -123,10 +114,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add \
             binary-sw.js \
+            binary.js \
             pt-BR/binary-sw.js \
             crossfit-sw.js \
             flappy-sw.js \
             curator/sw.js \
+            curator/index.html \
             crossfit-timer.html \
             flappy.html
           git commit -m "chore: bump PWA cache version to ${{ steps.version.outputs.value }} [skip ci]"

--- a/binary.html
+++ b/binary.html
@@ -55,4 +55,5 @@ permalink: /binary/
     <div id="binaryCelebration" class="binary-celebration" aria-hidden="true">Puzzle Complete!</div>
 </div>
 
+<p id="binary-app-version" style="font-size:11px;color:#6b7280;margin-top:8px;text-align:center"></p>
 <script src="/binary.js"></script>

--- a/binary.js
+++ b/binary.js
@@ -1,3 +1,5 @@
+const APP_VERSION = 'dev';
+
 document.addEventListener("DOMContentLoaded", () => {
     const gridSize = 8;
     const gridElement = document.getElementById("puzzleGrid");
@@ -869,4 +871,7 @@ document.addEventListener("DOMContentLoaded", () => {
     setupInstallPrompt();
     registerServiceWorker();
     startNewPuzzle();
+
+    const versionEl = document.getElementById("binary-app-version");
+    if (versionEl) versionEl.textContent = "v" + APP_VERSION;
 });

--- a/crossfit-timer.html
+++ b/crossfit-timer.html
@@ -32,6 +32,7 @@ permalink: /crossfit-timer/
             <div class="cf-badge-row">
                 <span class="cf-pill">Offline Ready</span>
                 <span class="cf-pill">One-Tap Pause</span>
+                <span class="cf-pill" id="crossfit-version" style="opacity:0.6"></span>
             </div>
         </div>
 
@@ -2327,6 +2328,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // Service Worker Registration for PWA
 const SW_VERSION = 'dev';
+document.getElementById('crossfit-version').textContent = 'v' + SW_VERSION;
 if ('serviceWorker' in navigator) {
     let hasRefreshedForUpdate = false;
 

--- a/curator/index.html
+++ b/curator/index.html
@@ -514,6 +514,7 @@
     <a href="#" class="logo" id="logo-btn">Curator</a>
     <div class="header-right">
       <span class="counter" id="counter"></span>
+      <span id="curator-version" style="font-size:10px;opacity:0.4;font-family:var(--mono)"></span>
       <button class="btn" id="sources-btn">⚙ Sources</button>
       <button class="btn" id="refresh-btn">⟳ Refresh</button>
       <button class="btn" id="key-btn" title="Change API key">🔑</button>
@@ -551,6 +552,7 @@
 
 <script>
 // ── Constants ────────────────────────────────────────────────────────────────
+const APP_VERSION = 'dev';
 const KEY_API   = 'curator_api_key';
 const KEY_SRCS  = 'curator_sources';
 const KEY_IDX   = 'curator_idx';
@@ -870,6 +872,8 @@ function saveKey() {
 
 // ── Event wiring ──────────────────────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('curator-version').textContent = 'v' + APP_VERSION;
+
   // Key screen
   document.getElementById('key-save-btn').addEventListener('click', saveKey);
   document.getElementById('key-input').addEventListener('keydown', e => {

--- a/flappy.html
+++ b/flappy.html
@@ -30,6 +30,7 @@ permalink: /flappy/
         <div class="instructions">
             <p>Tap or press Space to fly!</p>
             <p>Avoid the pipes and get the highest score!</p>
+            <p id="flappy-version" style="font-size:11px;opacity:0.6;margin-top:4px"></p>
         </div>
     </div>
     <style>
@@ -90,6 +91,7 @@ permalink: /flappy/
     
     <script>
         const SW_VERSION = 'dev';
+        document.getElementById('flappy-version').textContent = 'v' + SW_VERSION;
 
         // Register service worker with opt-in update flow
         if ('serviceWorker' in navigator) {

--- a/pt-BR/binary.html
+++ b/pt-BR/binary.html
@@ -56,4 +56,5 @@ permalink: /pt-BR/binary/
     <div id="binaryCelebration" class="binary-celebration" aria-hidden="true">{{ t.binary_page.celebration_text }}</div>
 </div>
 
+<p id="binary-app-version" style="font-size:11px;color:#6b7280;margin-top:8px;text-align:center"></p>
 <script src="/binary.js"></script>


### PR DESCRIPTION
## Summary
This PR updates the PWA cache versioning strategy and adds version display to the footer of all PWA applications.

## Key Changes
- **Versioning Strategy**: Changed from semantic versioning (git tags or commit hash) to timestamp-based versioning using UTC format `YYMMDDHHmm`
  - Removed `workflow_dispatch` input parameter for manual version specification
  - Simplified version resolution logic to always use current timestamp
  
- **Version Display**: Added `APP_VERSION` constant and footer display to all PWA applications:
  - `binary.js` / `binary.html`: Added version display element and initialization
  - `curator/index.html`: Added version span in header with styling
  - `crossfit-timer.html`: Added version pill badge
  - `flappy.html`: Added version paragraph below instructions
  
- **Build Process**: Updated GitHub Actions workflow to include new versioned files in git commits:
  - `binary.js` and `curator/index.html` now tracked for version updates
  - All versioned files properly staged in commit step

## Implementation Details
- Version constant defaults to `'dev'` in source files and gets replaced during CI/CD
- Version display uses consistent styling across apps (small font, reduced opacity)
- Timestamp-based versioning ensures automatic cache invalidation on every workflow run
- All changes maintain backward compatibility with existing PWA functionality

https://claude.ai/code/session_018nGQvBCCnLvStjHcs9QvuL