### PR TITLE
Add F1 Championship Dashboard PWA

### DIFF
--- a/f1-championship/icons/icon.svg
+++ b/f1-championship/icons/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <rect width="512" height="512" rx="112" fill="#0c0a1a"/>
+  <!-- Steering wheel outer ring -->
+  <circle cx="256" cy="256" r="172" stroke="#6366f1" stroke-width="40"/>
+  <!-- Center hub -->
+  <circle cx="256" cy="256" r="52" fill="#6366f1"/>
+  <!-- Top spoke -->
+  <rect x="236" y="84" width="40" height="108" rx="20" fill="#6366f1"/>
+  <!-- Bottom-left spoke -->
+  <rect x="236" y="84" width="40" height="108" rx="20" fill="#6366f1" transform="rotate(120 256 256)"/>
+  <!-- Bottom-right spoke -->
+  <rect x="236" y="84" width="40" height="108" rx="20" fill="#6366f1" transform="rotate(240 256 256)"/>
+</svg>

--- a/f1-championship/index.html
+++ b/f1-championship/index.html
@@ -1,0 +1,1151 @@
+---
+layout: null
+title: F1 Championship Dashboard
+permalink: /f1-championship/
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="F1 Champ">
+  <meta name="theme-color" content="#0c0a1a">
+  <title>F1 Championship</title>
+  <link rel="manifest" href="/f1-championship/manifest.json">
+  <link rel="apple-touch-icon" href="/f1-championship/icons/icon.svg">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:       #0c0a1a;
+      --surface:  #1a1825;
+      --surface2: #221f35;
+      --accent:   #6366f1;
+      --accent2:  #818cf8;
+      --text:     #f1f0ff;
+      --muted:    #9ca3af;
+      --border:   rgba(255,255,255,0.08);
+      --bhover:   rgba(99,102,241,0.35);
+      --gold:     #f59e0b;
+      --silver:   #94a3b8;
+      --bronze:   #cd7f32;
+      --red:      #f43f5e;
+      --green:    #10b981;
+      --radius:   16px;
+      --rsm:      10px;
+      --ease:     0.2s ease;
+    }
+
+    html, body { height: 100%; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      font-size: 16px;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+      overscroll-behavior: none;
+    }
+
+    /* ─── APP SHELL ─── */
+    #app {
+      display: flex;
+      flex-direction: column;
+      height: 100dvh;
+      max-width: 700px;
+      margin: 0 auto;
+    }
+
+    header {
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.85rem 1rem 0.75rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .hdr-icon { font-size: 1.35rem; line-height: 1; }
+    .hdr-title { flex: 1; font-size: 0.95rem; font-weight: 700; letter-spacing: -0.01em; }
+    .hdr-badge {
+      font-size: 0.68rem; font-weight: 600;
+      padding: 0.18rem 0.5rem;
+      background: var(--surface2); border: 1px solid var(--border);
+      border-radius: 20px; color: var(--muted);
+      cursor: pointer;
+    }
+    #btn-install-hdr {
+      font-size: 0.72rem; padding: 0.28rem 0.65rem;
+      background: var(--accent); color: #fff;
+      border: none; border-radius: 20px; cursor: pointer;
+      font-family: inherit; display: none;
+    }
+    #btn-install-hdr.show { display: block; }
+
+    main { flex: 1; overflow-y: auto; overflow-x: hidden; -webkit-overflow-scrolling: touch; }
+
+    .view { display: none; padding: 1rem; padding-bottom: 2rem; }
+    .view.active { display: block; }
+
+    /* ─── TAB BAR ─── */
+    #tab-bar {
+      flex-shrink: 0;
+      display: flex;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      padding-bottom: env(safe-area-inset-bottom, 0);
+    }
+    #tab-bar button {
+      flex: 1; padding: 0.6rem 0.5rem;
+      background: none; border: none; color: var(--muted);
+      font-size: 0.68rem; font-family: inherit; cursor: pointer;
+      display: flex; flex-direction: column; align-items: center; gap: 0.15rem;
+      transition: color var(--ease);
+    }
+    .tab-ico { font-size: 1.05rem; line-height: 1; }
+    #tab-bar button.active { color: var(--accent); }
+
+    /* ─── COMMON ─── */
+    .sec-title {
+      font-size: 0.68rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.08em; color: var(--muted); margin: 1.25rem 0 0.55rem;
+    }
+    .sec-title:first-child { margin-top: 0; }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+    }
+
+    .btn-primary {
+      background: var(--accent); color: #fff; border: none;
+      border-radius: var(--rsm); padding: 0.5rem 1rem;
+      font-family: inherit; font-size: 0.85rem; font-weight: 600;
+      cursor: pointer; transition: opacity var(--ease); white-space: nowrap;
+    }
+    .btn-primary:hover { opacity: 0.85; }
+    .btn-primary:disabled { opacity: 0.35; cursor: not-allowed; }
+
+    .btn-sec {
+      background: var(--surface2); color: var(--text);
+      border: 1px solid var(--border); border-radius: var(--rsm);
+      padding: 0.5rem 1rem; font-family: inherit; font-size: 0.85rem;
+      font-weight: 500; cursor: pointer; transition: border-color var(--ease);
+      white-space: nowrap;
+    }
+    .btn-sec:hover { border-color: var(--bhover); }
+
+    .btn-danger {
+      background: rgba(244,63,94,0.1); color: var(--red);
+      border: 1px solid rgba(244,63,94,0.2); border-radius: var(--rsm);
+      padding: 0.5rem 1rem; font-family: inherit; font-size: 0.85rem;
+      font-weight: 600; cursor: pointer; transition: background var(--ease);
+      width: 100%;
+    }
+    .btn-danger:hover { background: rgba(244,63,94,0.2); }
+
+    .input-field {
+      flex: 1; background: var(--surface2);
+      border: 1px solid var(--border); border-radius: var(--rsm);
+      color: var(--text); font-family: inherit; font-size: 0.88rem;
+      padding: 0.5rem 0.75rem; outline: none;
+      transition: border-color var(--ease);
+    }
+    .input-field:focus { border-color: var(--accent); }
+    .input-field::placeholder { color: var(--muted); opacity: 0.6; }
+
+    .player-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+    .driver-cell { display: flex; align-items: center; gap: 0.45rem; }
+
+    /* ─── PROGRESS ─── */
+    .progress-wrap { margin-bottom: 1.25rem; }
+    .progress-lbl { font-size: 0.8rem; color: var(--muted); margin-bottom: 0.3rem; }
+    .progress-lbl span { color: var(--text); font-weight: 600; }
+    .progress-bar { height: 5px; background: var(--surface2); border-radius: 3px; overflow: hidden; }
+    .progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, var(--accent), var(--accent2));
+      border-radius: 3px; transition: width 0.5s ease;
+    }
+
+    /* ─── PODIUM ─── */
+    .podium {
+      display: flex; align-items: flex-end;
+      gap: 0.5rem; margin-bottom: 1.25rem;
+    }
+    .podium-card {
+      flex: 1; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 0.85rem 0.5rem; text-align: center;
+    }
+    .podium-card.p1 {
+      background: linear-gradient(180deg, rgba(245,158,11,0.12) 0%, var(--surface) 100%);
+      border-color: rgba(245,158,11,0.28); order: 2;
+      padding-top: 1.15rem; padding-bottom: 1.15rem;
+    }
+    .podium-card.p2 { order: 1; }
+    .podium-card.p3 { order: 3; }
+    .p-avatar {
+      width: 40px; height: 40px; border-radius: 50%;
+      overflow: hidden; margin: 0 auto 0.3rem; flex-shrink: 0;
+    }
+    .avatar-letter {
+      width: 100%; height: 100%; border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      font-weight: 700; color: #fff;
+    }
+    .avatar-img { width: 100%; height: 100%; object-fit: cover; display: block; border-radius: 50%; }
+    .avatar-edit { position: relative; cursor: pointer; border-radius: 50%; flex-shrink: 0; overflow: hidden; }
+    .avatar-edit-overlay {
+      position: absolute; inset: 0; background: rgba(0,0,0,0.55);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.75rem; opacity: 0; transition: opacity var(--ease);
+      border-radius: 50%;
+    }
+    .avatar-edit:hover .avatar-edit-overlay { opacity: 1; }
+    .p-medal { font-size: 1rem; margin-bottom: 0.2rem; }
+    .p-name { font-size: 0.72rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .p-pts { font-size: 0.98rem; font-weight: 700; color: var(--accent2); line-height: 1.3; }
+    .p-pts span { font-size: 0.6rem; color: var(--muted); font-weight: 400; }
+    .p-sub { font-size: 0.62rem; color: var(--muted); margin-top: 0.1rem; }
+
+    /* ─── EMPTY STATE ─── */
+    .empty {
+      text-align: center; padding: 3rem 1rem; color: var(--muted);
+    }
+    .empty-ico { font-size: 3rem; margin-bottom: 0.75rem; }
+    .empty p { font-size: 0.88rem; line-height: 1.7; }
+
+    /* ─── STANDINGS TABLE ─── */
+    .tbl-wrap {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius); overflow: hidden; margin-bottom: 0.5rem;
+    }
+    .stbl { width: 100%; border-collapse: collapse; font-size: 0.87rem; }
+    .stbl thead th {
+      padding: 0.55rem 0.75rem; text-align: left;
+      font-size: 0.67rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.06em; color: var(--muted);
+      border-bottom: 1px solid var(--border);
+    }
+    .stbl tbody td { padding: 0.65rem 0.75rem; border-bottom: 1px solid var(--border); }
+    .stbl tbody tr:last-child td { border-bottom: none; }
+    .stbl tbody tr:hover { background: rgba(255,255,255,0.025); }
+    .td-pos { font-weight: 700; color: var(--accent2); width: 2rem; }
+    .td-pts { text-align: right !important; }
+    .td-c { text-align: center !important; }
+
+    /* ─── RACE GRID ─── */
+    .grid-scroll {
+      overflow-x: auto; -webkit-overflow-scrolling: touch;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius);
+    }
+    .rgrid { border-collapse: collapse; white-space: nowrap; font-size: 0.73rem; }
+    .rgrid th, .rgrid td {
+      padding: 0.42rem 0.48rem; border-right: 1px solid var(--border);
+      border-bottom: 1px solid var(--border); text-align: center;
+    }
+    .rgrid th { color: var(--muted); font-weight: 600; font-size: 0.75rem; background: var(--surface2); line-height: 1; }
+    .rgrid tr:last-child td { border-bottom: none; }
+    .rgrid td:last-child, .rgrid th:last-child { border-right: none; }
+    .sticky-col { position: sticky; left: 0; background: var(--surface); z-index: 1; text-align: left !important; min-width: 88px; }
+    .rgrid thead .sticky-col { background: var(--surface2); }
+    .gc { color: var(--muted); }
+    .gc.g1 { color: var(--gold); font-weight: 700; background: rgba(245,158,11,0.1); }
+    .gc.g2 { color: var(--silver); font-weight: 600; background: rgba(148,163,184,0.08); }
+    .gc.g3 { color: var(--bronze); font-weight: 600; background: rgba(205,127,50,0.08); }
+
+    /* ─── CALENDAR ─── */
+    .race-list { display: flex; flex-direction: column; gap: 0.5rem; }
+    .next-lbl {
+      font-size: 0.63rem; font-weight: 700; color: var(--accent2);
+      text-transform: uppercase; letter-spacing: 0.07em; margin-bottom: 0.25rem;
+      padding-left: 0.25rem;
+    }
+    .race-card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--rsm); padding: 0.75rem 0.9rem;
+      cursor: pointer; display: flex; align-items: center; gap: 0.65rem;
+      transition: border-color var(--ease), background var(--ease);
+    }
+    .race-card:hover { border-color: var(--bhover); background: var(--surface2); }
+    .race-card:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .race-card.next-race {
+      border-color: rgba(99,102,241,0.4);
+      background: linear-gradient(135deg, rgba(99,102,241,0.07) 0%, var(--surface) 100%);
+    }
+    .rnd-badge {
+      width: 30px; height: 30px; border-radius: var(--rsm);
+      background: var(--surface2); flex-shrink: 0;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.68rem; font-weight: 700; color: var(--muted);
+    }
+    .rnd-badge.done { background: rgba(99,102,241,0.15); color: var(--accent2); }
+    .race-flag { flex-shrink: 0; border-radius: 3px; display: block; }
+    .race-info { flex: 1; min-width: 0; }
+    .race-name { font-size: 0.83rem; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .race-meta { font-size: 0.7rem; color: var(--muted); margin-top: 0.08rem; }
+    .r-status {
+      font-size: 0.62rem; font-weight: 700; padding: 0.18rem 0.45rem;
+      border-radius: 20px; text-transform: uppercase; letter-spacing: 0.04em;
+      flex-shrink: 0;
+    }
+    .st-up   { background: rgba(255,255,255,0.05); color: var(--muted); }
+    .st-done { background: rgba(16,185,129,0.12); color: var(--green); }
+    .st-lock { background: rgba(99,102,241,0.12); color: var(--accent2); }
+
+    /* ─── SETTINGS ─── */
+    .set-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem; margin-bottom: 1rem; }
+    .set-title { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted); margin-bottom: 0.75rem; }
+    .player-row { display: flex; align-items: center; gap: 0.7rem; padding: 0.55rem 0; border-bottom: 1px solid var(--border); }
+    .player-row:last-of-type { border-bottom: none; }
+    .player-cdot { width: 11px; height: 11px; border-radius: 50%; flex-shrink: 0; }
+    .player-rname { flex: 1; font-size: 0.87rem; }
+    .btn-rm {
+      background: none; border: none; cursor: pointer;
+      color: var(--muted); font-size: 0.95rem; padding: 0.2rem;
+      line-height: 1; transition: color var(--ease);
+    }
+    .btn-rm:hover:not(:disabled) { color: var(--red); }
+    .btn-rm:disabled { opacity: 0.3; cursor: not-allowed; }
+    .add-form { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
+    .set-row { display: flex; gap: 0.5rem; margin-bottom: 0.5rem; }
+    .set-row .btn-sec { flex: 1; text-align: center; }
+
+    /* ─── MODAL ─── */
+    #modal-overlay {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.6);
+      z-index: 200; display: flex; align-items: flex-end;
+      justify-content: center;
+      backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+    }
+    #modal-overlay.hidden { display: none; }
+    #race-modal {
+      background: var(--surface); border-radius: 20px 20px 0 0;
+      width: 100%; max-width: 700px;
+      max-height: 92dvh; overflow-y: auto;
+      padding: 0 1.25rem calc(1.25rem + env(safe-area-inset-bottom, 0));
+    }
+    .modal-handle {
+      width: 36px; height: 4px; background: var(--border);
+      border-radius: 2px; margin: 0.75rem auto 1rem;
+    }
+    .modal-hdr {
+      display: flex; align-items: flex-start; gap: 0.75rem;
+      padding-bottom: 0.85rem; border-bottom: 1px solid var(--border);
+      margin-bottom: 0.85rem;
+    }
+    .modal-flag { font-size: 1.75rem; line-height: 1; }
+    .modal-rname { font-size: 0.97rem; font-weight: 700; }
+    .modal-rmeta { font-size: 0.75rem; color: var(--muted); margin-top: 0.12rem; }
+    .modal-rbadge {
+      margin-left: auto; font-size: 0.68rem; font-weight: 700;
+      color: var(--muted); background: var(--surface2);
+      padding: 0.2rem 0.5rem; border-radius: 20px; white-space: nowrap;
+    }
+    .lock-msg {
+      font-size: 0.77rem; color: var(--accent2); text-align: center;
+      padding: 0.5rem; background: rgba(99,102,241,0.1);
+      border-radius: var(--rsm); margin-bottom: 0.85rem;
+    }
+    .te-row {
+      display: flex; align-items: center; gap: 0.7rem;
+      padding: 0.5rem 0; border-bottom: 1px solid var(--border);
+    }
+    .te-row:last-of-type { border-bottom: none; }
+    .te-player { display: flex; align-items: center; gap: 0.45rem; min-width: 88px; flex-shrink: 0; }
+    .te-pdot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+    .te-pname { font-size: 0.85rem; font-weight: 600; }
+    .time-input {
+      flex: 1; background: var(--surface2);
+      border: 1px solid var(--border); border-radius: var(--rsm);
+      color: var(--text); font-family: 'DM Mono', 'Courier New', monospace;
+      font-size: 0.92rem; padding: 0.48rem 0.7rem;
+      outline: none; width: 100%;
+      transition: border-color var(--ease);
+    }
+    .time-input:focus { border-color: var(--accent); }
+    .time-input.err { border-color: var(--red); }
+    .time-input::placeholder { color: var(--muted); opacity: 0.5; }
+    .time-input[readonly] { opacity: 0.55; cursor: not-allowed; }
+
+    #modal-preview {
+      margin: 0.85rem 0 0.5rem;
+      background: var(--surface2); border-radius: var(--rsm);
+      padding: 0.75rem; min-height: 40px;
+    }
+    #modal-preview:empty { display: none; }
+    .pv-title { font-size: 0.63rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted); margin-bottom: 0.45rem; }
+    .pv-row { display: flex; align-items: center; gap: 0.5rem; padding: 0.22rem 0; font-size: 0.83rem; }
+    .pv-pos { width: 1.4rem; flex-shrink: 0; font-size: 0.95rem; }
+    .pv-name { flex: 1; font-weight: 600; }
+    .pv-time { font-family: 'DM Mono', monospace; font-size: 0.78rem; color: var(--muted); }
+    .pv-pts { font-size: 0.78rem; font-weight: 700; color: var(--accent2); }
+
+    .modal-actions { display: flex; gap: 0.5rem; margin-top: 0.75rem; flex-wrap: wrap; }
+    .modal-actions .btn-primary { flex: 1; }
+    .modal-actions .btn-sec    { flex: 1; }
+
+    @media (min-width: 600px) {
+      #modal-overlay { align-items: center; padding: 1.5rem; }
+      #race-modal { border-radius: 20px; max-height: 88dvh; }
+    }
+
+    /* ─── CONFIRM ─── */
+    #confirm-overlay {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.6);
+      z-index: 300; display: flex; align-items: center; justify-content: center;
+      padding: 1.5rem; backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+    }
+    #confirm-overlay.hidden { display: none; }
+    #confirm-box {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 1.5rem;
+      max-width: 340px; width: 100%;
+    }
+    .cf-title { font-size: 0.97rem; font-weight: 700; margin-bottom: 0.5rem; }
+    .cf-msg { font-size: 0.85rem; color: var(--muted); line-height: 1.65; margin-bottom: 1.25rem; }
+    .cf-actions { display: flex; gap: 0.5rem; }
+    .cf-actions button { flex: 1; }
+
+    /* ─── INSTALL BANNER ─── */
+    #install-banner {
+      position: fixed;
+      bottom: calc(62px + env(safe-area-inset-bottom, 0));
+      left: 50%; transform: translateX(-50%);
+      background: var(--surface2); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 0.75rem 1rem;
+      display: flex; align-items: center; gap: 0.75rem;
+      max-width: 380px; width: calc(100% - 2rem);
+      z-index: 150; box-shadow: 0 8px 32px rgba(0,0,0,0.45);
+    }
+    #install-banner.hidden { display: none; }
+    .ib-text { flex: 1; font-size: 0.8rem; }
+    #btn-install-now {
+      background: var(--accent); color: #fff; border: none;
+      border-radius: var(--rsm); padding: 0.38rem 0.75rem;
+      font-size: 0.78rem; font-weight: 600; cursor: pointer; font-family: inherit;
+    }
+    #btn-install-dismiss {
+      background: none; border: none; color: var(--muted);
+      cursor: pointer; font-size: 1rem; padding: 0.2rem; line-height: 1;
+    }
+  </style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <span class="hdr-icon">🏎️</span>
+    <div class="hdr-title">F1 Championship <span id="hdr-season">2026</span></div>
+    <span class="hdr-badge" id="hdr-gv" title="Click Settings to change">F1 25</span>
+    <button id="btn-install-hdr">Install</button>
+  </header>
+
+  <main>
+    <section id="view-standings" class="view active" role="tabpanel"></section>
+    <section id="view-calendar"  class="view"        role="tabpanel"></section>
+    <section id="view-settings"  class="view"        role="tabpanel"></section>
+  </main>
+
+  <nav id="tab-bar" role="tablist">
+    <button class="active" data-tab="standings" role="tab" aria-selected="true">
+      <span class="tab-ico">🏆</span>Championship
+    </button>
+    <button data-tab="calendar" role="tab" aria-selected="false">
+      <span class="tab-ico">📅</span>Calendar
+    </button>
+    <button data-tab="settings" role="tab" aria-selected="false">
+      <span class="tab-ico">⚙️</span>Settings
+    </button>
+  </nav>
+</div>
+
+<!-- Race Entry Modal -->
+<div id="modal-overlay" class="hidden" role="dialog" aria-modal="true" aria-label="Race entry">
+  <div id="race-modal">
+    <div class="modal-handle"></div>
+    <div id="modal-content"></div>
+  </div>
+</div>
+
+<!-- Confirm Dialog -->
+<div id="confirm-overlay" class="hidden" role="dialog" aria-modal="true">
+  <div id="confirm-box">
+    <div class="cf-title" id="cf-title"></div>
+    <div class="cf-msg"   id="cf-msg"></div>
+    <div class="cf-actions">
+      <button class="btn-sec"    id="btn-cf-cancel">Cancel</button>
+      <button class="btn-danger" id="btn-cf-ok">Confirm</button>
+    </div>
+  </div>
+</div>
+
+<!-- Install Banner -->
+<div id="install-banner" class="hidden">
+  <span class="ib-text">Add F1 Championship to your home screen</span>
+  <button id="btn-install-now">Install</button>
+  <button id="btn-install-dismiss" aria-label="Dismiss">✕</button>
+</div>
+
+<script>
+// ============================================================
+// CONSTANTS
+// ============================================================
+const CALENDAR = [
+  { round:1,  name:'Australian Grand Prix',     circuit:'Albert Park',                    flag:'🇦🇺', cc:'au', date:'2026-03-15' },
+  { round:2,  name:'Chinese Grand Prix',         circuit:'Shanghai International Circuit', flag:'🇨🇳', cc:'cn', date:'2026-03-22' },
+  { round:3,  name:'Japanese Grand Prix',        circuit:'Suzuka',                         flag:'🇯🇵', cc:'jp', date:'2026-04-05' },
+  { round:4,  name:'Bahrain Grand Prix',         circuit:'Bahrain International Circuit',  flag:'🇧🇭', cc:'bh', date:'2026-04-19' },
+  { round:5,  name:'Saudi Arabian Grand Prix',   circuit:'Jeddah Corniche Circuit',        flag:'🇸🇦', cc:'sa', date:'2026-05-03' },
+  { round:6,  name:'Miami Grand Prix',           circuit:'Miami International Autodrome',  flag:'🇺🇸', cc:'us', date:'2026-05-10' },
+  { round:7,  name:'Emilia Romagna Grand Prix',  circuit:'Imola',                          flag:'🇮🇹', cc:'it', date:'2026-05-24' },
+  { round:8,  name:'Monaco Grand Prix',          circuit:'Circuit de Monaco',              flag:'🇲🇨', cc:'mc', date:'2026-05-31' },
+  { round:9,  name:'Spanish Grand Prix',         circuit:'Barcelona-Catalunya',            flag:'🇪🇸', cc:'es', date:'2026-06-07' },
+  { round:10, name:'Canadian Grand Prix',        circuit:'Circuit Gilles Villeneuve',      flag:'🇨🇦', cc:'ca', date:'2026-06-21' },
+  { round:11, name:'Austrian Grand Prix',        circuit:'Red Bull Ring',                  flag:'🇦🇹', cc:'at', date:'2026-06-28' },
+  { round:12, name:'British Grand Prix',         circuit:'Silverstone',                    flag:'🇬🇧', cc:'gb', date:'2026-07-05' },
+  { round:13, name:'Belgian Grand Prix',         circuit:'Spa-Francorchamps',              flag:'🇧🇪', cc:'be', date:'2026-07-26' },
+  { round:14, name:'Hungarian Grand Prix',       circuit:'Hungaroring',                    flag:'🇭🇺', cc:'hu', date:'2026-08-02' },
+  { round:15, name:'Dutch Grand Prix',           circuit:'Zandvoort',                      flag:'🇳🇱', cc:'nl', date:'2026-08-30' },
+  { round:16, name:'Italian Grand Prix',         circuit:'Monza',                          flag:'🇮🇹', cc:'it', date:'2026-09-06' },
+  { round:17, name:'Azerbaijan Grand Prix',      circuit:'Baku City Circuit',              flag:'🇦🇿', cc:'az', date:'2026-09-20' },
+  { round:18, name:'Singapore Grand Prix',       circuit:'Marina Bay Street Circuit',      flag:'🇸🇬', cc:'sg', date:'2026-10-04' },
+  { round:19, name:'United States Grand Prix',   circuit:'Circuit of the Americas',        flag:'🇺🇸', cc:'us', date:'2026-10-18' },
+  { round:20, name:'Mexico City Grand Prix',     circuit:'Autodromo Hermanos Rodriguez',   flag:'🇲🇽', cc:'mx', date:'2026-10-25' },
+  { round:21, name:'São Paulo Grand Prix',       circuit:'Interlagos',                     flag:'🇧🇷', cc:'br', date:'2026-11-08' },
+  { round:22, name:'Las Vegas Grand Prix',       circuit:'Las Vegas Strip Circuit',        flag:'🇺🇸', cc:'us', date:'2026-11-21' },
+  { round:23, name:'Qatar Grand Prix',           circuit:'Lusail International Circuit',   flag:'🇶🇦', cc:'qa', date:'2026-11-29' },
+  { round:24, name:'Abu Dhabi Grand Prix',       circuit:'Yas Marina Circuit',             flag:'🇦🇪', cc:'ae', date:'2026-12-06' },
+];
+
+const F1_POINTS    = [25, 18, 15, 12, 10, 8, 6, 4, 2, 1];
+const PLR_COLORS   = ['#6366f1','#f43f5e','#10b981','#f59e0b','#3b82f6','#a855f7'];
+const NS           = 'f1-championship';
+
+// ============================================================
+// STATE
+// ============================================================
+let players = [];
+let results = {};
+let config  = {};
+
+// ============================================================
+// STORAGE
+// ============================================================
+function load(key, fallback) {
+  try { return JSON.parse(localStorage.getItem(`${NS}:${key}`)) ?? fallback; }
+  catch { return fallback; }
+}
+function save(key, val) {
+  localStorage.setItem(`${NS}:${key}`, JSON.stringify(val));
+}
+
+// ============================================================
+// SCORING ENGINE
+// ============================================================
+function parseTimeMs(str) {
+  if (!str) return null;
+  const m = str.trim().match(/^(\d+):(\d{2})\.(\d{3})$/);
+  if (!m) return null;
+  return parseInt(m[1]) * 60000 + parseInt(m[2]) * 1000 + parseInt(m[3]);
+}
+
+function getRaceRankings(roundKey) {
+  const race = results[roundKey];
+  if (!race || !race.entries) return [];
+  const entries = [];
+  for (const [pid, entry] of Object.entries(race.entries)) {
+    if (entry.lapTimeMs != null) {
+      const player = players.find(p => p.id === pid);
+      if (player) entries.push({ player, lapTime: entry.lapTime, lapTimeMs: entry.lapTimeMs });
+    }
+  }
+  entries.sort((a, b) => a.lapTimeMs - b.lapTimeMs);
+  return entries.map((e, i) => ({ ...e, position: i + 1, points: F1_POINTS[i] ?? 0 }));
+}
+
+function getStandings() {
+  const map = {};
+  for (const p of players) map[p.id] = { player: p, points: 0, races: 0, wins: 0, positions: [] };
+  for (const rk of Object.keys(results)) {
+    for (const r of getRaceRankings(rk)) {
+      if (!map[r.player.id]) continue;
+      map[r.player.id].points += r.points;
+      map[r.player.id].races  += 1;
+      if (r.position === 1) map[r.player.id].wins += 1;
+      map[r.player.id].positions.push(r.position);
+    }
+  }
+  return Object.values(map).sort((a, b) => b.points !== a.points ? b.points - a.points : b.wins - a.wins);
+}
+
+function getPlayerRound(pid, rk) {
+  const rank = getRaceRankings(rk).find(r => r.player.id === pid);
+  return rank ? { points: rank.points, position: rank.position } : null;
+}
+
+function bestFinish(pos) {
+  return pos.length ? 'P' + Math.min(...pos) : '—';
+}
+
+// ============================================================
+// UTILITIES
+// ============================================================
+function fmtDate(ds) {
+  const [y, m, d] = ds.split('-').map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+}
+function nextRound() {
+  for (const r of CALENDAR) if (!results[String(r.round)]) return r.round;
+  return null;
+}
+function uid() { return Math.random().toString(36).slice(2, 10); }
+function esc(s) { return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+
+// ============================================================
+// AVATAR HELPERS
+// ============================================================
+function avatarInner(player, fontSize) {
+  if (player.photo) return `<img class="avatar-img" src="${player.photo}" alt="${esc(player.name)}">`;
+  return `<div class="avatar-letter" style="background:${player.color};font-size:${fontSize}px">${esc(player.avatar)}</div>`;
+}
+
+function avatarHtml(player, size = 36) {
+  return `<div style="width:${size}px;height:${size}px;border-radius:50%;overflow:hidden;flex-shrink:0">${avatarInner(player, Math.round(size * 0.38))}</div>`;
+}
+
+function avatarEditHtml(player, size = 42) {
+  return `<div class="avatar-edit" data-pid="${player.id}" style="width:${size}px;height:${size}px" title="Tap to change photo">
+    ${avatarInner(player, Math.round(size * 0.38))}
+    <div class="avatar-edit-overlay">📷</div>
+    <input type="file" class="avatar-file-input" data-pid="${player.id}" accept="image/*" style="display:none">
+  </div>`;
+}
+
+function resizeImage(file, maxSize, cb) {
+  const reader = new FileReader();
+  reader.onload = e => {
+    const img = new Image();
+    img.onload = () => {
+      const scale = Math.min(maxSize / img.width, maxSize / img.height, 1);
+      const canvas = document.createElement('canvas');
+      canvas.width  = Math.round(img.width  * scale);
+      canvas.height = Math.round(img.height * scale);
+      canvas.getContext('2d').drawImage(img, 0, 0, canvas.width, canvas.height);
+      cb(canvas.toDataURL('image/jpeg', 0.82));
+    };
+    img.src = e.target.result;
+  };
+  reader.readAsDataURL(file);
+}
+
+// ============================================================
+// TABS
+// ============================================================
+function switchTab(tab) {
+  document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+  document.querySelectorAll('#tab-bar button').forEach(b => { b.classList.remove('active'); b.setAttribute('aria-selected','false'); });
+  document.getElementById(`view-${tab}`).classList.add('active');
+  const btn = document.querySelector(`[data-tab="${tab}"]`);
+  btn.classList.add('active');
+  btn.setAttribute('aria-selected','true');
+}
+
+// ============================================================
+// RENDER — STANDINGS
+// ============================================================
+function renderStandings() {
+  const standings = getStandings();
+  const done  = Object.keys(results).length;
+  const total = CALENDAR.length;
+  const pct   = (done / total * 100).toFixed(1);
+
+  let h = `<div class="progress-wrap">
+    <div class="progress-lbl"><span>${done}</span> of ${total} races completed</div>
+    <div class="progress-bar"><div class="progress-fill" style="width:${pct}%"></div></div>
+  </div>`;
+
+  if (done === 0) {
+    h += `<div class="empty">
+      <div class="empty-ico">🏁</div>
+      <p>No races recorded yet.<br>Open the Calendar tab to enter your first lap times!</p>
+    </div>`;
+  } else {
+    // Podium — DOM order: P1, P2, P3. CSS order: P2 | P1 | P3 via order property.
+    const top = standings.slice(0, Math.min(3, standings.length));
+    const cls  = ['p1','p2','p3'];
+    const med  = ['🥇','🥈','🥉'];
+    h += '<div class="podium">';
+    top.forEach((s, i) => {
+      h += `<div class="podium-card ${cls[i]}">
+        <div class="p-medal">${med[i]}</div>
+        <div class="p-avatar">${avatarInner(s.player, 15)}</div>
+        <div class="p-name">${esc(s.player.name)}</div>
+        <div class="p-pts">${s.points} <span>pts</span></div>
+        <div class="p-sub">${s.wins} win${s.wins !== 1 ? 's' : ''}</div>
+      </div>`;
+    });
+    h += '</div>';
+
+    // Standings table
+    h += '<div class="sec-title">Driver Standings</div>';
+    h += '<div class="tbl-wrap"><table class="stbl"><thead><tr><th>Pos</th><th>Driver</th><th>Pts</th><th class="td-c">Races</th><th class="td-c">Best</th></tr></thead><tbody>';
+    standings.forEach((s, i) => {
+      h += `<tr>
+        <td class="td-pos">${i + 1}</td>
+        <td><div class="driver-cell"><span class="player-dot" style="background:${s.player.color}"></span>${esc(s.player.name)}</div></td>
+        <td class="td-pts"><strong>${s.points}</strong></td>
+        <td class="td-c">${s.races}</td>
+        <td class="td-c">${bestFinish(s.positions)}</td>
+      </tr>`;
+    });
+    h += '</tbody></table></div>';
+
+    // Race-by-race grid
+    h += '<div class="sec-title">Race by Race</div>';
+    h += '<div class="grid-scroll"><table class="rgrid"><thead><tr><th class="sticky-col">Driver</th>';
+    CALENDAR.forEach(r => {
+      const done = !!results[String(r.round)];
+      h += `<th title="R${r.round} · ${r.name} · ${r.circuit}"><img src="https://flagcdn.com/w40/${r.cc}.png" alt="${r.flag}" width="20" height="15" style="display:block;border-radius:2px"></th>`;
+    });
+    h += '</tr></thead><tbody>';
+    players.forEach(p => {
+      h += `<tr><td class="sticky-col"><div class="driver-cell"><span class="player-dot" style="background:${p.color}"></span>${esc(p.name)}</div></td>`;
+      CALENDAR.forEach(r => {
+        const key  = String(r.round);
+        const data = getPlayerRound(p.id, key);
+        if (!data) { h += '<td class="gc">—</td>'; return; }
+        const g = data.position === 1 ? 'g1' : data.position === 2 ? 'g2' : data.position === 3 ? 'g3' : '';
+        h += `<td class="gc ${g}" title="P${data.position} · ${data.points}pts">${data.points}</td>`;
+      });
+      h += '</tr>';
+    });
+    h += '</tbody></table></div>';
+  }
+
+  document.getElementById('view-standings').innerHTML = h;
+}
+
+// ============================================================
+// RENDER — CALENDAR
+// ============================================================
+function renderCalendar() {
+  const next = nextRound();
+  let h = '<div class="race-list">';
+
+  CALENDAR.forEach(race => {
+    const key    = String(race.round);
+    const res    = results[key];
+    const locked = res?.locked === true;
+    const done   = !!res;
+    const isNext = race.round === next;
+
+    const statusCls  = locked ? 'st-lock' : done ? 'st-done' : 'st-up';
+    const statusText = locked ? '🔒 Locked' : done ? '✓ Done' : 'Upcoming';
+
+    if (isNext) h += '<div class="next-lbl">▶ Next race</div>';
+    h += `<div class="race-card${isNext ? ' next-race' : ''}" data-round="${race.round}" role="button" tabindex="0">
+      <div class="rnd-badge${done ? ' done' : ''}">${race.round}</div>
+      <img class="race-flag" src="https://flagcdn.com/w40/${race.cc}.png" alt="${race.flag}" width="28" height="21">
+      <div class="race-info">
+        <div class="race-name">${esc(race.name)}</div>
+        <div class="race-meta">${race.circuit} · ${fmtDate(race.date)}</div>
+      </div>
+      <div class="r-status ${statusCls}">${statusText}</div>
+    </div>`;
+  });
+
+  h += '</div>';
+  document.getElementById('view-calendar').innerHTML = h;
+
+  document.querySelectorAll('.race-card').forEach(card => {
+    const open = () => openModal(parseInt(card.dataset.round));
+    card.addEventListener('click', open);
+    card.addEventListener('keydown', e => { if (e.key === 'Enter' || e.key === ' ') open(); });
+  });
+}
+
+// ============================================================
+// RENDER — SETTINGS
+// ============================================================
+function renderSettings() {
+  const gv = config.gameVersion || 'F1 25';
+  let h = '';
+
+  // Players
+  h += '<div class="set-card"><div class="set-title">Players</div>';
+  players.forEach(p => {
+    h += `<div class="player-row">
+      ${avatarEditHtml(p, 42)}
+      <span class="player-rname">${esc(p.name)}</span>
+      <button class="btn-rm" data-pid="${p.id}" aria-label="Remove ${esc(p.name)}"${players.length <= 1 ? ' disabled' : ''}>✕</button>
+    </div>`;
+  });
+  if (players.length < 6) {
+    h += `<div class="add-form">
+      <input type="text" class="input-field" id="inp-new-player" placeholder="Player name" maxlength="20" autocomplete="off">
+      <button class="btn-primary" id="btn-add-player">Add</button>
+    </div>`;
+  } else {
+    h += '<p style="font-size:0.78rem;color:var(--muted);margin-top:0.6rem">Maximum 6 players reached.</p>';
+  }
+  h += '</div>';
+
+  // Season / game version
+  h += `<div class="set-card"><div class="set-title">Season</div>
+    <div class="add-form">
+      <input type="text" class="input-field" id="inp-gv" value="${esc(gv)}" placeholder="e.g. F1 25" maxlength="10">
+      <button class="btn-primary" id="btn-save-gv">Save</button>
+    </div>
+  </div>`;
+
+  // Data
+  h += `<div class="set-card"><div class="set-title">Data</div>
+    <div class="set-row">
+      <button class="btn-sec" id="btn-export">⬇ Export</button>
+      <label class="btn-sec" style="cursor:pointer;text-align:center">
+        ⬆ Import
+        <input type="file" id="inp-import" accept=".json" style="display:none">
+      </label>
+    </div>
+    <button class="btn-danger" id="btn-reset">Reset Season</button>
+  </div>`;
+
+  document.getElementById('view-settings').innerHTML = h;
+
+  // Wire events
+  document.querySelectorAll('.btn-rm').forEach(b => b.addEventListener('click', () => removePlayer(b.dataset.pid)));
+  document.querySelectorAll('.avatar-edit').forEach(wrap => {
+    const fileInput = wrap.querySelector('.avatar-file-input');
+    wrap.addEventListener('click', () => fileInput.click());
+    fileInput.addEventListener('change', e => {
+      const file = e.target.files[0];
+      if (!file) return;
+      resizeImage(file, 200, dataUrl => {
+        const p = players.find(x => x.id === wrap.dataset.pid);
+        if (p) { p.photo = dataUrl; save('players', players); renderAll(); }
+      });
+      e.target.value = '';
+    });
+  });
+  document.getElementById('btn-add-player')?.addEventListener('click', addPlayer);
+  document.getElementById('inp-new-player')?.addEventListener('keydown', e => { if (e.key === 'Enter') addPlayer(); });
+  document.getElementById('btn-save-gv')?.addEventListener('click', saveGV);
+  document.getElementById('btn-export')?.addEventListener('click', exportData);
+  document.getElementById('inp-import')?.addEventListener('change', importData);
+  document.getElementById('btn-reset')?.addEventListener('click', () =>
+    confirm2('Reset Season', 'Delete all recorded lap times? Player names will be kept. This cannot be undone.', () => {
+      results = {};
+      save('results', results);
+      renderAll();
+    })
+  );
+}
+
+// ============================================================
+// RENDER ALL
+// ============================================================
+function renderAll() {
+  const gv = config.gameVersion || 'F1 25';
+  document.getElementById('hdr-gv').textContent = gv;
+  renderStandings();
+  renderCalendar();
+  renderSettings();
+}
+
+// ============================================================
+// SETTINGS HANDLERS
+// ============================================================
+function addPlayer() {
+  const inp = document.getElementById('inp-new-player');
+  if (!inp) return;
+  const name = inp.value.trim();
+  if (!name || players.length >= 6) return;
+  players.push({ id: uid(), name, color: PLR_COLORS[players.length % PLR_COLORS.length], avatar: name.charAt(0).toUpperCase() });
+  save('players', players);
+  renderSettings();
+  renderStandings();
+  renderCalendar();
+}
+
+function removePlayer(pid) {
+  const hasData = Object.values(results).some(r => r.entries?.[pid]);
+  const doRemove = () => {
+    players = players.filter(p => p.id !== pid);
+    for (const k of Object.keys(results)) { if (results[k].entries) delete results[k].entries[pid]; }
+    save('players', players);
+    save('results', results);
+    renderAll();
+  };
+  hasData ? confirm2('Remove Player', 'This player has recorded race times. Their data will be deleted.', doRemove) : doRemove();
+}
+
+function saveGV() {
+  const inp = document.getElementById('inp-gv');
+  if (!inp) return;
+  config.gameVersion = inp.value.trim() || 'F1 25';
+  save('config', config);
+  document.getElementById('hdr-gv').textContent = config.gameVersion;
+}
+
+function exportData() {
+  const blob = new Blob([JSON.stringify({ config, players, results }, null, 2)], { type: 'application/json' });
+  const url  = URL.createObjectURL(blob);
+  const a    = Object.assign(document.createElement('a'), { href: url, download: `f1-championship-${new Date().toISOString().slice(0,10)}.json` });
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function importData(e) {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = ev => {
+    try {
+      const d = JSON.parse(ev.target.result);
+      if (!d.players || !d.results) throw new Error('bad');
+      confirm2('Import Data', 'Replace current data with this file?', () => {
+        config  = d.config  || {};
+        players = d.players;
+        results = d.results;
+        save('config', config);
+        save('players', players);
+        save('results', results);
+        renderAll();
+      });
+    } catch { alert('Invalid backup file.'); }
+  };
+  reader.readAsText(file);
+  e.target.value = '';
+}
+
+// ============================================================
+// MODAL
+// ============================================================
+let activeRound = null;
+
+function openModal(round) {
+  activeRound = round;
+  const race   = CALENDAR.find(r => r.round === round);
+  const key    = String(round);
+  const existing = results[key];
+  const locked   = existing?.locked === true;
+
+  let h = `<div class="modal-hdr">
+    <div class="modal-flag">${race.flag}</div>
+    <div>
+      <div class="modal-rname">${esc(race.name)}</div>
+      <div class="modal-rmeta">${race.circuit} · ${fmtDate(race.date)}</div>
+    </div>
+    <div class="modal-rbadge">Round ${round}</div>
+  </div>`;
+
+  if (locked) h += '<div class="lock-msg">🔒 This race is locked. Unlock to edit lap times.</div>';
+
+  h += '<div id="te-entries">';
+  players.forEach(p => {
+    const val = existing?.entries?.[p.id]?.lapTime || '';
+    h += `<div class="te-row">
+      <div class="te-player">
+        <span class="te-pdot" style="background:${p.color}"></span>
+        <span class="te-pname">${esc(p.name)}</span>
+      </div>
+      <input type="text" class="time-input" data-pid="${p.id}"
+        value="${esc(val)}" placeholder="1:23.456"
+        ${locked ? 'readonly' : ''}
+        inputmode="text" autocomplete="off" autocorrect="off" spellcheck="false">
+    </div>`;
+  });
+  h += '</div>';
+
+  h += '<div id="modal-preview"></div>';
+  h += '<div class="modal-actions">';
+  if (!locked) {
+    h += '<button class="btn-primary" id="btn-m-save">Save</button>';
+    h += '<button class="btn-sec"     id="btn-m-cancel">Cancel</button>';
+    if (existing) h += '<button class="btn-sec" id="btn-m-lock" style="flex:none">🔒 Lock</button>';
+  } else {
+    h += '<button class="btn-sec" id="btn-m-unlock" style="flex:1">🔓 Unlock</button>';
+    h += '<button class="btn-sec" id="btn-m-cancel" style="flex:1">Close</button>';
+  }
+  h += '</div>';
+
+  document.getElementById('modal-content').innerHTML = h;
+  document.getElementById('modal-overlay').classList.remove('hidden');
+
+  document.querySelectorAll('.time-input').forEach(inp => {
+    inp.addEventListener('input', updatePreview);
+    inp.addEventListener('blur',  validateTime);
+  });
+  document.getElementById('btn-m-save')?.addEventListener('click', saveModal);
+  document.getElementById('btn-m-cancel')?.addEventListener('click', closeModal);
+  document.getElementById('btn-m-lock')?.addEventListener('click', lockRace);
+  document.getElementById('btn-m-unlock')?.addEventListener('click', unlockRace);
+
+  updatePreview();
+
+  if (!locked) {
+    const first = document.querySelector('.time-input:not([readonly])');
+    if (first && !first.value) setTimeout(() => first.focus(), 50);
+  }
+}
+
+function closeModal() {
+  document.getElementById('modal-overlay').classList.add('hidden');
+  document.getElementById('modal-content').innerHTML = '';
+  activeRound = null;
+}
+
+function validateTime(e) {
+  const v = e.target.value.trim();
+  e.target.classList.toggle('err', v !== '' && parseTimeMs(v) === null);
+}
+
+function updatePreview() {
+  const entries = [];
+  document.querySelectorAll('.time-input').forEach(inp => {
+    const ms = parseTimeMs(inp.value.trim());
+    if (ms !== null) {
+      const p = players.find(x => x.id === inp.dataset.pid);
+      if (p) entries.push({ player: p, lapTime: inp.value.trim(), lapTimeMs: ms });
+    }
+  });
+  entries.sort((a, b) => a.lapTimeMs - b.lapTimeMs);
+
+  const el = document.getElementById('modal-preview');
+  if (!el || entries.length === 0) { if (el) el.innerHTML = ''; return; }
+
+  const med = ['🥇','🥈','🥉'];
+  let h = '<div class="pv-title">Preview Rankings</div>';
+  entries.forEach((e, i) => {
+    h += `<div class="pv-row">
+      <span class="pv-pos">${med[i] || 'P'+(i+1)}</span>
+      <span class="pv-name" style="color:${e.player.color}">${esc(e.player.name)}</span>
+      <span class="pv-time">${e.lapTime}</span>
+      <span class="pv-pts">+${F1_POINTS[i] ?? 0} pts</span>
+    </div>`;
+  });
+  el.innerHTML = h;
+}
+
+function saveModal() {
+  let hasValid = false, hasErr = false;
+  const entries = {};
+  document.querySelectorAll('.time-input').forEach(inp => {
+    const v  = inp.value.trim();
+    const ms = parseTimeMs(v);
+    if (v === '') return;
+    if (ms === null) { hasErr = true; inp.classList.add('err'); return; }
+    entries[inp.dataset.pid] = { lapTime: v, lapTimeMs: ms };
+    hasValid = true;
+  });
+  if (hasErr) return;
+  if (!hasValid) { closeModal(); return; }
+
+  results[String(activeRound)] = { locked: false, entries };
+  save('results', results);
+  closeModal();
+  renderAll();
+}
+
+function lockRace() {
+  const k = String(activeRound);
+  if (results[k]) { results[k].locked = true; save('results', results); closeModal(); renderAll(); }
+}
+
+function unlockRace() {
+  const k = String(activeRound);
+  if (results[k]) { results[k].locked = false; save('results', results); openModal(activeRound); }
+}
+
+document.getElementById('modal-overlay').addEventListener('click', e => {
+  if (e.target === document.getElementById('modal-overlay')) closeModal();
+});
+
+// ============================================================
+// CONFIRM DIALOG
+// ============================================================
+let confirmCb = null;
+
+function confirm2(title, msg, cb) {
+  document.getElementById('cf-title').textContent = title;
+  document.getElementById('cf-msg').textContent   = msg;
+  confirmCb = cb;
+  document.getElementById('confirm-overlay').classList.remove('hidden');
+}
+
+document.getElementById('btn-cf-ok').addEventListener('click', () => {
+  document.getElementById('confirm-overlay').classList.add('hidden');
+  if (confirmCb) { confirmCb(); confirmCb = null; }
+});
+document.getElementById('btn-cf-cancel').addEventListener('click', () => {
+  document.getElementById('confirm-overlay').classList.add('hidden');
+  confirmCb = null;
+});
+
+// ============================================================
+// TAB BAR
+// ============================================================
+document.querySelectorAll('#tab-bar button').forEach(btn =>
+  btn.addEventListener('click', () => switchTab(btn.dataset.tab))
+);
+
+// ============================================================
+// PWA INSTALL
+// ============================================================
+let installEvt = null;
+
+window.addEventListener('beforeinstallprompt', e => {
+  e.preventDefault();
+  installEvt = e;
+  if (!load('install-dismissed', false)) {
+    document.getElementById('install-banner').classList.remove('hidden');
+    document.getElementById('btn-install-hdr').classList.add('show');
+  }
+});
+
+function doInstall() {
+  if (!installEvt) return;
+  installEvt.prompt();
+  installEvt.userChoice.then(() => {
+    installEvt = null;
+    document.getElementById('install-banner').classList.add('hidden');
+    document.getElementById('btn-install-hdr').classList.remove('show');
+  });
+}
+
+document.getElementById('btn-install-hdr').addEventListener('click', doInstall);
+document.getElementById('btn-install-now').addEventListener('click', doInstall);
+document.getElementById('btn-install-dismiss').addEventListener('click', () => {
+  document.getElementById('install-banner').classList.add('hidden');
+  save('install-dismissed', true);
+});
+
+// ============================================================
+// INIT
+// ============================================================
+document.addEventListener('DOMContentLoaded', () => {
+  config  = load('config',  { season: 2026, gameVersion: 'F1 25' });
+  players = load('players', []);
+  results = load('results', {});
+
+  if (players.length === 0) {
+    players = [
+      { id: uid(), name: 'Player 1', color: PLR_COLORS[0], avatar: 'P' },
+      { id: uid(), name: 'Player 2', color: PLR_COLORS[1], avatar: 'P' },
+    ];
+    save('players', players);
+  }
+
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/f1-championship/sw.js').catch(() => {});
+  }
+
+  renderAll();
+});
+</script>
+</body>
+</html>

--- a/f1-championship/manifest.json
+++ b/f1-championship/manifest.json
@@ -1,0 +1,39 @@
+{
+  "id": "/f1-championship/",
+  "name": "F1 Championship Dashboard",
+  "short_name": "F1 Champ",
+  "description": "Track your lap time championship across the full 2026 F1 season.",
+  "start_url": "/f1-championship/",
+  "scope": "/f1-championship/",
+  "display": "standalone",
+  "background_color": "#0c0a1a",
+  "theme_color": "#0c0a1a",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/f1-championship/icons/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/f1-championship/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/f1-championship/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Calendar",
+      "url": "/f1-championship/#calendar",
+      "description": "View race calendar"
+    }
+  ]
+}

--- a/f1-championship/sw.js
+++ b/f1-championship/sw.js
@@ -1,0 +1,73 @@
+const CACHE_VERSION = '2603290001';
+const CACHE_NAME = `f1-championship-${CACHE_VERSION}`;
+const OFFLINE_URL = '/f1-championship/';
+const PRECACHE_URLS = [
+  '/f1-championship/',
+  '/f1-championship/manifest.json',
+  '/f1-championship/icons/icon.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(PRECACHE_URLS.map((url) => new Request(url, { cache: 'reload' })));
+    })
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames.map((cacheName) => {
+          if (cacheName !== CACHE_NAME && cacheName.startsWith('f1-championship-')) {
+            return caches.delete(cacheName);
+          }
+          return Promise.resolve();
+        })
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+
+  const requestUrl = new URL(event.request.url);
+  const isNavigationRequest = event.request.mode === 'navigate';
+  const isSameOrigin = requestUrl.origin === self.location.origin;
+
+  if (isNavigationRequest) {
+    event.respondWith(
+      fetch(event.request)
+        .then((networkResponse) => {
+          const responseClone = networkResponse.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+          return networkResponse;
+        })
+        .catch(() => caches.match(event.request).then((cached) => cached || caches.match(OFFLINE_URL)))
+    );
+    return;
+  }
+
+  if (isSameOrigin) {
+    event.respondWith(
+      caches.match(event.request).then((cachedResponse) => {
+        const networkFetch = fetch(event.request)
+          .then((networkResponse) => {
+            const responseClone = networkResponse.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+            return networkResponse;
+          })
+          .catch(() => cachedResponse);
+        return cachedResponse || networkFetch;
+      })
+    );
+  }
+});

--- a/index.html
+++ b/index.html
@@ -65,6 +65,12 @@ ref: home
             <p>A circular step sequencer inspired by the Dato Drum. Build beats with 4 voices, effects and BPM control.</p>
             <span class="app-tag">PWA</span>
         </a>
+        <a class="app-card" href="/f1-championship/">
+            <span class="app-icon">🏎️</span>
+            <h3>F1 Championship</h3>
+            <p>Track your lap time championship across the full 2026 F1 season. Compete race by race, earn points, see who rules the standings.</p>
+            <span class="app-tag">PWA</span>
+        </a>
     </div>
 </section>
 <section class="postlist">


### PR DESCRIPTION
## Summary

- New PWA at `/f1-championship/` to track a full 2026 F1 season lap-time competition between friends
- Each race weekend, players log their best lap time in the F1 game; the app ranks by fastest time, awards standard F1 points (25-18-15…), and shows live championship standings
- Added app card to the home page apps grid

## Features

- **Championship tab** — podium with player avatars, driver standings table, race-by-race grid with country flag headers and gold/silver/bronze point cells
- **Calendar tab** — all 24 races with flag images (flagcdn.com), circuit name, date, and status badges (Upcoming / Done / Locked); tap any race to enter lap times
- **Race entry modal** — per-player lap time inputs (`1:23.456` format), live preview rankings and points as you type, save/lock/unlock
- **Settings** — add/remove players (up to 6), profile photo upload (resized to 200px via canvas, stored in localStorage), game version label, export/import JSON, reset season
- **PWA** — manifest, service worker with cache versioning, installable on home screen

## Test plan

- [ ] Open `/f1-championship/` and verify Championship tab loads with empty state
- [ ] Go to Settings, rename players, tap avatar to upload a photo
- [ ] Open Calendar, tap Round 1, enter two lap times, verify live preview shows correct ranking and points
- [ ] Save and confirm standings update with podium and race grid
- [ ] Verify flag images appear in both the race grid headers and calendar cards
- [ ] Test Export → Reset → Import round-trip
- [ ] Confirm app card appears on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)