### PR TITLE
fix: show qualified teams in knockout bracket for completed groups

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -2425,6 +2425,15 @@ function getGroupQualifiers(gm) {
     const matches = gm[g] || [];
     const remaining = matches.filter(m => m.homeScore === null || m.awayScore === null);
 
+    // When all group matches are done, standings are final — use actual
+    // tiebreakers (GD, GF) instead of the conservative points-only logic below.
+    if (remaining.length === 0 && matches.length > 0) {
+      const st = computeStandings(teams, matches);
+      if (st[0]) slots[`1${g}`] = st[0].team;
+      if (st[1]) slots[`2${g}`] = st[1].team;
+      return;
+    }
+
     // Points already banked from completed matches.
     const basePts = {};
     teams.forEach(tm => { basePts[tm] = 0; });


### PR DESCRIPTION
## Summary

- `getGroupQualifiers` used a conservative points-only approach: any rival tied on points was treated as potentially finishing above the candidate (since GD/GF could swing in a remaining match). This is correct for incomplete groups, but wrong once all games are done.
- When a group is fully played, actual standings are final — GD and GF tiebreakers have resolved all ties. The fix adds an early-exit path for complete groups that calls `computeStandings` (which already applies GD→GF tiebreakers) to directly return the 1st and 2nd place teams.
- Groups B and C are already complete as of today, so Switzerland/Canada and Brazil/Morocco (or whoever actually placed 1st/2nd) will now correctly appear in the Round of 32 bracket.

## Test plan

- [ ] Open the Knockout tab → Round of 32: teams from completed groups (e.g. Group B, Group C) now show their flags/names instead of "TBD"
- [ ] Standings tab still shows the correct final table for completed groups
- [ ] Partially-played groups still show "TBD" until they're complete (conservative logic still applies)
- [ ] Once all 12 groups finish, all 32 R32 slots should be filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJJfYRm7eHGYTkFPspiv3J

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJJfYRm7eHGYTkFPspiv3J)_