### PR TITLE
feat(worldcup): add extra star for champion when Final winner is defined

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -1531,6 +1531,7 @@ function App(){
         </div>
       )}
     </div>
+    </ChampionContext.Provider>
   );
 }
 
@@ -2204,7 +2205,6 @@ function GlobalStats({stats,groupMatches,ko,isMobile}){
         </div>
       </div>
     </div>
-    </ChampionContext.Provider>
   );
 }
 

--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -150,9 +150,12 @@ const WC_TITLES = {
 // Teams appearing at the World Cup for the first time ever in 2026
 const WC_DEBUTANTS = new Set(["Cape Verde","Curacao","Jordan","Uzbekistan"]);
 
+const ChampionContext = React.createContext(null);
+
 // Renders team name with WC stars and/or NEW badge inline
 function TeamName({ name, style={} }) {
-  const titles = WC_TITLES[name] || 0;
+  const champion = React.useContext(ChampionContext);
+  const titles = (WC_TITLES[name] || 0) + (name === champion ? 1 : 0);
   const isNew  = WC_DEBUTANTS.has(name);
   return (
     <span style={{ display:"inline-flex", alignItems:"center", gap:3, minWidth:0, ...style }}>
@@ -1414,6 +1417,8 @@ function App(){
     setPredictions(prev=>({...prev,ko:{...prev.ko,[matchId]:{...prev.ko?.[matchId],[field]:val}}}));
   },[]);
 
+  const champion = React.useMemo(()=>koWinner(ko.final[0]),[ko]);
+
   const globalStats=useMemo(()=>{
     const allG=Object.values(groupMatches).flat();
     const gPlayed=allG.filter(m=>m.homeScore!==null&&m.awayScore!==null);
@@ -1444,6 +1449,7 @@ function App(){
   const currentNav = NAV.find(n=>n.v===view)||NAV[0];
 
   return(
+    <ChampionContext.Provider value={champion}>
     <div style={{minHeight:"100vh",background:`linear-gradient(160deg,${BG} 0%,#0d1a2e 60%,${BG} 100%)`,fontFamily:"'Trebuchet MS','Segoe UI',sans-serif",color:"#e8eaf0",paddingBottom:isMobile?68:0}}>
       {splash && <SplashScreen onDone={()=>setSplash(false)}/>}
 
@@ -2198,6 +2204,7 @@ function GlobalStats({stats,groupMatches,ko,isMobile}){
         </div>
       </div>
     </div>
+    </ChampionContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Summary

- Added a `ChampionContext` React context that holds the current Final match winner
- `App()` computes `champion = koWinner(ko.final[0])` and provides it via context
- `TeamName` reads the context and adds +1 to the star count when the team is the current champion
- Stars update automatically across the entire app (Knockout bracket, Standings, Fixtures, Fantasy) the moment a Final score is entered

## Test plan

- [ ] Enter scores through the Knockout bracket until the Final has a winner
- [ ] Verify the champion's name shows one extra star (e.g. Brazil goes from `5★` to `6★`)
- [ ] Verify teams with no previous titles get `1★` when they win
- [ ] Verify stars reset if the Final score is cleared
- [ ] Verify all other teams' star counts are unchanged

https://claude.ai/code/session_017cVcCaaAeiAf9akT6y3o5G

---
_Generated by [Claude Code](https://claude.ai/code/session_017cVcCaaAeiAf9akT6y3o5G)_