### PR TITLE
World Cup PWA: pad header for Dynamic Island safe area

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -3191,7 +3191,7 @@ function App(){
       )}
 
       {/* HEADER */}
-      <div style={{background:"linear-gradient(90deg,#0a1020,#162035,#0a1020)",borderBottom:`2px solid ${ACCENT}`,position:"sticky",top:0,zIndex:100,boxShadow:`0 4px 24px rgba(0,208,132,0.18)`,overflow:"hidden"}}>
+      <div style={{background:"linear-gradient(90deg,#0a1020,#162035,#0a1020)",borderBottom:`2px solid ${ACCENT}`,position:"sticky",top:0,zIndex:100,boxShadow:`0 4px 24px rgba(0,208,132,0.18)`,overflow:"hidden",paddingTop:"env(safe-area-inset-top, 0px)"}}>
         <div style={{maxWidth:1040,margin:"0 auto",padding:isMobile?"0 12px":"0 24px",height:isMobile?56:62,display:"flex",alignItems:"center",justifyContent:"space-between",gap:10}}>
 
           {/* LEFT: emblem + wordmark */}

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026061012';
+const CACHE_VERSION = '2026061013';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = ['/worldcup-2026/','/worldcup-2026/manifest.json','/worldcup-2026/icons/icon.svg'];


### PR DESCRIPTION
## Summary
- Fixes a regression from #161: enabling `viewport-fit=cover` lets the page draw under the iPhone status bar/Dynamic Island, which pushed the sticky app header underneath it.
- Adds `env(safe-area-inset-top)` as top padding on the header so its content sits below the Dynamic Island/notch while the background still extends to the top edge.
- Bumps the service worker cache version so installed PWAs pick up the fix.

## Test plan
- [ ] Reload the installed World Cup PWA on an iPhone with Dynamic Island/notch and confirm the header logo/title are no longer hidden behind it
- [ ] Verify header still looks correct on non-notched phones and desktop


---
_Generated by [Claude Code](https://claude.ai/code/session_01CsKNnNqvK5PZghURKH6HQa)_