### PR TITLE
Fix Oceania missing countries in Performance by Confederation

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -1451,6 +1451,7 @@ function ConfederationChart({groupMatches, ko, isMobile}) {
                 <div style={{display:"flex",alignItems:"center",gap:6,flexWrap:"wrap"}}>
                   <span style={{width:7,height:7,borderRadius:2,background:conf.color,display:"inline-block",flexShrink:0}}/>
                   <span style={{fontSize:10,fontWeight:700,color:"#ccc"}}>{conf.label}</span>
+                  <span style={{fontSize:8,fontWeight:800,letterSpacing:0.5,color:conf.color,background:`${conf.color}1a`,border:`1px solid ${conf.color}40`,borderRadius:4,padding:"1px 4px"}}>{conf.name}</span>
                   <span style={{fontSize:9,color:"#444"}}>({conf.teamCount} {conf.teamCount===1?"team":"teams"})</span>
                   {/* Always-visible team flags so every confederation shows its countries */}
                   <span style={{display:"flex",alignItems:"center",gap:2,flexWrap:"wrap"}}>

--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -1331,7 +1331,7 @@ function GroupMatchCard({match,onScore,isMobile}){
 const CONFEDERATIONS = {
   UEFA: {
     name:"UEFA", label:"Europe", color:"#4f8ef7",
-    teams:["Germany","Netherlands","Sweden","Belgium","Spain","France","England","Croatia","Switzerland","Portugal","Serbia","Bosnia","Czechia","Scotland","Norway","Austria"],
+    teams:["Germany","Netherlands","Sweden","Belgium","Spain","France","England","Croatia","Switzerland","Portugal","Serbia","Bosnia","Czechia","Scotland","Norway","Austria","Turkey"],
   },
   CONMEBOL: {
     name:"CONMEBOL", label:"S. America", color:"#f7c948",
@@ -1343,11 +1343,11 @@ const CONFEDERATIONS = {
   },
   CAF: {
     name:"CAF", label:"Africa", color:"#ff6b35",
-    teams:["Morocco","South Africa","Senegal","Ivory Coast","Egypt","Ghana","DR Congo","Cameroon","Tunisia","Mali","Nigeria","Algeria"],
+    teams:["Morocco","South Africa","Senegal","Ivory Coast","Egypt","Ghana","DR Congo","Cameroon","Tunisia","Mali","Nigeria","Algeria","Cape Verde"],
   },
   AFC: {
     name:"AFC", label:"Asia", color:"#a78bfa",
-    teams:["South Korea","Japan","Saudi Arabia","Iran","Iraq","Australia","Qatar","Uzbekistan"],
+    teams:["South Korea","Japan","Saudi Arabia","Iran","Iraq","Australia","Qatar","Uzbekistan","Jordan"],
   },
   OFC: {
     name:"OFC", label:"Oceania", color:"#ff3b55",
@@ -1448,10 +1448,16 @@ function ConfederationChart({groupMatches, ko, isMobile}) {
             <div key={conf.key}>
               {/* Conf name + teams row */}
               <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",marginBottom:4}}>
-                <div style={{display:"flex",alignItems:"center",gap:6}}>
+                <div style={{display:"flex",alignItems:"center",gap:6,flexWrap:"wrap"}}>
                   <span style={{width:7,height:7,borderRadius:2,background:conf.color,display:"inline-block",flexShrink:0}}/>
                   <span style={{fontSize:10,fontWeight:700,color:"#ccc"}}>{conf.label}</span>
-                  <span style={{fontSize:9,color:"#444"}}>({conf.teamCount} teams)</span>
+                  <span style={{fontSize:9,color:"#444"}}>({conf.teamCount} {conf.teamCount===1?"team":"teams"})</span>
+                  {/* Always-visible team flags so every confederation shows its countries */}
+                  <span style={{display:"flex",alignItems:"center",gap:2,flexWrap:"wrap"}}>
+                    {conf.teams.slice(0,isMobile?6:12).map(t=>(
+                      <Flag key={t} team={t} size={11} />
+                    ))}
+                  </span>
                 </div>
                 <div style={{display:"flex",alignItems:"center",gap:10}}>
                   {!noData&&<span style={{fontSize:9,color:"#555"}}>{conf.teamCount>0?`avg ${conf.avgPts} pts`:""}</span>}
@@ -1474,12 +1480,7 @@ function ConfederationChart({groupMatches, ko, isMobile}) {
                     display:"flex",alignItems:"center",
                     justifyContent:isNeg?"flex-start":"flex-end",
                     paddingRight:isNeg?0:5,paddingLeft:isNeg?5:0,
-                  }}>
-                    {/* Team flags inside bar */}
-                    {pct>18&&conf.teams.slice(0,isMobile?4:8).map(t=>(
-                      <Flag key={t} team={t} size={11} />
-                    ))}
-                  </div>
+                  }}/>
                 )}
                 {noData&&<div style={{position:"absolute",inset:0,display:"flex",alignItems:"center",paddingLeft:8,fontSize:9,color:"#333"}}>No results yet</div>}
               </div>


### PR DESCRIPTION
## Problem

In the World Cup 2026 app's **Performance by Confederation** chart, Oceania (OFC) appeared to be missing its countries.

## Root cause

The country flags were only rendered *inside* the colored performance bar, and only when the bar was wide enough (`pct > 18`). Oceania has a single, typically low-scoring team (New Zealand), so its bar was always too short — the flag never rendered and the confederation looked empty.

## Fix

- **Always show country flags** by moving them to the confederation's header row, so every confederation (including Oceania) displays its teams regardless of bar width.
- Removed the now-redundant in-bar flags that were the source of the bug.
- Singular/plural fix: shows "(1 team)" instead of "(1 teams)".
- **Bonus correctness fix:** three teams in the bracket weren't assigned to any confederation and were silently dropped from the chart. Added them to the correct confederations:
  - Turkey → UEFA
  - Cape Verde → CAF
  - Jordan → AFC

https://claude.ai/code/session_013acUnHJHL4HVcR97vLY5q4

---
_Generated by [Claude Code](https://claude.ai/code/session_013acUnHJHL4HVcR97vLY5q4)_