### PR TITLE
World Cup: only fetch real scores on refresh button press

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -4009,9 +4009,10 @@ function App(){
     setRefreshing(false);
   },[refreshing,applyAutoScores]);
 
-  // Pull the latest scores once on load so the "last updated" label and scores
-  // reflect the published snapshot without the user having to tap refresh.
-  useEffect(()=>{ handleRefreshScores(); },[]);// eslint-disable-line react-hooks/exhaustive-deps
+  // Real results are only pulled when the user taps the refresh button — we
+  // deliberately do NOT auto-fetch on load. The "last updated" label is seeded
+  // from the cached timestamp (UPDATED_KEY) so it still reflects the last
+  // refresh the user performed.
 
   const champion = React.useMemo(()=>koWinner(ko.final[0]),[ko]);
 


### PR DESCRIPTION
## Summary
Real results in the World Cup 2026 app were being fetched and applied automatically every time the app opened. This changes that so real results only update when the user taps the **Refresh scores** button.

## Change
- Removed the `useEffect(() => { handleRefreshScores(); }, [])` that auto-fetched `scores.json` on load.
- The "Updated {time}" label still works — it seeds from the cached `UPDATED_KEY` timestamp in localStorage, so it reflects the user's most recent manual refresh.
- `handleRefreshScores` is now only triggered by the refresh button in both the Fixtures and Knockout views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3kDV6uj17q7ZjnW2z2YJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3kDV6uj17q7ZjnW2z2YJJ)_