### PR TITLE
Add Yellow – Coldplay chords

### DIFF
--- a/music-theory/index.html
+++ b/music-theory/index.html
@@ -732,6 +732,12 @@ title: Music Theory
         { root: 0,  type: 'Dominant 7th', label: 'C7'  },
         { root: 10, type: 'Major',        label: 'B♭'  },
       ],
+      'Yellow – Coldplay': [
+        { root: 10, type: 'Major', label: 'B♭' },
+        { root: 5,  type: 'Major', label: 'F'  },
+        { root: 7,  type: 'Minor', label: 'Gm' },
+        { root: 3,  type: 'Major', label: 'E♭' },
+      ],
     };
 
     const INTERVAL_NAMES = [


### PR DESCRIPTION
Adds "Yellow – Coldplay" to the song dropdown with chords B♭ – F – Gm – E♭ (original key of B♭ major).

https://claude.ai/code/session_01JJvVqSEpmHraxwkfUzujzU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJvVqSEpmHraxwkfUzujzU)_