### PR TITLE
Add phase completion badges to rivals leaderboard

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -2218,8 +2218,8 @@ function FirstPlaceCelebration({ name, onDismiss }) {
 function RivalsLeaderboard({ rivals, myName, myPts, groupMatches, ko, canShare, onShare, onRemove, compareRival, onToggleCompare }) {
   const { t } = useLang();
   const allPlayers = [
-    { n: myName || t('you_default'), pts: myPts, isMe: true },
-    ...rivals.map(r => ({ n: r.n, pts: calcRivalPoints(r, groupMatches, ko), isMe: false })),
+    { n: myName || t('you_default'), pts: myPts, isMe: true, rival: null },
+    ...rivals.map(r => ({ n: r.n, pts: calcRivalPoints(r, groupMatches, ko), isMe: false, rival: r })),
   ].sort((a, b) => b.pts.total - a.pts.total);
 
   if (rivals.length === 0) {
@@ -2322,8 +2322,39 @@ function RivalsLeaderboard({ rivals, myName, myPts, groupMatches, ko, canShare, 
           }}>
             {i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : i+1}
           </div>
-          <div style={{ flex:1, fontSize:13, fontWeight:700, color:p.isMe?ACCENT:isComparing?PURPLE:'#ccc', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>
-            {p.n}{p.isMe ? t('you_suffix') : ''}
+          <div style={{ flex:1, overflow:'hidden', minWidth:0 }}>
+            <div style={{ fontSize:13, fontWeight:700, color:p.isMe?ACCENT:isComparing?PURPLE:'#ccc', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>
+              {p.n}{p.isMe ? t('you_suffix') : ''}
+            </div>
+            {!p.isMe && p.rival && (() => {
+              const phases = [
+                { key:'group', label:'G' },
+                { key:'r32',   label:'R32' },
+                { key:'r16',   label:'R16' },
+                { key:'qf',    label:'QF' },
+                { key:'sf',    label:'SF' },
+                { key:'final', label:'F' },
+              ].filter(ph => isPhaseUnlocked(ph.key, ko));
+              if (!phases.length) return null;
+              const preds = p.rival.predictions || { group:{}, ko:{} };
+              return (
+                <div style={{ display:'flex', gap:3, marginTop:2, flexWrap:'wrap' }}>
+                  {phases.map(ph => {
+                    const done = isPhaseGuessesComplete(ph.key, groupMatches, ko, preds);
+                    return (
+                      <span key={ph.key} style={{
+                        fontSize:8, fontWeight:800, padding:'1px 4px', borderRadius:4, letterSpacing:0.3,
+                        background: done ? 'rgba(0,208,132,0.15)' : 'transparent',
+                        border: `1px solid ${done ? 'rgba(0,208,132,0.4)' : 'rgba(255,255,255,0.1)'}`,
+                        color: done ? ACCENT : '#3a3f4e',
+                      }}>
+                        {done ? '✓ ' : ''}{ph.label}
+                      </span>
+                    );
+                  })}
+                </div>
+              );
+            })()}
           </div>
           <div style={{ display:'flex', alignItems:'baseline', gap:3 }}>
             <span style={{ fontSize:16, fontWeight:900, color:'#fff' }}>{p.pts.total}</span>


### PR DESCRIPTION
## Summary

- Each rival row in the leaderboard now shows small pill badges for every unlocked tournament phase (G, R32, R16, QF, SF, F)
- **Green + filled** badge = guesses for that phase are already entered for this rival
- **Gray + outlined** badge = guesses are missing — the user still needs to scan/import that friend's picks for this round
- Locked phases (teams not yet known) are hidden from the badge row entirely, keeping it clean until the round opens

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2SVxu1owLCFwSqwJeMKYz)_