### PR TITLE
Add Portuguese-BR translation to World Cup 2026 app

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -42,6 +42,347 @@
   <script type="text/babel" data-presets="react">
 const { useState, useMemo, useEffect, useCallback, useRef } = React;
 
+// ─── i18n ─────────────────────────────────────────────────────────────────────
+const TRANSLATIONS = {
+  en: {
+    // Header
+    header_title: "World Cup 2026",
+    header_subtitle: "USA · CANADA · MEXICO",
+    // Nav
+    nav_fantasy: "Fantasy",
+    nav_fixtures: "Fixtures",
+    nav_standings: "Standings",
+    nav_knockout: "Knockout",
+    nav_stats: "Stats",
+    // Phases / rounds (GuessesView)
+    phase_group: "Group Stage",
+    phase_r32: "Round of 32",
+    phase_r16: "Round of 16",
+    phase_qf: "Quarter-finals",
+    phase_sf: "Semi-finals",
+    phase_final: "Final",
+    // Knockout round full labels
+    round_r32: "⚽ Round of 32",
+    round_r16: "⚡ Round of 16",
+    round_qf: "🥊 Quarter-Finals",
+    round_sf: "🔥 Semi-Finals",
+    round_third: "🥉 Third Place",
+    round_final: "🏆 The Final",
+    // Match labels
+    match_label_third: "🥉 3rd Place",
+    match_label_final: "🏆 Final",
+    // FINISH_LABEL_MAP
+    finish_champion: "Champion",
+    finish_runner_up: "Runner-up",
+    finish_3rd: "3rd",
+    finish_4th: "4th",
+    finish_qf: "Quarter-final",
+    finish_r16: "Round of 16",
+    finish_gs: "Group Stage",
+    // TeamName
+    wc_winner_title: "× World Cup winner",
+    new_badge: "NEW",
+    // Standings
+    col_gd: "GD",
+    col_pts: "PTS",
+    col_grp: "GRP",
+    col_team: "Team",
+    top2_advance: "Top 2 advance",
+    best8_advance: "Best 8 of 12 advance",
+    third_race_title: "3RD PLACE RACE",
+    eliminated_below: "· · · Eliminated below · · ·",
+    top8_advance_sorted: "Top 8 advance · sorted by Pts → GD → GF",
+    // Result dots tooltip
+    result_upcoming: "Upcoming",
+    result_won: "Won",
+    result_lost: "Lost",
+    result_draw: "Draw",
+    // Result dot legend labels
+    legend_won: "Won",
+    legend_draw: "Draw",
+    legend_lost: "Lost",
+    legend_next: "Next",
+    // Fixtures
+    scored_badge: "{n} scored",
+    played_count: "{n}/72 played",
+    all_groups_option: "All Groups ({n} played)",
+    group_option: "Group {g} ({n} played)",
+    fixtures_button: "Fixtures →",
+    group_played_count: "{n}/6 played",
+    match_count: "{n} match",
+    matches_count: "{n} matches",
+    now_badge: "NOW",
+    win_badge: "WIN ✓",
+    draw_badge: "DRAW",
+    // KO match card
+    penalty_shootout: "🥅 Penalty Shootout",
+    win_pen: "WIN (PEN)",
+    advance: "ADVANCE",
+    tbd: "TBD",
+    // KO view
+    the_wc_final: "The World Cup Final",
+    // Fantasy / GuessesView
+    fantasy_label: "🎯 Fantasy",
+    pts_label: "pts",
+    pts_played_summary: "{played} played · 🎯 {exact} exact · ✅ {correct} right · ❌ {wrong} wrong",
+    share_all: "📋 Share All",
+    copied: "✓ Copied!",
+    share_phase: "📋 Share Phase",
+    pts_earned: "{pts} pts earned this phase",
+    locked_enter_results: "🔒 Enter results for the previous round first",
+    enter_prev_round: "Enter previous round results to unlock",
+    actual_score: "Actual: {a}–{b}",
+    // Stats
+    stat_host_cities: "Host Cities",
+    stat_farthest_trip: "Farthest Trip",
+    stat_total_goals: "Total Goals",
+    stat_goals_per_game: "Goals/Game",
+    perf_by_conf: "Performance by Confederation",
+    metric_pts: "PTS",
+    metric_gf: "GF",
+    metric_gd: "GD",
+    metric_total_pts: "Total Points",
+    metric_goals_scored: "Goals Scored",
+    metric_goal_diff: "Goal Diff",
+    all_stages_combined: "All stages combined",
+    no_results_yet: "No results yet",
+    conf_teams: "teams",
+    conf_team: "team",
+    conf_avg_pts: "avg {n} pts",
+    top_scoring_nations: "Top Scoring Nations (All Stages)",
+    enter_scores_rankings: "Enter scores to see rankings",
+    // Historical chart
+    chart_gpg: "Goals / Game",
+    chart_goals: "Total Goals",
+    chart_teams: "Teams",
+    chart_all_editions: "All Editions",
+    chart_gpg_btn: "GPG",
+    chart_goals_btn: "Goals",
+    chart_teams_btn: "Teams",
+    chart_most: "Most (1954: 5.38)",
+    chart_fewest: "Fewest (1990: 2.21)",
+    chart_live: "2026 live",
+    chart_hist_avg: "Hist. avg",
+    // Past Champions
+    past_champions: "Past Champions",
+    col_year: "Year",
+    col_champion: "Champion",
+    col_runner_up: "Runner-up",
+    col_gpg: "GPG",
+    show_all_editions: "Show all {n} editions ↓",
+    // FinishBadge
+    debut: "Debut",
+    first_appearance: "First appearance in 2026 🎉",
+    // Team History
+    team_wc_history: "Team WC History",
+    sort_best_finish: "Best Finish",
+    sort_most_apps: "Most Apps",
+    sort_alpha: "A–Z",
+    // Fun Facts
+    did_you_know: "Did You Know? 🤓",
+    // Confederation labels
+    conf_europe: "Europe",
+    conf_s_america: "S. America",
+    conf_nc_america: "N/C America",
+    conf_africa: "Africa",
+    conf_asia: "Asia",
+    conf_oceania: "Oceania",
+    // Splash
+    splash_subtitle: "USA · Canada · Mexico",
+    // buildShareText phase labels (for plain-text share)
+    share_group_stage: "GROUP STAGE",
+    share_r32: "ROUND OF 32",
+    share_r16: "ROUND OF 16",
+    share_qf: "QUARTER-FINALS",
+    share_sf: "SEMI-FINALS",
+    share_final: "FINAL",
+    share_header: "⚽ *World Cup 2026 – My Guesses*",
+    share_header_phase: "⚽ *World Cup 2026 – My {phase} Guesses*",
+    share_total: "*🏆 Total: {total} pts* ({played} played · 🎯 {exact} exact · ✅ {correct} right · ❌ {wrong} wrong)",
+  },
+  'pt-BR': {
+    // Header
+    header_title: "Copa do Mundo 2026",
+    header_subtitle: "EUA · CANADÁ · MÉXICO",
+    // Nav
+    nav_fantasy: "Bolão",
+    nav_fixtures: "Jogos",
+    nav_standings: "Classificação",
+    nav_knockout: "Mata-mata",
+    nav_stats: "Estatísticas",
+    // Phases / rounds (GuessesView)
+    phase_group: "Fase de Grupos",
+    phase_r32: "Rodada de 32",
+    phase_r16: "Oitavas de Final",
+    phase_qf: "Quartas de Final",
+    phase_sf: "Semifinais",
+    phase_final: "Final",
+    // Knockout round full labels
+    round_r32: "⚽ Rodada de 32",
+    round_r16: "⚡ Oitavas de Final",
+    round_qf: "🥊 Quartas de Final",
+    round_sf: "🔥 Semifinais",
+    round_third: "🥉 Terceiro Lugar",
+    round_final: "🏆 A Final",
+    // Match labels
+    match_label_third: "🥉 3º Lugar",
+    match_label_final: "🏆 Final",
+    // FINISH_LABEL_MAP
+    finish_champion: "Campeão",
+    finish_runner_up: "Vice-campeão",
+    finish_3rd: "3º lugar",
+    finish_4th: "4º lugar",
+    finish_qf: "Quartas",
+    finish_r16: "Oitavas",
+    finish_gs: "Fase de Grupos",
+    // TeamName
+    wc_winner_title: "× campeão mundial",
+    new_badge: "NOVO",
+    // Standings
+    col_gd: "SG",
+    col_pts: "PTS",
+    col_grp: "GRP",
+    col_team: "Seleção",
+    top2_advance: "Top 2 avançam",
+    best8_advance: "Top 8 de 12 avançam",
+    third_race_title: "DISPUTA PELO 3º",
+    eliminated_below: "· · · Eliminados abaixo · · ·",
+    top8_advance_sorted: "Top 8 avançam · por Pts → SG → GF",
+    // Result dots tooltip
+    result_upcoming: "Próximo",
+    result_won: "Vitória",
+    result_lost: "Derrota",
+    result_draw: "Empate",
+    // Result dot legend labels
+    legend_won: "Vitória",
+    legend_draw: "Empate",
+    legend_lost: "Derrota",
+    legend_next: "Próximo",
+    // Fixtures
+    scored_badge: "{n} marcados",
+    played_count: "{n}/72 jogados",
+    all_groups_option: "Todos os Grupos ({n} jogados)",
+    group_option: "Grupo {g} ({n} jogados)",
+    fixtures_button: "Jogos →",
+    group_played_count: "{n}/6 jogados",
+    match_count: "{n} jogo",
+    matches_count: "{n} jogos",
+    now_badge: "AGORA",
+    win_badge: "VITÓRIA ✓",
+    draw_badge: "EMPATE",
+    // KO match card
+    penalty_shootout: "🥅 Disputa de Pênaltis",
+    win_pen: "VITÓRIA (PEN)",
+    advance: "AVANÇA",
+    tbd: "A DEF.",
+    // KO view
+    the_wc_final: "A Grande Final",
+    // Fantasy / GuessesView
+    fantasy_label: "🎯 Bolão",
+    pts_label: "pts",
+    pts_played_summary: "{played} jogados · 🎯 {exact} exatos · ✅ {correct} certos · ❌ {wrong} errados",
+    share_all: "📋 Compartilhar Tudo",
+    copied: "✓ Copiado!",
+    share_phase: "📋 Compartilhar Fase",
+    pts_earned: "{pts} pts nesta fase",
+    locked_enter_results: "🔒 Insira os resultados da fase anterior primeiro",
+    enter_prev_round: "Insira os resultados da rodada anterior para desbloquear",
+    actual_score: "Real: {a}–{b}",
+    // Stats
+    stat_host_cities: "Cidades-Sede",
+    stat_farthest_trip: "Viagem Mais Longa",
+    stat_total_goals: "Total de Gols",
+    stat_goals_per_game: "Gols/Jogo",
+    perf_by_conf: "Desempenho por Confederação",
+    metric_pts: "PTS",
+    metric_gf: "GF",
+    metric_gd: "SG",
+    metric_total_pts: "Pontos Totais",
+    metric_goals_scored: "Gols Marcados",
+    metric_goal_diff: "Saldo de Gols",
+    all_stages_combined: "Todas as fases combinadas",
+    no_results_yet: "Sem resultados ainda",
+    conf_teams: "seleções",
+    conf_team: "seleção",
+    conf_avg_pts: "méd. {n} pts",
+    top_scoring_nations: "Seleções Mais Artilheiras (Todas as Fases)",
+    enter_scores_rankings: "Insira os placares para ver a classificação",
+    // Historical chart
+    chart_gpg: "Gols / Jogo",
+    chart_goals: "Total de Gols",
+    chart_teams: "Seleções",
+    chart_all_editions: "Todas as Edições",
+    chart_gpg_btn: "GPJ",
+    chart_goals_btn: "Gols",
+    chart_teams_btn: "Seleções",
+    chart_most: "Mais (1954: 5.38)",
+    chart_fewest: "Menos (1990: 2.21)",
+    chart_live: "2026 ao vivo",
+    chart_hist_avg: "Méd. hist.",
+    // Past Champions
+    past_champions: "Campeões Anteriores",
+    col_year: "Ano",
+    col_champion: "Campeão",
+    col_runner_up: "Vice",
+    col_gpg: "GPJ",
+    show_all_editions: "Mostrar todas as {n} edições ↓",
+    // FinishBadge
+    debut: "Estreia",
+    first_appearance: "Primeira participação em 2026 🎉",
+    // Team History
+    team_wc_history: "Histórico das Seleções",
+    sort_best_finish: "Melhor Fase",
+    sort_most_apps: "Mais Copas",
+    sort_alpha: "A–Z",
+    // Fun Facts
+    did_you_know: "Você Sabia? 🤓",
+    // Confederation labels
+    conf_europe: "Europa",
+    conf_s_america: "Am. do Sul",
+    conf_nc_america: "Am. do Norte",
+    conf_africa: "África",
+    conf_asia: "Ásia",
+    conf_oceania: "Oceania",
+    // Splash
+    splash_subtitle: "EUA · Canadá · México",
+    // buildShareText phase labels (for plain-text share)
+    share_group_stage: "FASE DE GRUPOS",
+    share_r32: "RODADA DE 32",
+    share_r16: "OITAVAS DE FINAL",
+    share_qf: "QUARTAS DE FINAL",
+    share_sf: "SEMIFINAIS",
+    share_final: "FINAL",
+    share_header: "⚽ *Copa do Mundo 2026 – Meus Palpites*",
+    share_header_phase: "⚽ *Copa do Mundo 2026 – Meus Palpites: {phase}*",
+    share_total: "*🏆 Total: {total} pts* ({played} jogados · 🎯 {exact} exatos · ✅ {correct} certos · ❌ {wrong} errados)",
+  },
+};
+
+const LangContext = React.createContext(null);
+
+function LangProvider({ children }) {
+  const [lang, setLang] = React.useState(() => {
+    try {
+      const stored = localStorage.getItem('wc2026:lang');
+      if (stored) return stored;
+    } catch(e) {}
+    return navigator.language.startsWith('pt') ? 'pt-BR' : 'en';
+  });
+  const t = (key) => (TRANSLATIONS[lang]?.[key] ?? TRANSLATIONS['en'][key] ?? key);
+  const toggle = () => {
+    const next = lang === 'en' ? 'pt-BR' : 'en';
+    setLang(next);
+    try { localStorage.setItem('wc2026:lang', next); } catch(e) {}
+  };
+  return (
+    <LangContext.Provider value={{ lang, t, toggle }}>
+      {children}
+    </LangContext.Provider>
+  );
+}
+
+function useLang() { return React.useContext(LangContext); }
+
 // ─── Constants ────────────────────────────────────────────────────────────────
 const ACCENT = "#00d084";
 const GOLD   = "#ffd700";
@@ -159,6 +500,7 @@ const ChampionContext = React.createContext(null);
 // Renders team name with WC stars and/or NEW badge inline
 function TeamName({ name, style={} }) {
   const champion = React.useContext(ChampionContext);
+  const { t } = useLang();
   const titles = (WC_TITLES[name] || 0) + (name === champion ? 1 : 0);
   const isNew  = WC_DEBUTANTS.has(name);
   return (
@@ -169,7 +511,7 @@ function TeamName({ name, style={} }) {
           fontSize:10, color:GOLD, letterSpacing:0, flexShrink:0, fontWeight:800,
           display:"inline-flex", alignItems:"center", gap:1, lineHeight:1,
           textShadow:"0 0 4px rgba(255,215,0,0.6)",
-        }} title={`${titles}× World Cup winner`}>
+        }} title={`${titles}${t('wc_winner_title')}`}>
           {titles}<span style={{fontSize:9}}>★</span>
         </span>
       )}
@@ -179,7 +521,7 @@ function TeamName({ name, style={} }) {
           color:"#0a1020", background:ACCENT,
           borderRadius:3, padding:"1px 4px", flexShrink:0,
           lineHeight:"1.4",
-        }}>NEW</span>
+        }}>{t('new_badge')}</span>
       )}
     </span>
   );
@@ -619,25 +961,30 @@ function calcPoints(groupMatches, ko, predictions) {
   return { total, byPhase, exact, correct, wrong, played };
 }
 
-function buildShareText(groupMatches, ko, predictions, pts, phaseKey) {
+function buildShareText(groupMatches, ko, predictions, pts, phaseKey, tFn) {
+  const t = tFn || (k => TRANSLATIONS['en'][k] || k);
   const phaseLabels = {
-    group:'GROUP STAGE', r32:'ROUND OF 32', r16:'ROUND OF 16',
-    qf:'QUARTER-FINALS', sf:'SEMI-FINALS', final:'FINAL',
+    group: t('share_group_stage'),
+    r32:   t('share_r32'),
+    r16:   t('share_r16'),
+    qf:    t('share_qf'),
+    sf:    t('share_sf'),
+    final: t('share_final'),
   };
   const lines = [];
   const single = phaseKey && phaseKey !== 'all';
 
   if (single) {
-    lines.push(`⚽ *World Cup 2026 – My ${phaseLabels[phaseKey]} Guesses*`);
+    lines.push(t('share_header_phase').replace('{phase}', phaseLabels[phaseKey]));
   } else {
-    lines.push('⚽ *World Cup 2026 – My Guesses*');
+    lines.push(t('share_header'));
   }
   lines.push('');
 
-  const teamFlag = t => {
-    if (!t) return '❓';
-    const cc = FLAG[t];
-    if (!cc) return t;
+  const teamFlag = tm => {
+    if (!tm) return '❓';
+    const cc = FLAG[tm];
+    if (!cc) return tm;
     return ccToFlagEmoji(cc);
   };
 
@@ -674,7 +1021,13 @@ function buildShareText(groupMatches, ko, predictions, pts, phaseKey) {
   });
 
   if (!single && pts) {
-    lines.push(`*🏆 Total: ${pts.total} pts* (${pts.played} played · 🎯 ${pts.exact} exact · ✅ ${pts.correct} right · ❌ ${pts.wrong} wrong)`);
+    const totalLine = t('share_total')
+      .replace('{total}', pts.total)
+      .replace('{played}', pts.played)
+      .replace('{exact}', pts.exact)
+      .replace('{correct}', pts.correct)
+      .replace('{wrong}', pts.wrong);
+    lines.push(totalLine);
     lines.push('');
   }
   lines.push('jorgecensi.github.io/worldcup-2026');
@@ -707,11 +1060,12 @@ function computeStandings(teams, matches) {
 // Colour-coded result dots shown after a team's name in the standings.
 const RESULT_DOT_COLORS = { win:ACCENT, loss:RED, draw:GOLD, future:"#4a4f5e" };
 function ResultDots({ results=[] }) {
+  const { t } = useLang();
   if(!results.length) return null;
   return (
     <span style={{display:"inline-flex",alignItems:"center",gap:2,marginLeft:4,flexShrink:0}}>
       {results.map((r,i)=>(
-        <span key={i} title={r==="future"?"Upcoming":r==="win"?"Won":r==="loss"?"Lost":"Draw"}
+        <span key={i} title={r==="future"?t('result_upcoming'):r==="win"?t('result_won'):r==="loss"?t('result_lost'):t('result_draw')}
           style={{width:6,height:6,borderRadius:"50%",background:RESULT_DOT_COLORS[r]||"#4a4f5e",display:"inline-block"}}/>
       ))}
     </span>
@@ -923,6 +1277,7 @@ const SPLASH_CSS = `
 `;
 
 function SplashScreen({ onDone }) {
+  const { t } = useLang();
   const [phase, setPhase] = useState("in"); // in | hold | out
 
   useEffect(() => {
@@ -1027,13 +1382,13 @@ function SplashScreen({ onDone }) {
             animation:"shimmer 2.5s linear 1s infinite",
             marginBottom:6,
           }}>
-            World Cup 2026
+            {t('header_title')}
           </div>
           <div style={{
             animation:"taglineUp 0.5s ease 1.05s both",
             fontSize:11, color:ACCENT, letterSpacing:4, fontWeight:700, textTransform:"uppercase",
           }}>
-            USA · Canada · Mexico
+            {t('splash_subtitle')}
           </div>
         </div>
 
@@ -1187,6 +1542,7 @@ function GuessBadge({ pts }) {
 }
 
 function GuessGroupMatchCard({ match, prediction, onPred, isMobile }) {
+  const { t } = useLang();
   const predH = prediction?.home ?? null;
   const predA = prediction?.away ?? null;
   const actual = match.homeScore !== null && match.awayScore !== null;
@@ -1213,7 +1569,7 @@ function GuessGroupMatchCard({ match, prediction, onPred, isMobile }) {
       </div>
       {actual && hasPred && (
         <div style={{marginTop:5, fontSize:9, color:"#555", textAlign:"center"}}>
-          Actual: {match.homeScore}–{match.awayScore}
+          {t('actual_score').replace('{a}',match.homeScore).replace('{b}',match.awayScore)}
         </div>
       )}
     </div>
@@ -1221,6 +1577,7 @@ function GuessGroupMatchCard({ match, prediction, onPred, isMobile }) {
 }
 
 function GuessKOMatchCard({ match, prediction, onPred, isMobile, matchLabel }) {
+  const { t } = useLang();
   const hasTeams = !!match.teamA && !!match.teamB;
   const predA = prediction?.a ?? null;
   const predB = prediction?.b ?? null;
@@ -1234,7 +1591,7 @@ function GuessKOMatchCard({ match, prediction, onPred, isMobile, matchLabel }) {
       <Flag team={team||null} size={isMobile?21:19} faded={!team}/>
       <span style={{flex:1, fontSize:12, fontWeight:400, color:team?"#ccc":"#444",
         fontStyle:team?"normal":"italic", overflow:"hidden", textOverflow:"ellipsis", whiteSpace:"nowrap"}}>
-        {team ? <TeamName name={team}/> : "TBD"}
+        {team ? <TeamName name={team}/> : t('tbd')}
       </span>
       <Stepper value={val} onChange={v=>onPred(match.id,field,v)} color={PURPLE} disabled={!hasTeams}/>
     </div>
@@ -1252,11 +1609,11 @@ function GuessKOMatchCard({ match, prediction, onPred, isMobile, matchLabel }) {
       {teamRow(match.teamA, predA, "a", true)}
       {teamRow(match.teamB, predB, "b", false)}
       {!hasTeams && (
-        <div style={{marginTop:6, fontSize:9, color:"#555", textAlign:"center"}}>Enter previous round results to unlock</div>
+        <div style={{marginTop:6, fontSize:9, color:"#555", textAlign:"center"}}>{t('enter_prev_round')}</div>
       )}
       {actual && hasPred && hasTeams && (
         <div style={{marginTop:5, fontSize:9, color:"#555", textAlign:"center"}}>
-          Actual: {match.scoreA}–{match.scoreB}
+          {t('actual_score').replace('{a}',match.scoreA).replace('{b}',match.scoreB)}
         </div>
       )}
     </div>
@@ -1264,13 +1621,14 @@ function GuessKOMatchCard({ match, prediction, onPred, isMobile, matchLabel }) {
 }
 
 function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isMobile }) {
+  const { t } = useLang();
   const PHASES = [
-    { key:'group', label:'Group Stage',    matches:Object.values(groupMatches).flat().sort((a,b)=>a.group.localeCompare(b.group)||(a.dk||0)-(b.dk||0)||(a.tk||0)-(b.tk||0)) },
-    { key:'r32',   label:'Round of 32',   matches:ko.r32 },
-    { key:'r16',   label:'Round of 16',   matches:ko.r16 },
-    { key:'qf',    label:'Quarter-finals', matches:ko.qf },
-    { key:'sf',    label:'Semi-finals',    matches:ko.sf },
-    { key:'final', label:'Final',          matches:[...ko.third,...ko.final] },
+    { key:'group', label:t('phase_group'),    matches:Object.values(groupMatches).flat().sort((a,b)=>a.group.localeCompare(b.group)||(a.dk||0)-(b.dk||0)||(a.tk||0)-(b.tk||0)) },
+    { key:'r32',   label:t('phase_r32'),   matches:ko.r32 },
+    { key:'r16',   label:t('phase_r16'),   matches:ko.r16 },
+    { key:'qf',    label:t('phase_qf'), matches:ko.qf },
+    { key:'sf',    label:t('phase_sf'),    matches:ko.sf },
+    { key:'final', label:t('phase_final'),          matches:[...ko.third,...ko.final] },
   ];
 
   const isUnlocked = key => {
@@ -1300,23 +1658,23 @@ function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isM
       <div style={{background:CARD, border:`1px solid rgba(167,139,250,0.3)`, borderRadius:14, padding:"14px 16px", marginBottom:14}}>
         <div style={{display:"flex", alignItems:"center", justifyContent:"space-between", flexWrap:"wrap", gap:8}}>
           <div>
-            <div style={{fontSize:9, color:PURPLE, letterSpacing:2, fontWeight:700, textTransform:"uppercase", marginBottom:4}}>🎯 Fantasy</div>
+            <div style={{fontSize:9, color:PURPLE, letterSpacing:2, fontWeight:700, textTransform:"uppercase", marginBottom:4}}>{t('fantasy_label')}</div>
             <div style={{fontSize:22, fontWeight:900, color:"#fff"}}>
-              {pts.total} <span style={{fontSize:13, color:"#666", fontWeight:400}}>pts</span>
+              {pts.total} <span style={{fontSize:13, color:"#666", fontWeight:400}}>{t('pts_label')}</span>
             </div>
             {pts.played > 0 && (
               <div style={{fontSize:10, color:"#666", marginTop:2}}>
-                {pts.played} played · 🎯 {pts.exact} exact · ✅ {pts.correct} right · ❌ {pts.wrong} wrong
+                {t('pts_played_summary').replace('{played}',pts.played).replace('{exact}',pts.exact).replace('{correct}',pts.correct).replace('{wrong}',pts.wrong)}
               </div>
             )}
           </div>
           <button
-            onClick={()=>copyText(buildShareText(groupMatches,ko,predictions,pts,null),'all')}
+            onClick={()=>copyText(buildShareText(groupMatches,ko,predictions,pts,null,t),'all')}
             style={{background:`rgba(167,139,250,0.15)`, border:`1px solid rgba(167,139,250,0.4)`,
               color:PURPLE, borderRadius:10, padding:"8px 14px", fontSize:12, fontWeight:700,
               cursor:"pointer", display:"flex", alignItems:"center", gap:6}}
           >
-            {copied==='all' ? '✓ Copied!' : '📋 Share All'}
+            {copied==='all' ? t('copied') : t('share_all')}
           </button>
         </div>
       </div>
@@ -1346,22 +1704,22 @@ function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isM
         <div>
           <div style={{fontSize:12, fontWeight:700, color:"#ccc"}}>{currentPhase?.label}</div>
           {pts.byPhase[phase] > 0 && (
-            <div style={{fontSize:10, color:PURPLE, marginTop:2}}>{pts.byPhase[phase]} pts earned this phase</div>
+            <div style={{fontSize:10, color:PURPLE, marginTop:2}}>{t('pts_earned').replace('{pts}',pts.byPhase[phase])}</div>
           )}
         </div>
         <button
-          onClick={()=>copyText(buildShareText(groupMatches,ko,predictions,pts,phase),'phase')}
+          onClick={()=>copyText(buildShareText(groupMatches,ko,predictions,pts,phase,t),'phase')}
           style={{background:"transparent", border:`1px solid rgba(167,139,250,0.3)`,
             color:"#888", borderRadius:8, padding:"5px 10px", fontSize:10, fontWeight:700, cursor:"pointer"}}
         >
-          {copied==='phase' ? '✓ Copied!' : '📋 Share Phase'}
+          {copied==='phase' ? t('copied') : t('share_phase')}
         </button>
       </div>
 
       {/* Match list */}
       {!isUnlocked(phase) ? (
         <div style={{textAlign:"center", padding:"32px 0", color:"#555", fontSize:13}}>
-          🔒 Enter results for the previous round first
+          {t('locked_enter_results')}
         </div>
       ) : (
         <div style={{display:"flex", flexDirection:"column", gap:8}}>
@@ -1374,7 +1732,7 @@ function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isM
           ) : (
             currentPhase.matches.map(m => {
               const label = phase === 'final'
-                ? (m.id === 'third' ? '🥉 3rd Place' : '🏆 Final')
+                ? (m.id === 'third' ? t('match_label_third') : t('match_label_final'))
                 : undefined;
               return (
                 <GuessKOMatchCard key={m.id} match={m}
@@ -1391,6 +1749,7 @@ function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isM
 }
 
 function App(){
+  const { t, lang, toggle } = useLang();
   const [splash,setSplash]=useState(true);
   const [groupMatches,setGroupMatches]=useState(buildInitialGroupMatches);
   const [ko,setKo]=useState(buildInitialKO);
@@ -1459,11 +1818,11 @@ function App(){
   const totalEntered=Object.values(groupMatches).flat().filter(m=>m.homeScore!==null).length;
 
   const NAV=[
-    {v:"guesses",   Icon:IconGuesses,   label:"Fantasy"},
-    {v:"fixtures",  Icon:IconFixtures,  label:"Fixtures"},
-    {v:"standings", Icon:IconStandings, label:"Standings"},
-    {v:"knockout",  Icon:IconKnockout,  label:"Knockout"},
-    {v:"stats",     Icon:IconStats,     label:"Stats"},
+    {v:"guesses",   Icon:IconGuesses,   label:t('nav_fantasy')},
+    {v:"fixtures",  Icon:IconFixtures,  label:t('nav_fixtures')},
+    {v:"standings", Icon:IconStandings, label:t('nav_standings')},
+    {v:"knockout",  Icon:IconKnockout,  label:t('nav_knockout')},
+    {v:"stats",     Icon:IconStats,     label:t('nav_stats')},
   ];
 
   const currentNav = NAV.find(n=>n.v===view)||NAV[0];
@@ -1485,8 +1844,8 @@ function App(){
               style={{width:isMobile?28:42,height:"auto",display:"block",filter:"drop-shadow(0 0 6px rgba(0,208,132,0.3))"}}
             />
             <div>
-              <div style={{fontSize:isMobile?13:15,fontWeight:900,letterSpacing:isMobile?1:2,textTransform:"uppercase",color:"#fff",lineHeight:1.15}}>World Cup 2026</div>
-              <div style={{fontSize:isMobile?9:8,color:ACCENT,letterSpacing:isMobile?1:2,fontWeight:700}}>USA · CANADA · MEXICO</div>
+              <div style={{fontSize:isMobile?13:15,fontWeight:900,letterSpacing:isMobile?1:2,textTransform:"uppercase",color:"#fff",lineHeight:1.15}}>{t('header_title')}</div>
+              <div style={{fontSize:isMobile?9:8,color:ACCENT,letterSpacing:isMobile?1:2,fontWeight:700}}>{t('header_subtitle')}</div>
             </div>
           </div>
 
@@ -1521,9 +1880,19 @@ function App(){
               </div>
             )}
 
+            {/* Language toggle */}
+            <button onClick={toggle} title={lang==='en'?"Switch to Portuguese":"Mudar para Inglês"} style={{
+              background:"transparent",border:"none",cursor:"pointer",
+              fontSize:isMobile?18:20,lineHeight:1,padding:"2px 4px",flexShrink:0,
+              borderRadius:6,transition:"background 0.15s",fontFamily:EMOJI_FONT,
+            }}
+            onMouseEnter={e=>e.currentTarget.style.background="rgba(255,255,255,0.1)"}
+            onMouseLeave={e=>e.currentTarget.style.background="transparent"}
+            >{lang==='en'?'🇦🇺':'🇧🇷'}</button>
+
             {/* Mobile score badge */}
             {isMobile&&totalEntered>0&&(
-              <div style={{background:`${ACCENT}22`,border:`1px solid ${ACCENT}55`,borderRadius:20,padding:"3px 9px",fontSize:12,color:ACCENT,fontWeight:700,flexShrink:0}}>{totalEntered} scored</div>
+              <div style={{background:`${ACCENT}22`,border:`1px solid ${ACCENT}55`,borderRadius:20,padding:"3px 9px",fontSize:12,color:ACCENT,fontWeight:700,flexShrink:0}}>{t('scored_badge').replace('{n}',totalEntered)}</div>
             )}
           </div>
         </div>
@@ -1618,6 +1987,7 @@ function FixedFilterBar({isMobile,navHeight,marginTop,children}){
 // ─── FIXTURES VIEW ─────────────────────────────────────────────────────────────
 // All 72 group matches sorted chronologically, grouped by date
 function FixturesView({groupMatches,onScore,isMobile,navHeight,initialFilter,onFilterUsed}){
+  const { t } = useLang();
   const [filter,setFilter]=useState(initialFilter||"ALL");
   const dateRefs=useRef({});
   const containerRef=useRef(null);
@@ -1670,7 +2040,7 @@ function FixturesView({groupMatches,onScore,isMobile,navHeight,initialFilter,onF
   return(
     <div ref={containerRef} style={{paddingBottom:isMobile?130:0}}>
       <div style={{display:"flex",alignItems:"center",justifyContent:"flex-end",marginBottom:14,flexWrap:"wrap",gap:8}}>
-        <span style={{fontSize:10,color:"#555"}}>{scored}/72 played</span>
+        <span style={{fontSize:10,color:"#555"}}>{t('played_count').replace('{n}',scored)}</span>
       </div>
 
       {/* Date sections */}
@@ -1693,10 +2063,10 @@ function FixturesView({groupMatches,onScore,isMobile,navHeight,initialFilter,onF
                   fontSize:8,fontWeight:800,letterSpacing:1,
                   color:"#0a1020",background:ACCENT,
                   borderRadius:4,padding:"2px 6px",flexShrink:0,
-                }}>NOW</span>
+                }}>{t('now_badge')}</span>
               )}
               <div style={{flex:1,height:1,background:isToday?`${ACCENT}44`:BORDER}}/>
-              <div style={{fontSize:9,color:"#555"}}>{dayMatches.length} match{dayMatches.length!==1?"es":""}</div>
+              <div style={{fontSize:9,color:"#555"}}>{dayMatches.length===1?t('match_count').replace('{n}',1):t('matches_count').replace('{n}',dayMatches.length)}</div>
             </div>
             {/* Matches grid: 1 col mobile, 2 col desktop */}
             <div style={{display:"grid",gridTemplateColumns:isMobile?"1fr":"1fr 1fr",gap:8}}>
@@ -1714,14 +2084,13 @@ function FixturesView({groupMatches,onScore,isMobile,navHeight,initialFilter,onF
           value={filter}
           onChange={setFilter}
           options={[
-            {value:"ALL",label:`⚽ All Groups (${scored} played)`},
+            {value:"ALL",label:t('all_groups_option').replace('{n}',scored)},
             ...Object.keys(GROUPS).map(g=>{
               const count=groupMatches[g].filter(m=>m.homeScore!==null).length;
               return {value:g,label:(
                 <span style={{display:"inline-flex",alignItems:"center",gap:5,width:"100%"}}>
-                  <span style={{display:"inline-flex",gap:1}}>{GROUPS[g].map(t=><Flag key={t} team={t} size={13}/>)}</span>
-                  <span>Group {g}</span>
-                  <span style={{marginLeft:"auto",opacity:0.45,fontSize:11}}>({count} played)</span>
+                  <span style={{display:"inline-flex",gap:1}}>{GROUPS[g].map(team=><Flag key={team} team={team} size={13}/>)}</span>
+                  <span>{t('group_option').replace('{g}',g).replace('{n}',count)}</span>
                 </span>
               )};
             }),
@@ -1734,6 +2103,7 @@ function FixturesView({groupMatches,onScore,isMobile,navHeight,initialFilter,onF
 
 // ─── STANDINGS VIEW ────────────────────────────────────────────────────────────
 function StandingsView({groupMatches,isMobile,onShowFixtures}){
+  const { t } = useLang();
   const thirdPlaces=Object.entries(GROUPS).map(([g,teams])=>{
     const s=computeStandings(teams,groupMatches[g]);
     return {...s[2],group:g};
@@ -1752,11 +2122,11 @@ function StandingsView({groupMatches,isMobile,onShowFixtures}){
                 <div style={{display:"flex",flexDirection:"column",gap:4}}>
                   <span style={{fontSize:15,fontWeight:900,color:GOLD,letterSpacing:1}}>GROUP {g}</span>
                   <div style={{display:"flex",gap:3,flexWrap:"wrap"}}>
-                    {teams.map(t=><Flag key={t} team={t} size={16} />)}
+                    {teams.map(tm=><Flag key={tm} team={tm} size={16} />)}
                   </div>
                 </div>
                 <div style={{display:"flex",alignItems:"center",gap:6}}>
-                  <span style={{fontSize:11,color:"#555",background:"rgba(255,255,255,0.05)",borderRadius:10,padding:"2px 7px"}}>{played}/6 played</span>
+                  <span style={{fontSize:11,color:"#555",background:"rgba(255,255,255,0.05)",borderRadius:10,padding:"2px 7px"}}>{t('group_played_count').replace('{n}',played)}</span>
                   <button
                     onClick={()=>onShowFixtures(g)}
                     style={{
@@ -1770,15 +2140,15 @@ function StandingsView({groupMatches,isMobile,onShowFixtures}){
                       WebkitTapHighlightColor:"transparent",
                     }}
                   >
-                    Fixtures <span style={{fontSize:12}}>→</span>
+                    {t('fixtures_button')}
                   </button>
                 </div>
               </div>
               {/* Compact table header */}
               <div style={{display:"grid",gridTemplateColumns:"24px 1fr 36px 36px",gap:2,padding:"7px 12px",fontSize:10,color:"#555",letterSpacing:1,fontWeight:700,textTransform:"uppercase"}}>
-                <span>#</span><span>Team</span>
-                <span style={{textAlign:"center"}}>GD</span>
-                <span style={{textAlign:"center"}}>PTS</span>
+                <span>#</span><span>{t('col_team')}</span>
+                <span style={{textAlign:"center"}}>{t('col_gd')}</span>
+                <span style={{textAlign:"center"}}>{t('col_pts')}</span>
               </div>
               {standings.map((row,i)=>(
                 <div key={row.team} style={{display:"grid",gridTemplateColumns:"24px 1fr 36px 36px",gap:2,padding:"10px 12px",borderTop:`1px solid rgba(255,255,255,0.04)`,background:i<2?"rgba(0,208,132,0.04)":"transparent",alignItems:"center"}}>
@@ -1797,10 +2167,10 @@ function StandingsView({groupMatches,isMobile,onShowFixtures}){
               <div style={{padding:"6px 12px",borderTop:`1px solid rgba(255,255,255,0.05)`,display:"flex",alignItems:"center",justifyContent:"space-between",gap:8,fontSize:11,color:"#444",flexWrap:"wrap"}}>
                 <span style={{display:"flex",alignItems:"center",gap:5}}>
                   <span style={{width:7,height:7,borderRadius:2,background:ACCENT,display:"inline-block",flexShrink:0}}/>
-                  Top 2 advance
+                  {t('top2_advance')}
                 </span>
                 <span style={{display:"flex",alignItems:"center",gap:8}}>
-                  {[["win","Won"],["draw","Draw"],["loss","Lost"],["future","Next"]].map(([k,lbl])=>(
+                  {[["win",t('legend_won')],["draw",t('legend_draw')],["loss",t('legend_lost')],["future",t('legend_next')]].map(([k,lbl])=>(
                     <span key={k} style={{display:"inline-flex",alignItems:"center",gap:3}}>
                       <span style={{width:6,height:6,borderRadius:"50%",background:RESULT_DOT_COLORS[k],display:"inline-block"}}/>{lbl}
                     </span>
@@ -1815,19 +2185,19 @@ function StandingsView({groupMatches,isMobile,onShowFixtures}){
       {/* ── 3rd Place Race ── */}
       <div style={{background:CARD,border:`1px solid ${BORDER}`,borderRadius:14,overflow:"hidden"}}>
         <div style={{padding:"10px 14px",background:"rgba(0,0,0,0.3)",borderBottom:`1px solid ${BORDER}`,display:"flex",alignItems:"baseline",gap:8}}>
-          <span style={{fontSize:15,fontWeight:900,color:PURPLE,letterSpacing:1}}>3RD PLACE RACE</span>
-          <span style={{fontSize:11,color:"#555"}}>Best 8 of 12 advance</span>
+          <span style={{fontSize:15,fontWeight:900,color:PURPLE,letterSpacing:1}}>{t('third_race_title')}</span>
+          <span style={{fontSize:11,color:"#555"}}>{t('best8_advance')}</span>
         </div>
         <div style={{display:"grid",gridTemplateColumns:"24px 1fr 44px 36px 36px",gap:2,padding:"7px 12px",fontSize:10,color:"#555",letterSpacing:1,fontWeight:700,textTransform:"uppercase"}}>
-          <span>#</span><span>Team</span><span style={{textAlign:"center"}}>GRP</span>
-          <span style={{textAlign:"center"}}>GD</span>
-          <span style={{textAlign:"center"}}>PTS</span>
+          <span>#</span><span>{t('col_team')}</span><span style={{textAlign:"center"}}>{t('col_grp')}</span>
+          <span style={{textAlign:"center"}}>{t('col_gd')}</span>
+          <span style={{textAlign:"center"}}>{t('col_pts')}</span>
         </div>
         {thirdPlaces.map((row,i)=>(
           <React.Fragment key={row.team}>
             {i===8&&(
               <div style={{padding:"3px 12px",background:`${RED}14`,borderTop:`1px solid ${RED}33`,borderBottom:`1px solid ${RED}33`,fontSize:9,color:RED,fontWeight:700,letterSpacing:1,textTransform:"uppercase",textAlign:"center"}}>
-                · · · Eliminated below · · ·
+                {t('eliminated_below')}
               </div>
             )}
             <div style={{display:"grid",gridTemplateColumns:"24px 1fr 44px 36px 36px",gap:2,padding:"10px 12px",borderTop:i===8?"none":`1px solid rgba(255,255,255,0.04)`,background:i<8?`${PURPLE}12`:"transparent",alignItems:"center"}}>
@@ -1847,7 +2217,7 @@ function StandingsView({groupMatches,isMobile,onShowFixtures}){
         ))}
         <div style={{padding:"6px 12px",borderTop:`1px solid rgba(255,255,255,0.05)`,display:"flex",alignItems:"center",gap:5,fontSize:11,color:"#444"}}>
           <span style={{width:7,height:7,borderRadius:2,background:PURPLE,display:"inline-block",flexShrink:0}}/>
-          Top 8 advance · sorted by Pts → GD → GF
+          {t('top8_advance_sorted')}
         </div>
       </div>
 
@@ -1857,14 +2227,15 @@ function StandingsView({groupMatches,isMobile,onShowFixtures}){
 
 // ─── KNOCKOUT VIEW ─────────────────────────────────────────────────────────────
 function KnockoutView({ko,onScore,isMobile,navHeight}){
+  const { t } = useLang();
   const [round,setRound]=useState("r32");
   const ROUNDS=[
-    {key:"r32",label:"R32",fullLabel:"⚽ Round of 32"},
-    {key:"r16",label:"R16",fullLabel:"⚡ Round of 16"},
-    {key:"qf",label:"QF",fullLabel:"🥊 Quarter-Finals"},
-    {key:"sf",label:"SF",fullLabel:"🔥 Semi-Finals"},
-    {key:"third",label:"3rd",fullLabel:"🥉 Third Place"},
-    {key:"final",label:"🏆 Final",fullLabel:"🏆 The Final"},
+    {key:"r32",label:"R32",fullLabel:t('round_r32')},
+    {key:"r16",label:"R16",fullLabel:t('round_r16')},
+    {key:"qf",label:"QF",fullLabel:t('round_qf')},
+    {key:"sf",label:"SF",fullLabel:t('round_sf')},
+    {key:"third",label:t('finish_3rd'),fullLabel:t('round_third')},
+    {key:"final",label:"🏆 Final",fullLabel:t('round_final')},
   ];
   const matches=ko[round];
   const currentRound=ROUNDS.find(r=>r.key===round);
@@ -1905,7 +2276,7 @@ function KnockoutView({ko,onScore,isMobile,navHeight}){
       <SLabel>{currentRound?.fullLabel}</SLabel>      {round==="final"&&ko.final[0].teamA&&(
         <div style={{textAlign:"center",marginBottom:16}}>
           <div style={{fontSize:30}}>🏆</div>
-          <div style={{fontSize:12,color:GOLD,fontWeight:700,letterSpacing:2,textTransform:"uppercase"}}>The World Cup Final</div>
+          <div style={{fontSize:12,color:GOLD,fontWeight:700,letterSpacing:2,textTransform:"uppercase"}}>{t('the_wc_final')}</div>
           {koWinner(ko.final[0])&&<div style={{marginTop:8,fontSize:isMobile?17:21,fontWeight:900,color:GOLD,display:"flex",alignItems:"center",justifyContent:"center",gap:6}}><Flag team={koWinner(ko.final[0])} size={isMobile?17:21} /> <TeamName name={koWinner(ko.final[0])} style={{color:GOLD}}/> 🎉</div>}
         </div>
       )}
@@ -1923,10 +2294,10 @@ function KnockoutView({ko,onScore,isMobile,navHeight}){
             <div style={{display:"flex",alignItems:"center",gap:10,marginBottom:10}}>
               <div style={{fontSize:11,fontWeight:800,letterSpacing:1,color:"#fff"}}>{date}</div>
               {isToday&&(
-                <span style={{fontSize:8,fontWeight:800,letterSpacing:1,color:"#0a1020",background:ACCENT,borderRadius:4,padding:"2px 6px",flexShrink:0}}>NOW</span>
+                <span style={{fontSize:8,fontWeight:800,letterSpacing:1,color:"#0a1020",background:ACCENT,borderRadius:4,padding:"2px 6px",flexShrink:0}}>{t('now_badge')}</span>
               )}
               <div style={{flex:1,height:1,background:isToday?`${ACCENT}44`:BORDER}}/>
-              <div style={{fontSize:9,color:"#555"}}>{dayMatches.length} match{dayMatches.length!==1?"es":""}</div>
+              <div style={{fontSize:9,color:"#555"}}>{dayMatches.length===1?t('match_count').replace('{n}',1):t('matches_count').replace('{n}',dayMatches.length)}</div>
             </div>
             <div style={{display:"grid",gridTemplateColumns:isMobile?"1fr":"1fr 1fr",gap:9}}>
               {dayMatches.map(m=>{
@@ -1955,6 +2326,7 @@ function KnockoutView({ko,onScore,isMobile,navHeight}){
 
 // ─── KO MATCH CARD ─────────────────────────────────────────────────────────────
 function KOMatchCard({match,matchIdx,round,onScore,isMobile}){
+  const { t } = useLang();
   const winner=koWinner(match);
   const draw=match.scoreA!==null&&match.scoreB!==null&&+match.scoreA===+match.scoreB;
   const penWinner=draw&&match.penA!==null&&match.penB!==null
@@ -1966,7 +2338,7 @@ function KOMatchCard({match,matchIdx,round,onScore,isMobile}){
       <div style={{display:"flex",alignItems:"center",gap:8,padding:"9px 0"}}>
         <div style={{display:"flex",alignItems:"center",gap:6,flex:1,minWidth:0}}>
           <Flag team={has?team:null} size={isMobile?21:19} faded={!has} />
-          <span style={{fontSize:12,fontWeight:isWinner?800:400,color:isWinner?"#fff":has?"#aaa":"#444",fontStyle:has?"normal":"italic",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{has?<TeamName name={team}/>:"TBD"}</span>
+          <span style={{fontSize:12,fontWeight:isWinner?800:400,color:isWinner?"#fff":has?"#aaa":"#444",fontStyle:has?"normal":"italic",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{has?<TeamName name={team}/>:t('tbd')}</span>
         </div>
         <div style={{display:"flex",alignItems:"center",gap:5,flexShrink:0}}>
           <Stepper value={score} onChange={v=>onScore(round,matchIdx,scoreField,v)} highlight={isWinner&&!draw} disabled={!has}/>
@@ -1995,7 +2367,7 @@ function KOMatchCard({match,matchIdx,round,onScore,isMobile}){
           background:"linear-gradient(135deg, rgba(167,139,250,0.12), rgba(167,139,250,0.03))",
           border:"1px solid rgba(167,139,250,0.4)",
           animation:`penStripIn 0.4s cubic-bezier(0.22,1,0.36,1) both${penWinner?"":", penGlow 2.2s ease-in-out infinite 0.4s"}`}}>
-          <div style={{textAlign:"center",fontSize:9,letterSpacing:2.5,fontWeight:800,color:PURPLE,textTransform:"uppercase",marginBottom:8}}>🥅 Penalty Shootout</div>
+          <div style={{textAlign:"center",fontSize:9,letterSpacing:2.5,fontWeight:800,color:PURPLE,textTransform:"uppercase",marginBottom:8}}>{t('penalty_shootout')}</div>
           <div style={{display:"flex",alignItems:"flex-start",justifyContent:"center",gap:14}}>
             {penCell(match.teamA,match.penA,"penA",penWinner===match.teamA)}
             <span style={{fontSize:9,color:"#666",fontWeight:800,marginTop:8}}>VS</span>
@@ -2004,8 +2376,8 @@ function KOMatchCard({match,matchIdx,round,onScore,isMobile}){
         </div>
       )}
       <div style={{marginTop:5,display:"flex",gap:5,justifyContent:"center",flexWrap:"wrap"}}>
-        {draw&&penWinner&&<span style={{fontSize:8,color:ACCENT,background:`${ACCENT}18`,border:`1px solid ${ACCENT}44`,borderRadius:20,padding:"2px 7px",fontWeight:700,display:"inline-flex",alignItems:"center",gap:3}}><Flag team={penWinner} size={11} /> <TeamName name={penWinner}/> WIN (PEN)</span>}
-        {!draw&&winner&&<span style={{fontSize:8,color:ACCENT,background:`${ACCENT}18`,border:`1px solid ${ACCENT}44`,borderRadius:20,padding:"2px 7px",fontWeight:700,display:"inline-flex",alignItems:"center",gap:3}}><Flag team={winner} size={11} /> <TeamName name={winner}/> ADVANCE</span>}
+        {draw&&penWinner&&<span style={{fontSize:8,color:ACCENT,background:`${ACCENT}18`,border:`1px solid ${ACCENT}44`,borderRadius:20,padding:"2px 7px",fontWeight:700,display:"inline-flex",alignItems:"center",gap:3}}><Flag team={penWinner} size={11} /> <TeamName name={penWinner}/> {t('win_pen')}</span>}
+        {!draw&&winner&&<span style={{fontSize:8,color:ACCENT,background:`${ACCENT}18`,border:`1px solid ${ACCENT}44`,borderRadius:20,padding:"2px 7px",fontWeight:700,display:"inline-flex",alignItems:"center",gap:3}}><Flag team={winner} size={11} /> <TeamName name={winner}/> {t('advance')}</span>}
       </div>
     </div>
   );
@@ -2013,6 +2385,7 @@ function KOMatchCard({match,matchIdx,round,onScore,isMobile}){
 
 // ─── GROUP MATCH CARD ──────────────────────────────────────────────────────────
 function GroupMatchCard({match,onScore,isMobile}){
+  const { t } = useLang();
   const played=match.homeScore!==null&&match.awayScore!==null;
   const hw=played&&match.homeScore>match.awayScore;
   const aw=played&&match.awayScore>match.homeScore;
@@ -2028,7 +2401,7 @@ function GroupMatchCard({match,onScore,isMobile}){
       <div style={{display:"flex",alignItems:"center",gap:7,paddingBottom:5,borderBottom:`1px solid ${BORDER}`}}>
         <Flag team={match.home} size={isMobile?21:19} />
         <span style={{flex:1,fontSize:12,fontWeight:hw?800:500,color:hw?"#fff":"#aaa",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>
-          {hw ? <><TeamName name={match.home}/><span style={{fontSize:7,color:ACCENT,marginLeft:5,letterSpacing:1}}>WIN ✓</span></> : <TeamName name={match.home}/>}
+          {hw ? <><TeamName name={match.home}/><span style={{fontSize:7,color:ACCENT,marginLeft:5,letterSpacing:1}}>{t('win_badge')}</span></> : <TeamName name={match.home}/>}
         </span>
         <Stepper value={match.homeScore} onChange={v=>onScore("homeScore",v)} highlight={hw}/>
       </div>
@@ -2036,11 +2409,11 @@ function GroupMatchCard({match,onScore,isMobile}){
       <div style={{display:"flex",alignItems:"center",gap:7,paddingTop:5}}>
         <Flag team={match.away} size={isMobile?21:19} />
         <span style={{flex:1,fontSize:12,fontWeight:aw?800:500,color:aw?"#fff":"#aaa",overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>
-          {aw ? <><TeamName name={match.away}/><span style={{fontSize:7,color:ACCENT,marginLeft:5,letterSpacing:1}}>WIN ✓</span></> : <TeamName name={match.away}/>}
+          {aw ? <><TeamName name={match.away}/><span style={{fontSize:7,color:ACCENT,marginLeft:5,letterSpacing:1}}>{t('win_badge')}</span></> : <TeamName name={match.away}/>}
         </span>
         <Stepper value={match.awayScore} onChange={v=>onScore("awayScore",v)} highlight={aw}/>
       </div>
-      {draw&&<div style={{textAlign:"center",fontSize:8,color:"#666",letterSpacing:1,marginTop:5}}>DRAW</div>}
+      {draw&&<div style={{textAlign:"center",fontSize:8,color:"#666",letterSpacing:1,marginTop:5}}>{t('draw_badge')}</div>}
     </div>
   );
 }
@@ -2163,6 +2536,7 @@ const TEAM_WC_HISTORY = {
 };
 
 function ConfederationChart({groupMatches, ko, isMobile}) {
+  const { t } = useLang();
   const data = useMemo(()=>{
     // Build per-team stats across group + KO
     const teamStats = {};
@@ -2224,16 +2598,17 @@ function ConfederationChart({groupMatches, ko, isMobile}) {
   const metricFn = d => metric==="pts" ? d.totalPts : metric==="gf" ? d.totalGF : d.totalGD;
   const maxVal = Math.max(...data.map(d=>Math.abs(metricFn(d))||0), 1);
 
-  const metricLabel = metric==="pts"?"Total Points":metric==="gf"?"Goals Scored":"Goal Diff";
+  const metricLabel = metric==="pts"?t('metric_total_pts'):metric==="gf"?t('metric_goals_scored'):t('metric_goal_diff');
+  const confLabelMap = {UEFA:t('conf_europe'),CONMEBOL:t('conf_s_america'),CONCACAF:t('conf_nc_america'),CAF:t('conf_africa'),AFC:t('conf_asia'),OFC:t('conf_oceania')};
 
   return(
     <div style={{background:CARD,border:`1px solid ${BORDER}`,borderRadius:12,padding:"14px 14px",marginBottom:13}}>
       {/* Header */}
       <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",marginBottom:12,flexWrap:"wrap",gap:8}}>
-        <div style={{fontSize:8,color:"#555",letterSpacing:2,textTransform:"uppercase",fontWeight:700}}>Performance by Confederation</div>
+        <div style={{fontSize:8,color:"#555",letterSpacing:2,textTransform:"uppercase",fontWeight:700}}>{t('perf_by_conf')}</div>
         {/* Metric toggle */}
         <div style={{display:"flex",gap:3}}>
-          {[["pts","PTS"],["gf","GF"],["gd","GD"]].map(([v,label])=>(
+          {[["pts",t('metric_pts')],["gf",t('metric_gf')],["gd",t('metric_gd')]].map(([v,label])=>(
             <button key={v} onClick={()=>setMetric(v)} style={{
               padding:"3px 8px",borderRadius:5,fontSize:8,fontWeight:700,letterSpacing:0.8,
               border:`1px solid ${metric===v?GOLD:BORDER}`,
@@ -2257,18 +2632,18 @@ function ConfederationChart({groupMatches, ko, isMobile}) {
               <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",marginBottom:4}}>
                 <div style={{display:"flex",alignItems:"center",gap:6,flexWrap:"wrap"}}>
                   <span style={{width:7,height:7,borderRadius:2,background:conf.color,display:"inline-block",flexShrink:0}}/>
-                  <span style={{fontSize:10,fontWeight:700,color:"#ccc"}}>{conf.label}</span>
+                  <span style={{fontSize:10,fontWeight:700,color:"#ccc"}}>{confLabelMap[conf.key]||conf.label}</span>
                   <span style={{fontSize:8,fontWeight:800,letterSpacing:0.5,color:conf.color,background:`${conf.color}1a`,border:`1px solid ${conf.color}40`,borderRadius:4,padding:"1px 4px"}}>{conf.name}</span>
-                  <span style={{fontSize:9,color:"#444"}}>({conf.teamCount} {conf.teamCount===1?"team":"teams"})</span>
+                  <span style={{fontSize:9,color:"#444"}}>({conf.teamCount} {conf.teamCount===1?t('conf_team'):t('conf_teams')})</span>
                   {/* Always-visible team flags so every confederation shows its countries */}
                   <span style={{display:"flex",alignItems:"center",gap:2,flexWrap:"wrap"}}>
-                    {conf.teams.slice(0,isMobile?6:12).map(t=>(
-                      <Flag key={t} team={t} size={11} />
+                    {conf.teams.slice(0,isMobile?6:12).map(tm=>(
+                      <Flag key={tm} team={tm} size={11} />
                     ))}
                   </span>
                 </div>
                 <div style={{display:"flex",alignItems:"center",gap:10}}>
-                  {!noData&&<span style={{fontSize:9,color:"#555"}}>{conf.teamCount>0?`avg ${conf.avgPts} pts`:""}</span>}
+                  {!noData&&<span style={{fontSize:9,color:"#555"}}>{conf.teamCount>0?t('conf_avg_pts').replace('{n}',conf.avgPts):""}</span>}
                   <span style={{fontSize:11,fontWeight:900,color:noData?"#333":isNeg?RED:conf.color,minWidth:24,textAlign:"right"}}>
                     {noData?"—":val>0?`+${val}`:val}
                   </span>
@@ -2290,30 +2665,42 @@ function ConfederationChart({groupMatches, ko, isMobile}) {
                     paddingRight:isNeg?0:5,paddingLeft:isNeg?5:0,
                   }}/>
                 )}
-                {noData&&<div style={{position:"absolute",inset:0,display:"flex",alignItems:"center",paddingLeft:8,fontSize:9,color:"#333"}}>No results yet</div>}
+                {noData&&<div style={{position:"absolute",inset:0,display:"flex",alignItems:"center",paddingLeft:8,fontSize:9,color:"#333"}}>{t('no_results_yet')}</div>}
               </div>
             </div>
           );
         })}
       </div>
 
-      <div style={{marginTop:10,fontSize:8,color:"#444",textAlign:"right"}}>{metricLabel} · All stages combined</div>
+      <div style={{marginTop:10,fontSize:8,color:"#444",textAlign:"right"}}>{metricLabel} · {t('all_stages_combined')}</div>
     </div>
   );
 }
 
 // Curated trivia about the 2026 tournament — the kind of thing you'd drop at a watch party
-const FUN_FACTS = [
-  {emoji:"🌎", text:"First-ever World Cup hosted by three countries at once — and Mexico becomes the first nation to host it three times."},
-  {emoji:"🦌", text:"Say hello to the mascots: Maple the Moose (Canada), Zayu the Jaguar (Mexico) and Clutch the Bald Eagle (USA)."},
-  {emoji:"✈️", text:"Vancouver's BC Place and Mexico City's Estadio Azteca sit ~4,400 km apart — the longest hop between venues in World Cup history."},
-  {emoji:"🏝️", text:"Curaçao, population ~150,000, is the smallest nation ever to qualify for a men's World Cup."},
-  {emoji:"🧤", text:"Mexico's Guillermo Ochoa is the first goalkeeper ever named to six World Cup squads."},
-  {emoji:"🐶", text:"In 1966 the World Cup trophy was stolen in London — and found a week later, wrapped in newspaper, by a dog named Pickles."},
-  {emoji:"📅", text:"104 matches over 39 days: the biggest, longest World Cup ever — 40 more games than Qatar 2022."},
-];
+const FUN_FACTS = {
+  en: [
+    {emoji:"🌎", text:"First-ever World Cup hosted by three countries at once — and Mexico becomes the first nation to host it three times."},
+    {emoji:"🦌", text:"Say hello to the mascots: Maple the Moose (Canada), Zayu the Jaguar (Mexico) and Clutch the Bald Eagle (USA)."},
+    {emoji:"✈️", text:"Vancouver's BC Place and Mexico City's Estadio Azteca sit ~4,400 km apart — the longest hop between venues in World Cup history."},
+    {emoji:"🏝️", text:"Curaçao, population ~150,000, is the smallest nation ever to qualify for a men's World Cup."},
+    {emoji:"🧤", text:"Mexico's Guillermo Ochoa is the first goalkeeper ever named to six World Cup squads."},
+    {emoji:"🐶", text:"In 1966 the World Cup trophy was stolen in London — and found a week later, wrapped in newspaper, by a dog named Pickles."},
+    {emoji:"📅", text:"104 matches over 39 days: the biggest, longest World Cup ever — 40 more games than Qatar 2022."},
+  ],
+  'pt-BR': [
+    {emoji:"🌎", text:"Primeira Copa do Mundo sediada por três países ao mesmo tempo — e o México se torna a primeira nação a sediar o torneio três vezes."},
+    {emoji:"🦌", text:"Conheça os mascotes: Maple, o Alce (Canadá), Zayu, o Jaguar (México) e Clutch, a Águia Careca (EUA)."},
+    {emoji:"✈️", text:"O BC Place de Vancouver e o Estádio Azteca, na Cidade do México, ficam a ~4.400 km um do outro — a maior distância entre sedes na história da Copa."},
+    {emoji:"🏝️", text:"Curaçao, com ~150.000 habitantes, é a menor nação já classificada para uma Copa do Mundo masculina."},
+    {emoji:"🧤", text:"Guillermo Ochoa, do México, é o primeiro goleiro convocado para seis Copas do Mundo."},
+    {emoji:"🐶", text:"Em 1966, a taça da Copa foi roubada em Londres — e encontrada uma semana depois, embrulhada em jornal, por um cachorro chamado Pickles."},
+    {emoji:"📅", text:"104 jogos em 39 dias: a maior e mais longa Copa da história — 40 jogos a mais do que a Copa do Qatar 2022."},
+  ],
+};
 
 function HistoricalGoalsChart({stats}) {
+  const { t } = useLang();
   const [metric, setMetric] = useState("gpg");
 
   const currentGpg = stats.totalPlayed > 0 ? stats.totalGoals / stats.totalPlayed : null;
@@ -2334,10 +2721,10 @@ function HistoricalGoalsChart({stats}) {
     <div style={{background:CARD, border:`1px solid ${BORDER}`, borderRadius:12, padding:"14px 14px", marginBottom:13}}>
       <div style={{display:"flex", alignItems:"center", justifyContent:"space-between", marginBottom:10, gap:6, flexWrap:"wrap"}}>
         <div style={{fontSize:8, color:"#555", letterSpacing:2, textTransform:"uppercase", fontWeight:700}}>
-          {metric==="gpg"?"Goals / Game":metric==="goals"?"Total Goals":"Teams"} · All Editions
+          {metric==="gpg"?t('chart_gpg'):metric==="goals"?t('chart_goals'):t('chart_teams')} · {t('chart_all_editions')}
         </div>
         <div style={{display:"flex", gap:3}}>
-          {[["gpg","GPG"],["goals","Goals"],["teams","Teams"]].map(([v,l])=>(
+          {[["gpg",t('chart_gpg_btn')],["goals",t('chart_goals_btn')],["teams",t('chart_teams_btn')]].map(([v,l])=>(
             <button key={v} onClick={()=>setMetric(v)} style={{
               padding:"3px 8px", borderRadius:5, fontSize:8, fontWeight:700, letterSpacing:0.8,
               border:`1px solid ${metric===v?ACCENT:BORDER}`,
@@ -2406,16 +2793,17 @@ function HistoricalGoalsChart({stats}) {
       </div>
 
       <div style={{display:"flex", gap:10, fontSize:8, color:"#444", flexWrap:"wrap", marginTop:6}}>
-        <span><span style={{color:GOLD}}>■</span> Most (1954: 5.38)</span>
-        <span><span style={{color:RED}}>■</span> Fewest (1990: 2.21)</span>
-        <span><span style={{color:ACCENT}}>■</span> 2026 live</span>
-        {metric==="gpg" && <span><span style={{color:GOLD, opacity:0.5}}>╌</span> Hist. avg {avgGpg.toFixed(2)}</span>}
+        <span><span style={{color:GOLD}}>■</span> {t('chart_most')}</span>
+        <span><span style={{color:RED}}>■</span> {t('chart_fewest')}</span>
+        <span><span style={{color:ACCENT}}>■</span> {t('chart_live')}</span>
+        {metric==="gpg" && <span><span style={{color:GOLD, opacity:0.5}}>╌</span> {t('chart_hist_avg')} {avgGpg.toFixed(2)}</span>}
       </div>
     </div>
   );
 }
 
 function PastChampions({isMobile}) {
+  const { t } = useLang();
   const [showAll, setShowAll] = useState(false);
   const reversed = useMemo(()=>[...HISTORICAL_WC].reverse(), []);
   const displayed = showAll ? reversed : reversed.slice(0, 8);
@@ -2429,10 +2817,10 @@ function PastChampions({isMobile}) {
   return (
     <div style={{background:CARD, border:`1px solid ${BORDER}`, borderRadius:12, padding:"12px 14px", marginBottom:13}}>
       <div style={{fontSize:8, color:"#555", letterSpacing:2, textTransform:"uppercase", marginBottom:10, fontWeight:700}}>
-        Past Champions
+        {t('past_champions')}
       </div>
       <div style={{display:"grid", gridTemplateColumns:"34px 1fr 1fr 34px", gap:6, paddingBottom:6, borderBottom:`1px solid ${BORDER}`, marginBottom:4}}>
-        {["Year","Champion","Runner-up","GPG"].map(h=>(
+        {[t('col_year'),t('col_champion'),t('col_runner_up'),t('col_gpg')].map(h=>(
           <div key={h} style={{fontSize:8, color:"#444", fontWeight:700, letterSpacing:0.5}}>{h}</div>
         ))}
       </div>
@@ -2467,14 +2855,16 @@ function PastChampions({isMobile}) {
           marginTop:8, width:"100%", padding:"6px 0", fontSize:9, color:"#555",
           background:"transparent", border:`1px solid ${BORDER}`, borderRadius:6,
           cursor:"pointer", letterSpacing:0.5,
-        }}>Show all {HISTORICAL_WC.length} editions ↓</button>
+        }}>{t('show_all_editions').replace('{n}',HISTORICAL_WC.length)}</button>
       )}
     </div>
   );
 }
 
+const FINISH_I18N_KEY = {W:'finish_champion',F:'finish_runner_up','3':'finish_3rd','4':'finish_4th',QF:'finish_qf',R16:'finish_r16',GS:'finish_gs'};
 function FinishBadge({finish, size=9}) {
-  if (!finish) return <span style={{fontSize:size,color:"#555",fontStyle:"italic"}}>Debut</span>;
+  const { t } = useLang();
+  if (!finish) return <span style={{fontSize:size,color:"#555",fontStyle:"italic"}}>{t('debut')}</span>;
   const color = FINISH_COLOR_MAP[finish] || "#555";
   const icon = finish==="W"?"🏆 ":finish==="F"?"🥈 ":finish==="3"?"🥉 ":"";
   return (
@@ -2483,12 +2873,13 @@ function FinishBadge({finish, size=9}) {
       background:`${color}22`, border:`1px solid ${color}44`,
       borderRadius:4, padding:"1px 5px", whiteSpace:"nowrap",
     }}>
-      {icon}{FINISH_LABEL_MAP[finish]||finish}
+      {icon}{FINISH_I18N_KEY[finish]?t(FINISH_I18N_KEY[finish]):(FINISH_LABEL_MAP[finish]||finish)}
     </span>
   );
 }
 
 function TeamHistoryRow({team, history, expanded, onToggle}) {
+  const { t } = useLang();
   const finishes = Object.values(history);
   const bestFinish = finishes.length > 0
     ? finishes.reduce((b,f)=>(FINISH_RANK[f]||99)<(FINISH_RANK[b]||99)?f:b, finishes[0])
@@ -2523,7 +2914,7 @@ function TeamHistoryRow({team, history, expanded, onToggle}) {
       {expanded && (
         <div style={{padding:"8px 4px 10px 20px", display:"flex", flexWrap:"wrap", gap:5, borderBottom:`1px solid rgba(255,255,255,0.04)`}}>
           {years.length===0 ? (
-            <span style={{fontSize:9, color:"#555", fontStyle:"italic"}}>First appearance in 2026 🎉</span>
+            <span style={{fontSize:9, color:"#555", fontStyle:"italic"}}>{t('first_appearance')}</span>
           ) : years.map(year=>{
             const f = history[year];
             const col = FINISH_COLOR_MAP[f]||"#333";
@@ -2535,7 +2926,7 @@ function TeamHistoryRow({team, history, expanded, onToggle}) {
                 borderRadius:5, padding:"4px 7px", minWidth:46,
               }}>
                 <span style={{fontSize:8, color:"#666", fontWeight:600}}>{year}</span>
-                <span style={{fontSize:9, fontWeight:800, color:col}}>{icon||FINISH_LABEL_MAP[f]||f}</span>
+                <span style={{fontSize:9, fontWeight:800, color:col}}>{icon||(FINISH_I18N_KEY[f]?t(FINISH_I18N_KEY[f]):(FINISH_LABEL_MAP[f]||f))}</span>
               </div>
             );
           })}
@@ -2546,6 +2937,7 @@ function TeamHistoryRow({team, history, expanded, onToggle}) {
 }
 
 function TeamHistorySection({isMobile}) {
+  const { t } = useLang();
   const [expanded, setExpanded] = useState(null);
   const [sortBy, setSortBy] = useState("best");
 
@@ -2572,10 +2964,10 @@ function TeamHistorySection({isMobile}) {
     <div style={{background:CARD, border:`1px solid ${BORDER}`, borderRadius:12, padding:"12px 14px", marginBottom:13}}>
       <div style={{display:"flex", alignItems:"center", justifyContent:"space-between", marginBottom:10, gap:6, flexWrap:"wrap"}}>
         <div style={{fontSize:8, color:"#555", letterSpacing:2, textTransform:"uppercase", fontWeight:700}}>
-          Team WC History
+          {t('team_wc_history')}
         </div>
         <div style={{display:"flex", gap:3}}>
-          {[["best","Best Finish"],["apps","Most Apps"],["alpha","A–Z"]].map(([v,l])=>(
+          {[["best",t('sort_best_finish')],["apps",t('sort_most_apps')],["alpha",t('sort_alpha')]].map(([v,l])=>(
             <button key={v} onClick={()=>setSortBy(v)} style={{
               padding:"3px 8px", borderRadius:5, fontSize:8, fontWeight:700, letterSpacing:0.8,
               border:`1px solid ${sortBy===v?ACCENT:BORDER}`,
@@ -2601,11 +2993,13 @@ function TeamHistorySection({isMobile}) {
 }
 
 function FunFacts({isMobile}){
+  const { t, lang } = useLang();
+  const facts = FUN_FACTS[lang] || FUN_FACTS['en'];
   return(
     <div style={{background:CARD,border:`1px solid ${BORDER}`,borderRadius:12,padding:"12px 14px"}}>
-      <div style={{fontSize:8,color:"#555",letterSpacing:2,textTransform:"uppercase",marginBottom:10,fontWeight:700}}>Did You Know? 🤓</div>
+      <div style={{fontSize:8,color:"#555",letterSpacing:2,textTransform:"uppercase",marginBottom:10,fontWeight:700}}>{t('did_you_know')}</div>
       <div style={{display:"flex",flexDirection:"column",gap:9}}>
-        {FUN_FACTS.map((f,i)=>(
+        {facts.map((f,i)=>(
           <div key={i} style={{display:"flex",gap:8,alignItems:"flex-start"}}>
             <span style={{fontSize:14,flexShrink:0,lineHeight:1.5}}>{f.emoji}</span>
             <span style={{fontSize:10.5,color:"#aaa",lineHeight:1.5}}>{f.text}</span>
@@ -2617,14 +3011,15 @@ function FunFacts({isMobile}){
 }
 
 function GlobalStats({stats,groupMatches,ko,isMobile}){
+  const { t } = useLang();
   return(
     <div>
       <div style={{display:"grid",gridTemplateColumns:isMobile?"1fr 1fr":"repeat(4,1fr)",gap:10,marginBottom:16}}>
         {[
-          {label:"Host Cities",value:"16",icon:"🏙️",color:ACCENT},
-          {label:"Farthest Trip",value:"4,400 km",icon:"✈️",color:PURPLE},
-          {label:"Total Goals",value:stats.totalGoals,icon:"⚽",color:GOLD},
-          {label:"Goals/Game",value:stats.avgGoals,icon:"📈",color:RED},
+          {label:t('stat_host_cities'),value:"16",icon:"🏙️",color:ACCENT},
+          {label:t('stat_farthest_trip'),value:"4,400 km",icon:"✈️",color:PURPLE},
+          {label:t('stat_total_goals'),value:stats.totalGoals,icon:"⚽",color:GOLD},
+          {label:t('stat_goals_per_game'),value:stats.avgGoals,icon:"📈",color:RED},
         ].map(k=>(
           <div key={k.label} style={{background:CARD,border:`1px solid ${BORDER}`,borderRadius:12,padding:"13px 10px",textAlign:"center"}}>
             <div style={{fontSize:20,marginBottom:3}}>{k.icon}</div>
@@ -2637,9 +3032,9 @@ function GlobalStats({stats,groupMatches,ko,isMobile}){
       <div style={{display:"grid",gridTemplateColumns:isMobile?"1fr":"1fr 1fr",gap:12,marginBottom:13}}>
         <FunFacts isMobile={isMobile}/>
         <div style={{background:CARD,border:`1px solid ${BORDER}`,borderRadius:12,padding:"12px 14px"}}>
-          <div style={{fontSize:8,color:"#555",letterSpacing:2,textTransform:"uppercase",marginBottom:10,fontWeight:700}}>Top Scoring Nations (All Stages)</div>
+          <div style={{fontSize:8,color:"#555",letterSpacing:2,textTransform:"uppercase",marginBottom:10,fontWeight:700}}>{t('top_scoring_nations')}</div>
           {stats.topScorers.length===0
-            ?<div style={{color:"#444",fontSize:12,textAlign:"center",paddingTop:12}}>Enter scores to see rankings</div>
+            ?<div style={{color:"#444",fontSize:12,textAlign:"center",paddingTop:12}}>{t('enter_scores_rankings')}</div>
             :stats.topScorers.map(([team,goals],i)=>(
               <div key={team} style={{display:"flex",alignItems:"center",gap:7,marginBottom:7}}>
                 <span style={{width:14,fontSize:9,color:i===0?GOLD:"#555",fontWeight:700}}>{i+1}</span>
@@ -2659,7 +3054,7 @@ function GlobalStats({stats,groupMatches,ko,isMobile}){
 }
 
   const root = ReactDOM.createRoot(document.getElementById('root'));
-  root.render(React.createElement(App));
+  root.render(React.createElement(LangProvider, null, React.createElement(App)));
   </script>
   <script>
     if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary

- Adds a full `TRANSLATIONS` object (~100 string keys) with `en` and `pt-BR` entries covering every user-facing string in the app
- Auto-detects device language via `navigator.language` on first visit — Brazilian users see pt-BR by default
- Saves the user's language preference to `localStorage` (`wc2026:lang`)
- Adds a 🇦🇺 / 🇧🇷 flag toggle button in the header to manually switch languages

## What's translated

- Nav labels: Fantasy → Bolão, Fixtures → Jogos, Standings → Classificação, Knockout → Mata-mata, Stats → Estatísticas
- Round/phase labels: Group Stage, Round of 32/16, Quarter-finals, Semi-finals, Final, Third Place
- Standings column headers, KO bracket labels, match badges (WIN, DRAW, NOW, scored)
- Stats section headers and confederation names
- Fantasy/Bolão tab scoring labels and share text
- Past Champions table headers and Team History section
- Fun Facts — full Portuguese translations
- Header title: World Cup 2026 → Copa do Mundo 2026 (in pt-BR)
- Template strings like "Show all {n} editions" use `.replace('{n}', value)` pattern

## Test plan

- [ ] Visit the app — English-locale device shows English by default, `pt-BR` locale shows Portuguese
- [ ] Click the 🇦🇺 flag → switches to Portuguese (🇧🇷 appears), preference saved to localStorage
- [ ] Click the 🇧🇷 flag → switches back to English (🇦🇺 appears)
- [ ] Refresh page — language preference is remembered
- [ ] All 5 tabs (Fantasy, Fixtures, Standings, Knockout, Stats) display correctly in both languages
- [ ] No broken strings (fallback to `en` key if `pt-BR` key is missing)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnDK1uUDXZmLampoye8PLA)_