### PR TITLE
Allow late starters to use Fantasy without group-stage guesses

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -1138,6 +1138,13 @@ function isPhaseUnlocked(key, ko) {
   return koPhaseBucket(key, ko).some(m => !!m.teamA || !!m.teamB);
 }
 
+// True once every group-stage match has a real result. Lets people who join
+// after the group stage already happened skip those (now-moot) guesses and
+// jump straight into the fantasy leaderboard from the knockout rounds onward.
+function isGroupStageComplete(groupMatches) {
+  return Object.values(groupMatches).flat().every(m => m.homeScore !== null && m.awayScore !== null);
+}
+
 // True once every guess for a single phase (group, or an unlocked KO round) is filled in.
 // Each phase is judged independently, so a completed phase stays shareable even
 // while a later phase is still being filled in.
@@ -2526,8 +2533,9 @@ function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isM
   const [phase, setPhase] = useState('group');
   const pts = useMemo(()=>calcPoints(groupMatches,ko,predictions),[groupMatches,ko,predictions]);
   // Group stage being complete unlocks "Copy All" / proximity sharing for good —
-  // a later phase still in progress doesn't re-lock it.
-  const canShare = useMemo(()=>isPhaseGuessesComplete('group',groupMatches,ko,predictions),[groupMatches,ko,predictions]);
+  // a later phase still in progress doesn't re-lock it. Late joiners who missed
+  // the (now-moot) group stage in real life don't need to back-fill those guesses.
+  const canShare = useMemo(()=>isPhaseGuessesComplete('group',groupMatches,ko,predictions) || isGroupStageComplete(groupMatches),[groupMatches,ko,predictions]);
   const canSharePhase = useMemo(()=>isPhaseGuessesComplete(phase,groupMatches,ko,predictions),[phase,groupMatches,ko,predictions]);
   const [copied, setCopied] = useState(null); // null | 'all' | 'phase'
 


### PR DESCRIPTION
## Summary
- Previously, the Fantasy leaderboard, rival sharing/comparison, and "Copy All" were locked behind filling in predictions for **all** group-stage matches.
- This was a problem for people who start using the app after the World Cup group phase has already finished in real life — they'd have to retroactively fill in 30+ guesses for matches that already happened just to unlock the social features.
- Now, those features unlock if **either** the user has filled in all their group-stage guesses, **or** the real-life group stage is already complete (every group match has a final score). Late joiners can skip straight to predicting knockout rounds and competing on the leaderboard.

## Test plan
- [x] Verified `worldcup-2026/index.html` still transpiles cleanly with Babel (`@babel/preset-react`).
- [ ] Manually verify in-browser: with group stage incomplete + predictions incomplete, leaderboard stays locked; with group stage complete in real life + no predictions, leaderboard/sharing unlock.

https://claude.ai/code/session_015zXNNUdLndaegxGdFeGWtW

---
_Generated by [Claude Code](https://claude.ai/code/session_015zXNNUdLndaegxGdFeGWtW)_