### PR TITLE
Catch up on kick-off notifications when the app regains focus

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -2849,9 +2849,12 @@ async function showKickoffNotification(match,t){
 }
 
 // Polls the upcoming-matches list while notifications are enabled and fires a
-// kick-off notification the moment a match's kick-off time is reached.
+// kick-off notification once a match's kick-off time is reached. Also
+// re-checks whenever the app regains visibility/focus, so a kick-off that
+// happened while the phone was locked or the app was backgrounded still
+// surfaces a notification as soon as the user comes back.
 const NOTIF_CHECK_MS=30000;
-const NOTIF_WINDOW_MS=2*60*1000; // grace window so a missed tick doesn't skip a kick-off
+const NOTIF_CATCHUP_MS=3*60*60*1000; // how late a kick-off can still trigger a notification
 function useGameNotifications(matches,enabled,t){
   const matchesRef=useRef(matches);
   matchesRef.current=matches;
@@ -2867,19 +2870,28 @@ function useGameNotifications(matches,enabled,t){
       const state=loadNotifState();
       let changed=false;
       matchesRef.current.forEach(m=>{
+        if(state.notified[m.id]) return;
         const ts=m.kickoff.getTime();
-        if(now>=ts && now-ts<NOTIF_WINDOW_MS && !state.notified[m.id]){
-          state.notified[m.id]=true;
-          changed=true;
-          showKickoffNotification(m,tRef.current);
-        }
+        if(now<ts) return;
+        if(now-ts<NOTIF_CATCHUP_MS) showKickoffNotification(m,tRef.current);
+        state.notified[m.id]=true;
+        changed=true;
       });
       if(changed) saveNotifState(state);
     };
 
     check();
     const interval=setInterval(check,NOTIF_CHECK_MS);
-    return ()=>clearInterval(interval);
+    const onVisible=()=>{ if(document.visibilityState==='visible') check(); };
+    document.addEventListener('visibilitychange',onVisible);
+    window.addEventListener('focus',check);
+    window.addEventListener('pageshow',check);
+    return ()=>{
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange',onVisible);
+      window.removeEventListener('focus',check);
+      window.removeEventListener('pageshow',check);
+    };
   },[enabled,matches]);
 }
 

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026061013';
+const CACHE_VERSION = '2026061100';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = ['/worldcup-2026/','/worldcup-2026/manifest.json','/worldcup-2026/icons/icon.svg'];


### PR DESCRIPTION
## Summary

Follow-up to #155. On iPhone, an installed PWA is suspended by iOS as soon as it's locked or backgrounded — so the 30-second in-page poll that watches for kick-offs simply stops running, and the user never gets notified.

## Fix

`useGameNotifications` now:
- Re-runs its check whenever the app regains visibility/focus (`visibilitychange`, `focus`, `pageshow`) — covering "unlock the phone and come back to the app".
- Treats any not-yet-notified match whose kick-off was up to **3 hours** ago as still notifiable (`NOTIF_CATCHUP_MS`), so a kick-off missed while locked/backgrounded still fires a "⚽ Kick-off!" notification once the user returns.
- Marks matches older than that window as notified without showing a (stale) notification, so they don't get re-checked forever.

Also bumps the service worker `CACHE_VERSION` so the update reaches installed PWAs.

## Test plan
- [x] Syntax-checked the modified hook with `node --check`
- [ ] Manual check on iPhone: enable notifications, lock the phone before kick-off, unlock after kick-off and confirm the rich notification appears

https://claude.ai/code/session_016DUdaxECk3gBiYe3SmZK2x

---
_Generated by [Claude Code](https://claude.ai/code/session_016DUdaxECk3gBiYe3SmZK2x)_