### PR TITLE
Fix filter strip positioning on mobile to avoid tab bar overlap

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -1206,7 +1206,7 @@ function FixturesView({groupMatches,onScore,isMobile,initialFilter,onFilterUsed}
   },[closestDate, filter]);
 
   return(
-    <div ref={containerRef} style={{paddingBottom:isMobile?70:0}}>
+    <div ref={containerRef} style={{paddingBottom:isMobile?130:0}}>
       <div style={{display:"flex",alignItems:"center",justifyContent:"flex-end",marginBottom:14,flexWrap:"wrap",gap:8}}>
         <span style={{fontSize:10,color:"#555"}}>{scored}/72 played</span>
       </div>
@@ -1246,8 +1246,8 @@ function FixturesView({groupMatches,onScore,isMobile,initialFilter,onFilterUsed}
         );
       })}
 
-      {/* Group filter strip — pinned to the bottom so it stays within thumb's reach on phones */}
-      <div style={{position:"sticky",bottom:isMobile?54:0,zIndex:50,marginTop:8,paddingTop:8,paddingBottom:8,background:"rgba(10,16,32,0.92)",backdropFilter:"blur(6px)",borderTop:`1px solid ${BORDER}`}}>
+      {/* Group filter strip — fixed above the bottom tab bar on phones so it's always within thumb's reach */}
+      <div style={isMobile?{position:"fixed",left:0,right:0,bottom:58,zIndex:150,padding:"8px 10px",background:"rgba(10,16,32,0.94)",backdropFilter:"blur(6px)",borderTop:`1px solid ${BORDER}`}:{position:"sticky",bottom:0,zIndex:50,marginTop:8,paddingTop:8,paddingBottom:8,background:"rgba(10,16,32,0.92)",backdropFilter:"blur(6px)",borderTop:`1px solid ${BORDER}`}}>
         <div style={{overflowX:"auto",WebkitOverflowScrolling:"touch"}}>
           <div style={{display:"flex",gap:5,minWidth:"max-content"}}>
             {["ALL",...Object.keys(GROUPS)].map(g=>{
@@ -1357,7 +1357,7 @@ function KnockoutView({ko,onScore,isMobile}){
   const matches=ko[round];
   const currentRound=ROUNDS.find(r=>r.key===round);
   return(
-    <div style={{paddingBottom:isMobile?70:0}}>
+    <div style={{paddingBottom:isMobile?130:0}}>
       <SLabel>{currentRound?.fullLabel}</SLabel>      {round==="final"&&ko.final[0].teamA&&(
         <div style={{textAlign:"center",marginBottom:16}}>
           <div style={{fontSize:30}}>🏆</div>
@@ -1369,8 +1369,8 @@ function KnockoutView({ko,onScore,isMobile}){
         {matches.map((m,i)=><KOMatchCard key={m.id} match={m} matchIdx={i} round={round} onScore={onScore} isMobile={isMobile}/>)}
       </div>
 
-      {/* Round filter strip — pinned to the bottom so it stays within thumb's reach on phones */}
-      <div style={{position:"sticky",bottom:isMobile?54:0,zIndex:50,marginTop:14,paddingTop:8,paddingBottom:8,background:"rgba(10,16,32,0.92)",backdropFilter:"blur(6px)",borderTop:`1px solid ${BORDER}`}}>
+      {/* Round filter strip — fixed above the bottom tab bar on phones so it's always within thumb's reach */}
+      <div style={isMobile?{position:"fixed",left:0,right:0,bottom:58,zIndex:150,padding:"8px 10px",background:"rgba(10,16,32,0.94)",backdropFilter:"blur(6px)",borderTop:`1px solid ${BORDER}`}:{position:"sticky",bottom:0,zIndex:50,marginTop:14,paddingTop:8,paddingBottom:8,background:"rgba(10,16,32,0.92)",backdropFilter:"blur(6px)",borderTop:`1px solid ${BORDER}`}}>
         <div style={{overflowX:"auto",WebkitOverflowScrolling:"touch"}}>
           <div style={{display:"flex",gap:5,minWidth:"max-content"}}>
             {ROUNDS.map(r=>{


### PR DESCRIPTION
## Summary
Improved the mobile UI layout by repositioning filter strips to be fixed above the bottom tab bar instead of sticky, ensuring they remain accessible without overlapping navigation elements.

## Key Changes
- **Container padding adjustment**: Increased bottom padding from 70px to 130px on mobile for both group and knockout views to accommodate the repositioned filter strips
- **Filter strip positioning (Group view)**: Changed from `sticky` positioning (bottom: 54px) to `fixed` positioning (bottom: 58px) on mobile, with conditional styling based on device type
- **Filter strip positioning (KO view)**: Applied the same fixed positioning change to the knockout round filter strip
- **Styling refinements**: 
  - Updated background opacity from 0.92 to 0.94 for better visibility
  - Changed padding approach from separate `paddingTop`/`paddingBottom` to unified `padding: "8px 10px"` for mobile
  - Increased z-index from 50 to 150 on mobile to ensure proper layering above content
  - Added explicit `left: 0` and `right: 0` to fixed elements for full-width coverage
- **Comment updates**: Clarified that filter strips are now "fixed above the bottom tab bar" rather than "pinned to the bottom"

## Implementation Details
The changes use conditional styling (`isMobile ? {...} : {...}`) to apply different positioning strategies:
- **Mobile**: Fixed positioning at bottom: 58px with higher z-index (150) to sit above the tab bar
- **Desktop**: Sticky positioning with original behavior maintained

This ensures filter controls remain within thumb's reach on mobile devices while maintaining the original desktop experience.

https://claude.ai/code/session_019eFEgwnsMpXzE4JtaEB4Fb