### PR TITLE
fix(elastomania): correct spring constraint length so bike stays together

### DIFF
--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -258,7 +258,7 @@ permalink: /elastomania/
         label: 'frontWheel'
       });
 
-      chassis = Bodies.rectangle(SPAWN_X, SPAWN_Y - 12, CHASSIS_W, CHASSIS_H, {
+      chassis = Bodies.rectangle(SPAWN_X, SPAWN_Y - 20, CHASSIS_W, CHASSIS_H, {
         density: 0.005,
         frictionAir: 0.02,
         collisionFilter: { category: 0x0004, mask: 0x0000 },
@@ -268,13 +268,13 @@ permalink: /elastomania/
       const rearConstraint = Constraint.create({
         bodyA: chassis, bodyB: rearWheel,
         pointA: { x: -20, y: 5 }, pointB: { x: 0, y: 0 },
-        stiffness: 0.7, damping: 0.2, length: 18
+        stiffness: 0.9, damping: 0.1, length: 15
       });
 
       const frontConstraint = Constraint.create({
         bodyA: chassis, bodyB: frontWheel,
         pointA: { x: 20, y: 5 }, pointB: { x: 0, y: 0 },
-        stiffness: 0.7, damping: 0.2, length: 18
+        stiffness: 0.9, damping: 0.1, length: 15
       });
 
       const terrainBodies = [];


### PR DESCRIPTION
## Problem

The motorcycle falls apart immediately on spawn. Root cause: the spring constraint `length` (18px) was much longer than the actual initial distance between the chassis attachment point and each wheel center (~7px). Since initial gap < rest length, the spring was in a compressed state and immediately blew the chassis upward and the wheels outward.

## Fix

- Raise chassis spawn from `SPAWN_Y - 12` → `SPAWN_Y - 20`, so the attachment point (`y: chassis_center + 5`) is exactly 15px above each wheel center
- Set `length: 15` to match this actual geometry
- Increase `stiffness: 0.7 → 0.9` for a stiffer, more stable suspension
- Reduce `damping: 0.2 → 0.1`

## Test plan

- [ ] Start the game — bike spawns in one piece, wheels on the ground
- [ ] `→` key / right button accelerates, bike drives forward
- [ ] Bike can climb the first gentle hill without falling apart
- [ ] Lean controls (↑↓) tilt the chassis

https://claude.ai/code/session_01KffwgiXR9mA4KE8h1sTQYs

---
_Generated by [Claude Code](https://claude.ai/code/session_01KffwgiXR9mA4KE8h1sTQYs)_