### PR TITLE
worldcup: fix NOW indicator getting stuck a day behind

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -730,6 +730,14 @@ function matchToUTC(date, time) {
   if (ap === "AM" && h === 12) h = 0;
   return new Date(Date.UTC(2026, month, day, h - 10, m));
 }
+// dateKey()/dk values are derived from the AEST-labeled date strings above, so
+// "today" must be expressed in that same AEST reference frame (UTC+10) to stay
+// comparable — otherwise sections keep being flagged as "now" for up to a day
+// after every match in them has already kicked off.
+function todayDk() {
+  const aest = new Date(Date.now() + 10 * 60 * 60 * 1000);
+  return (aest.getUTCMonth() + 1) * 100 + aest.getUTCDate();
+}
 
 // [homeIdx, awayIdx, date, time, city]
 const GROUP_SCHEDULE = {
@@ -3406,12 +3414,11 @@ function FixturesView({groupMatches,onScore,isMobile,navHeight,initialFilter,onF
 
   const scored=Object.values(groupMatches).flat().filter(m=>m.homeScore!==null).length;
 
-  // Find the date section closest to today (local device time)
+  // Find the date section closest to today
   const closestDate=useMemo(()=>{
     if(byDate.length===0) return null;
-    const now=new Date();
-    const todayDk=(now.getMonth()+1)*100+now.getDate();
-    const future=byDate.filter(d=>d.dk>=todayDk);
+    const dk=todayDk();
+    const future=byDate.filter(d=>d.dk>=dk);
     return future.length>0 ? future[0].date : byDate[byDate.length-1].date;
   },[byDate]);
 
@@ -3641,12 +3648,11 @@ function KnockoutView({ko,onScore,isMobile,navHeight}){
     return Object.values(map).sort((a,b)=>a.dk-b.dk);
   },[matches]);
 
-  // Find the date section closest to today (local device time)
+  // Find the date section closest to today
   const closestDate=useMemo(()=>{
     if(byDate.length===0) return null;
-    const now=new Date();
-    const todayDk=(now.getMonth()+1)*100+now.getDate();
-    const future=byDate.filter(d=>d.dk>0&&d.dk>=todayDk);
+    const dk=todayDk();
+    const future=byDate.filter(d=>d.dk>0&&d.dk>=dk);
     return future.length>0 ? future[0].date : byDate[byDate.length-1].date;
   },[byDate]);
 


### PR DESCRIPTION
## Summary
- Yes, it was a UTC/timezone issue. The schedule's date strings (e.g. "Fri 12 Jun") are AEST-labeled dates (per `matchToUTC`, which converts them to UTC by subtracting 10 hours), but the "NOW" badge compared them against `(now.getMonth()+1)*100+now.getDate()` — the **device's local calendar date**, an unrelated reference frame.
- For most timezones (anything behind AEST/UTC+10, i.e. basically the Americas/Europe/Africa), this left the NOW badge pinned on a date section whose matches had already kicked off — and finished — up to a full day earlier.
- Added a shared `todayDk()` helper that shifts "now" into the same AEST reference frame used by `dateKey()`, so the comparison is apples-to-apples. Used it in both `FixturesView` and `KnockoutView`.

## Verification
Simulated `closestDate` over the next 72h using the real schedule data (extracted `dateKey`/`matchToUTC`/`generateGroupMatches`):
- Before: for UTC-3/UTC+0/UTC-5/UTC+1 users, the badge stayed on "Fri 12 Jun" until local date rolled to June 13 — roughly a day after both that day's matches had already finished.
- After: the badge moves to "Sat 13 Jun" ~18h after the tournament start, right around when both "Fri 12 Jun" matches have actually finished, and the result is now timezone-independent.

## Test plan
- [x] Verified the edited script still transforms cleanly via `@babel/standalone` (no syntax errors)
- [ ] Open the Fixtures and Knockout tabs in a browser around a match day boundary to confirm the NOW badge lands on the right date section


---
_Generated by [Claude Code](https://claude.ai/code/session_01RpBA3a7Je2q4bxhtbcrWZN)_