### PR TITLE
Replace favicon with custom drum machine SVG icon

### DIFF
--- a/drum-machine-manifest.json
+++ b/drum-machine-manifest.json
@@ -11,9 +11,9 @@
   "orientation": "portrait-primary",
   "icons": [
     {
-      "src": "/img/favicon.ico",
-      "sizes": "16x16 32x32",
-      "type": "image/x-icon",
+      "src": "/img/drum-machine-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
       "purpose": "any maskable"
     }
   ],

--- a/drum-machine.html
+++ b/drum-machine.html
@@ -14,8 +14,8 @@ permalink: /drum-machine/
     <meta name="description" content="A circular step sequencer inspired by the Dato Drum. Build beats with 4 voices, swappable samples, effects and BPM/swing control.">
     <title>Drum Machine</title>
     <link rel="manifest" href="/drum-machine-manifest.json">
-    <link rel="icon" type="image/png" sizes="192x192" href="/img/favicon.ico">
-    <link rel="apple-touch-icon" href="/img/favicon.ico">
+    <link rel="icon" type="image/svg+xml" href="/img/drum-machine-icon.svg">
+    <link rel="apple-touch-icon" href="/img/drum-machine-icon.svg">
     <style>
         *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/img/drum-machine-icon.svg
+++ b/img/drum-machine-icon.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Dark background rounded square -->
+  <rect width="512" height="512" rx="80" fill="#0d0d0d"/>
+
+  <!-- Outer ring (kick - red) -->
+  <circle cx="256" cy="256" r="210" fill="none" stroke="#FF4757" stroke-width="18" stroke-dasharray="1" opacity="0.25"/>
+  <!-- Inner rings -->
+  <circle cx="256" cy="256" r="165" fill="none" stroke="#FFA502" stroke-width="18" stroke-dasharray="1" opacity="0.25"/>
+  <circle cx="256" cy="256" r="120" fill="none" stroke="#2ED573" stroke-width="18" stroke-dasharray="1" opacity="0.25"/>
+  <circle cx="256" cy="256" r="75"  fill="none" stroke="#A29BFE" stroke-width="18" stroke-dasharray="1" opacity="0.25"/>
+
+  <!-- Kick steps (ring r=210, 16 steps) — active at 0°, 90°, 180°, 270° (indices 0,4,8,12) -->
+  <!-- Step 0: 270deg (top) -->
+  <circle cx="256" cy="46"  r="13" fill="#FF4757"/>
+  <!-- Step 2: 315deg -->
+  <circle cx="404.7" cy="107.3" r="9" fill="#FF4757" opacity="0.35"/>
+  <!-- Step 4: 0deg (right) -->
+  <circle cx="466" cy="256" r="13" fill="#FF4757"/>
+  <!-- Step 6: 45deg -->
+  <circle cx="404.7" cy="404.7" r="9" fill="#FF4757" opacity="0.35"/>
+  <!-- Step 8: 90deg (bottom) -->
+  <circle cx="256" cy="466" r="13" fill="#FF4757"/>
+  <!-- Step 10 -->
+  <circle cx="107.3" cy="404.7" r="9" fill="#FF4757" opacity="0.35"/>
+  <!-- Step 12: 180deg (left) -->
+  <circle cx="46" cy="256"  r="13" fill="#FF4757"/>
+  <!-- Step 14 -->
+  <circle cx="107.3" cy="107.3" r="9" fill="#FF4757" opacity="0.35"/>
+
+  <!-- Snare steps (ring r=165) — active at 0°, 90°(+half), 180°, 270°(+half) roughly -->
+  <!-- Step 4 = 0deg right -->
+  <circle cx="421" cy="256" r="12" fill="#FFA502"/>
+  <!-- Step 8 = 90deg bottom -->
+  <circle cx="256" cy="421" r="12" fill="#FFA502"/>
+  <!-- Step 12 = 180deg left -->
+  <circle cx="91"  cy="256" r="12" fill="#FFA502"/>
+  <!-- inactive dots -->
+  <circle cx="373.7" cy="139.4" r="8" fill="#FFA502" opacity="0.30"/>
+  <circle cx="373.7" cy="372.6" r="8" fill="#FFA502" opacity="0.30"/>
+  <circle cx="138.3" cy="372.6" r="8" fill="#FFA502" opacity="0.30"/>
+  <circle cx="138.3" cy="139.4" r="8" fill="#FFA502" opacity="0.30"/>
+  <circle cx="256"   cy="91"   r="8" fill="#FFA502" opacity="0.30"/>
+
+  <!-- Hi-hat steps (ring r=120) — dense pattern: every 45deg active -->
+  <circle cx="256" cy="136" r="10" fill="#2ED573"/>
+  <circle cx="341" cy="171" r="10" fill="#2ED573"/>
+  <circle cx="376" cy="256" r="10" fill="#2ED573"/>
+  <circle cx="341" cy="341" r="10" fill="#2ED573"/>
+  <circle cx="256" cy="376" r="10" fill="#2ED573"/>
+  <circle cx="171" cy="341" r="10" fill="#2ED573"/>
+  <circle cx="136" cy="256" r="10" fill="#2ED573"/>
+  <circle cx="171" cy="171" r="10" fill="#2ED573"/>
+
+  <!-- Clap steps (ring r=75) — active at 2 positions -->
+  <circle cx="256" cy="181" r="9" fill="#A29BFE"/>
+  <circle cx="331" cy="256" r="9" fill="#A29BFE"/>
+  <circle cx="256" cy="331" r="9" fill="#A29BFE"/>
+  <circle cx="181" cy="256" r="9" fill="#A29BFE" opacity="0.40"/>
+
+  <!-- Playhead indicator (bright white line from center pointing up) -->
+  <line x1="256" y1="256" x2="256" y2="50" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+  <!-- Center hub -->
+  <circle cx="256" cy="256" r="22" fill="#1a1a1a" stroke="white" stroke-width="3" opacity="0.9"/>
+  <circle cx="256" cy="256" r="8" fill="white" opacity="0.85"/>
+</svg>


### PR DESCRIPTION
## Summary
Replaced the generic favicon with a custom SVG icon that visually represents the drum machine application. The new icon depicts a circular step sequencer with four concentric rings representing different drum voices (kick, snare, hi-hat, and clap) with active step indicators.

## Changes
- **Added** `img/drum-machine-icon.svg` - A new 512x512 SVG icon featuring:
  - Dark rounded square background
  - Four concentric rings in different colors (red for kick, orange for snare, green for hi-hat, purple for clap)
  - Colored dots representing active steps on each ring
  - White playhead indicator and center hub to convey the circular sequencer concept
  
- **Updated** `drum-machine-manifest.json` - Changed the PWA manifest icon reference:
  - From: `favicon.ico` (16x16, 32x32 PNG)
  - To: `drum-machine-icon.svg` (scalable SVG)
  
- **Updated** `drum-machine.html` - Updated favicon and apple-touch-icon links:
  - Changed icon type from `image/png` to `image/svg+xml`
  - Updated both `rel="icon"` and `rel="apple-touch-icon"` to reference the new SVG

## Implementation Details
The SVG icon uses a circular design that directly mirrors the drum machine's UI, making it immediately recognizable as a step sequencer. The color-coded rings and step indicators provide visual continuity with the application interface.

https://claude.ai/code/session_01QqyuaVevRLshrFBibbpoqX