### PR TITLE
World Cup app: use jorgecensi.com for share links

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -1158,14 +1158,14 @@ function buildShareText(groupMatches, ko, predictions, pts, phaseKey, tFn) {
     lines.push(totalLine);
     lines.push('');
   }
-  lines.push('jorgecensi.github.io/worldcup-2026');
+  lines.push('jorgecensi.com/worldcup-2026');
   return lines.join('\n');
 }
 
 // ─── Proximity / Rival sharing ────────────────────────────────────────────────
 const RIVALS_KEY  = "wc2026:rivals:v1";
 const PLAYER_KEY  = "wc2026:player:v1";
-const SHARE_BASE  = "https://jorgecensi.github.io/worldcup-2026/";
+const SHARE_BASE  = "https://jorgecensi.com/worldcup-2026/";
 
 function loadRivals() {
   try { const r = localStorage.getItem(RIVALS_KEY); return r ? JSON.parse(r) : []; }


### PR DESCRIPTION
## Summary
- Replace `jorgecensi.github.io` with `jorgecensi.com` in the World Cup 2026 app's share text and share/transfer URL base, since `jorgecensi.com` is the main site (CNAME already configured).

## Test plan
- [ ] Open the app, generate a share text and verify it now shows `jorgecensi.com/worldcup-2026`
- [ ] Generate a rival/transfer share link and verify it points to `https://jorgecensi.com/worldcup-2026/?...`


---
_Generated by [Claude Code](https://claude.ai/code/session_016nA1LLSkkU8rwWTe6BYRFP)_