### PR TITLE
Gate scale quiz: master major scales before minor unlocks

### DIFF
--- a/music-theory/index.html
+++ b/music-theory/index.html
@@ -839,6 +839,7 @@ title: Music Theory
       quizScore:    { correct: 0, total: 0 },
       quizLevel:    1,
       quizStreak:   0,
+      majorScaleRootsDone: new Set(),  // major keys answered correctly — gates other scales
     };
 
     // ── Audio (Tone.js Salamander piano) ──────────────────────────────────────
@@ -1203,8 +1204,21 @@ title: Music Theory
     function generateScaleQuestion() {
       const lvl = QUIZ_LEVELS[state.quizLevel];
       const rootPool = state.quizLevel === 1 ? [0,2,4,5,7,9,11] : [...Array(12).keys()];
-      const root = rootPool[Math.floor(Math.random() * rootPool.length)];
-      const type = lvl.scalePool[Math.floor(Math.random() * lvl.scalePool.length)];
+
+      // Gate non-major scales: only test Major until every major key available
+      // at this level has been answered correctly. While still learning the
+      // majors, prefer keys that haven't been gotten right yet.
+      const majorsMastered = rootPool.every(r => state.majorScaleRootsDone.has(r));
+      const pool = majorsMastered ? lvl.scalePool : ['Major'];
+      let root;
+      if (majorsMastered) {
+        root = rootPool[Math.floor(Math.random() * rootPool.length)];
+      } else {
+        const untested = rootPool.filter(r => !state.majorScaleRootsDone.has(r));
+        root = untested[Math.floor(Math.random() * untested.length)];
+      }
+      const type = pool[Math.floor(Math.random() * pool.length)];
+
       let rootMidi = lvl.midiMin + ((root - (lvl.midiMin % 12) + 12) % 12);
       const span = SCALES[type].intervals[SCALES[type].intervals.length - 1];
       if (rootMidi + span > lvl.midiMax) rootMidi -= 12;
@@ -1214,6 +1228,7 @@ title: Music Theory
         answerPcs: new Set(midis.map(m => m % 12)),
         answerName: `${NOTE_NAMES[root]} ${type} scale`,
         rootPc: root,
+        scaleType: type,
       };
     }
 
@@ -1294,6 +1309,11 @@ title: Music Theory
       const correct = played.size === expected.size && [...expected].every(pc => played.has(pc));
       if (correct) { state.quizScore.correct++; state.quizStreak++; }
       else { state.quizStreak = 0; }
+
+      // Track mastery of each major key — it unlocks the other scales.
+      if (correct && state.quizType === 'scales' && state.quizQuestion.scaleType === 'Major') {
+        state.majorScaleRootsDone.add(state.quizQuestion.rootPc);
+      }
 
       // Recolour the keys: green = right note played, red = wrong note played,
       // amber = a correct note the player missed.

--- a/music-theory/sw.js
+++ b/music-theory/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2606020100';
+const CACHE_VERSION = '2606020200';
 const CACHE_NAME = `music-theory-${CACHE_VERSION}`;
 const OFFLINE_URL = '/music-theory/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary

The scale quiz was mixing in the minor scale too early. It now follows a **majors-first** progression: only **Major** scales are tested until every major key available at the current level has been answered correctly. Once the majors are mastered, the rest of the level's scale pool (Natural Minor and beyond) unlocks.

## Changes

- **`majorScaleRootsDone`** state set tracks which major keys have been answered correctly.
- **`generateScaleQuestion()`** now restricts the scale pool to `['Major']` until every major key in the current level's root pool is mastered, and while learning it **prioritises keys not yet gotten right** so the set can actually be completed (rather than random repeats).
- **`checkQuizAnswer()`** records a major key as mastered when its scale is played correctly.
- Bumped the service worker `CACHE_VERSION`.

## Behaviour notes

- Mastery is tracked per the current level's key set (Level 1 = the 7 white-key majors; Levels 2–3 = all 12). Levelling up introduces new keys, so the new majors must be cleared before the other scales reappear at that level.
- Progress is in-memory only (resets on reload), consistent with how score/level already behave. There's no on-screen indicator that minor is gated — happy to add a small "majors remaining" hint if you'd like.

https://claude.ai/code/session_011ypKTPPGZdoSNymo9K7KBG

---
_Generated by [Claude Code](https://claude.ai/code/session_011ypKTPPGZdoSNymo9K7KBG)_