### PR TITLE
Sort knockout matches by time within each date group

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -4672,7 +4672,8 @@ function KnockoutView({ko,onScore,isMobile,navHeight,groupMatches,onRefreshScore
       if(!map[m.date]) map[m.date]={date:m.date,dk:m.dk,matches:[]};
       map[m.date].matches.push(m);
     });
-    return Object.values(map).sort((a,b)=>a.dk-b.dk);
+    return Object.values(map).sort((a,b)=>a.dk-b.dk)
+      .map(g=>({...g,matches:[...g.matches].sort((a,b)=>timeKey(a.time||'0:00 AM')-timeKey(b.time||'0:00 AM'))}));
   },[matches]);
 
   // Find the date section closest to today; skip today if all its games have already kicked off


### PR DESCRIPTION
## Summary

- In the **Knockout tab**, games on the same day now appear sorted by kick-off time (earliest first) instead of bracket-slot order
- For example, on Thu 2 Jul the R32 games were showing 10 AM → 6 AM → 2 AM; they now show 2 AM → 6 AM → 10 AM
- The date groups themselves were already sorted (oldest date first) — this only fixes the ordering *within* each date group
- The **Fantasy tab** had the equivalent fix applied in PR #191

## Test plan

- [ ] Open Knockout tab → R32: on days with multiple games (e.g. Tue 30 Jun, Thu 2 Jul, Fri 3 Jul, Sat 4 Jul), verify games are in ascending time order
- [ ] Check R16, QF — same expectation
- [ ] Verify date group headings and scroll-to-closest-date still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016A8ej1qYaowWwo1pDP1V3m

---
_Generated by [Claude Code](https://claude.ai/code/session_016A8ej1qYaowWwo1pDP1V3m)_