### PR TITLE
Fix mobile bottom nav not sticking to bottom when scrolling

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -4337,8 +4337,9 @@ function App(){
         {view==="guesses"   && <GuessesView   groupMatches={groupMatches} ko={ko} predictions={predictions} onGroupPred={updateGroupPred} onKOPred={updateKOPred} isMobile={isMobile} navHeight={navHeight} rivals={rivals} playerName={playerName} onShare={()=>{setShareModalMode('rival');setShowShareModal(true);}} onRemoveRival={handleRemoveRival} onResolveLink={handleResolvePastedLink}/>}
       </div>
 
-      {/* MOBILE BOTTOM NAV */}
-      {isMobile&&(
+      {/* MOBILE BOTTOM NAV — portaled to <body> so the zoom:1.2 on the MAIN
+           container cannot create a new containing block that breaks position:fixed */}
+      {isMobile&&ReactDOM.createPortal(
         <div ref={navRef} style={{position:"fixed",bottom:0,left:0,right:0,background:"#0a1020",borderTop:`2px solid ${ACCENT}33`,display:"flex",zIndex:200,paddingBottom:"env(safe-area-inset-bottom, 0px)"}}>
           {NAV.map(({v,Icon,label})=>(
             <button key={v} onClick={()=>{setView(v);window.scrollTo({top:0});}} style={{flex:1,padding:"14px 0 12px",border:"none",background:"transparent",cursor:"pointer",display:"flex",flexDirection:"column",alignItems:"center",gap:2}}>
@@ -4347,7 +4348,8 @@ function App(){
               {view===v&&<span style={{width:18,height:2,background:ACCENT,borderRadius:2,marginTop:1}}/>}
             </button>
           ))}
-        </div>
+        </div>,
+        document.body
       )}
     </div>
     </ChampionContext.Provider>


### PR DESCRIPTION
## Summary

- The World Cup app's mobile bottom nav (`position:fixed; bottom:0`) was not staying fixed to the bottom of the screen when scrolling on phones.
- Root cause: the MAIN content container applies `zoom:1.2` on mobile. In WebKit/Blink, CSS `zoom` can create its own containing block for `position:fixed` elements and interfere with fixed positioning across the page layout.
- The `FixedFilterBar` component already works around this exact issue by portaling itself to `<body>` via `ReactDOM.createPortal`. This PR applies the same fix to the mobile bottom nav.

## What changed

`worldcup-2026/index.html` — wrapped the mobile bottom nav in `ReactDOM.createPortal(..., document.body)` so it renders as a direct child of `<body>`, ensuring no ancestor CSS (zoom, overflow, stacking context) can affect its `position:fixed` anchoring to the real viewport.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmKWESZWhVQe2AZc1AJkLC)_