### PR TITLE
feat(music-theory): sustain notes while piano key is held down

### DIFF
--- a/music-theory/index.html
+++ b/music-theory/index.html
@@ -359,7 +359,7 @@ title: Music Theory
 
     .key-white {
       position: relative;
-      width: 52px;
+      width: 60px;
       height: 180px;
       background: #f0ebe0;
       border: 1px solid #8a8070;
@@ -380,8 +380,8 @@ title: Music Theory
 
     .key-black {
       position: absolute;
-      width: 32px;
-      height: 112px;
+      width: 38px;
+      height: 88px;
       background: #1a1632;
       border-radius: 0 0 6px 6px;
       cursor: pointer;
@@ -804,7 +804,7 @@ title: Music Theory
     const WHITE_PCS = [0,2,4,5,7,9,11];
     const MIDI_START = 36;  // C2
     const MIDI_END   = 108; // C8
-    const WHITE_W    = 53; // px per white key (width + 1px gap)
+    const WHITE_W    = 61; // px per white key (width + 1px gap)
 
     // ── State ─────────────────────────────────────────────────────────────────
 
@@ -939,7 +939,7 @@ title: Music Theory
           el.setAttribute('aria-label', `${NOTE_NAMES[pc]}${octave}`);
           // Position: center over the gap between the preceding and following white keys
           // Preceding white key index (0-based) = whiteCount - 1
-          const leftPx = (whiteCount - 1) * WHITE_W + WHITE_W - 17;
+          const leftPx = (whiteCount - 1) * WHITE_W + WHITE_W - 19;
           el.style.left = leftPx + 'px';
           el.appendChild(noteLabel);
         }

--- a/music-theory/index.html
+++ b/music-theory/index.html
@@ -859,6 +859,25 @@ title: Music Theory
       sampler.triggerAttackRelease(midiToNoteName(midi), '8n');
     }
 
+    const heldNotes = new Set();
+
+    async function startNote(midi) {
+      if (!samplerReady) return;
+      await Tone.start();
+      if (!heldNotes.has(midi)) {
+        heldNotes.add(midi);
+        sampler.triggerAttack(midiToNoteName(midi));
+      }
+    }
+
+    function stopNote(midi) {
+      if (!samplerReady) return;
+      if (heldNotes.has(midi)) {
+        heldNotes.delete(midi);
+        sampler.triggerRelease(midiToNoteName(midi));
+      }
+    }
+
     async function playChord(midiNotes) {
       if (!samplerReady) return;
       await Tone.start();
@@ -927,8 +946,11 @@ title: Music Theory
 
         el.addEventListener('pointerdown', (e) => {
           e.preventDefault();
-          onKeyDown(midi, el);
+          el.setPointerCapture(e.pointerId);
+          onKeyPress(midi, el);
         });
+        el.addEventListener('pointerup', () => onKeyRelease(midi, el));
+        el.addEventListener('pointercancel', () => onKeyRelease(midi, el));
 
         kb.appendChild(el);
       }
@@ -937,11 +959,10 @@ title: Music Theory
       kb.style.width = (whiteCount * WHITE_W - 1) + 'px';
     }
 
-    function onKeyDown(midi, el) {
+    function onKeyPress(midi, el) {
       if (state.mode === 'quiz') return;
-      playNote(midi);
+      startNote(midi);
       el.classList.add('pressed');
-      setTimeout(() => el.classList.remove('pressed'), 180);
 
       if (state.mode === 'intervals') {
         state.ivNotes.push(midi);
@@ -949,6 +970,11 @@ title: Music Theory
         updateHighlight();
         updateIntervalDisplay();
       }
+    }
+
+    function onKeyRelease(midi, el) {
+      stopNote(midi);
+      el.classList.remove('pressed');
     }
 
     // ── Highlight ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Notes now sustain for as long as the pointer is held on a piano key
- Switched from `triggerAttackRelease` (fixed duration) to `triggerAttack` on pointerdown and `triggerRelease` on pointerup/pointercancel
- Added `setPointerCapture` so releasing outside the key still stops the note
- Tracks held notes in a `Set` to avoid double-triggering

https://claude.ai/code/session_014bwC96TZj2AowzyswTXoTL

---
_Generated by [Claude Code](https://claude.ai/code/session_014bwC96TZj2AowzyswTXoTL)_