### PR TITLE
Fix Group C matchday 2 game times

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -829,8 +829,8 @@ const GROUP_SCHEDULE = {
   C:[
     [0,1,"Sun 14 Jun","8:00 AM","New York"],
     [2,3,"Sun 14 Jun","11:00 AM","Boston"],
-    [3,1,"Fri 19 Jun","6:00 PM","Boston"],
-    [0,2,"Fri 19 Jun","8:30 PM","Philadelphia"],
+    [3,1,"Sat 20 Jun","8:00 AM","Boston"],
+    [0,2,"Sat 20 Jun","10:30 AM","Philadelphia"],
     [3,0,"Thu 25 Jun","8:00 AM","Miami"],
     [1,2,"Thu 25 Jun","8:00 AM","Atlanta"],
   ],

--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -829,8 +829,8 @@ const GROUP_SCHEDULE = {
   C:[
     [0,1,"Sun 14 Jun","8:00 AM","New York"],
     [2,3,"Sun 14 Jun","11:00 AM","Boston"],
-    [3,1,"Sat 20 Jun","8:00 AM","Boston"],
-    [0,2,"Sat 20 Jun","11:00 AM","Philadelphia"],
+    [3,1,"Fri 19 Jun","6:00 PM","Boston"],
+    [0,2,"Fri 19 Jun","8:30 PM","Philadelphia"],
     [3,0,"Thu 25 Jun","8:00 AM","Miami"],
     [1,2,"Thu 25 Jun","8:00 AM","Atlanta"],
   ],


### PR DESCRIPTION
## Summary

- Scotland vs Morocco (Boston): was showing `Sat 20 Jun 8:00 AM`, corrected to `Fri 19 Jun 6:00 PM ET`
- Brazil vs Haiti (Philadelphia): was showing `Sat 20 Jun 11:00 AM`, corrected to `Fri 19 Jun 8:30 PM ET`

Both Group C matchday 2 games were actually played on Friday June 19, not Saturday June 20.

## Sources
- [Scotland vs Morocco – My World Cup Guide](https://myworldcupguide.com/matches/scotland-vs-morocco-30/)
- [Brazil vs Haiti – ESPN](``https://www.espn.com/soccer/story/_/id/49097937/brazil-haiti-fifa-world-cup-2026-tv-channel-how-watch-kick-live-stream-referee-predicted-line-ups``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRsymcfJtUPwHwSVMy9PAa

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRsymcfJtUPwHwSVMy9PAa)_