### PR TITLE
Improve leaderboard exact scores and right outcomes visibility

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -2358,11 +2358,11 @@ function RivalsLeaderboard({ rivals, myName, myPts, groupMatches, ko, canShare, 
           </div>
           <div style={{ display:'flex', alignItems:'baseline', gap:3 }}>
             <span style={{ fontSize:16, fontWeight:900, color:'#fff' }}>{p.pts.total}</span>
-            <span style={{ fontSize:9, color:'#555' }}>{t('pts_label')}</span>
+            <span style={{ fontSize:9, color:'#777' }}>{t('pts_label')}</span>
           </div>
           {p.pts.played > 0 && (
-            <div style={{ fontSize:9, color:'#444', flexShrink:0 }}>
-              🎯{p.pts.exact} ✅{p.pts.correct}
+            <div style={{ fontSize:10, color:'#888', flexShrink:0, lineHeight:1.2 }}>
+              🎯<span style={{color:GOLD,fontWeight:800}}>{p.pts.exact}</span>{' '}✅<span style={{color:ACCENT,fontWeight:800}}>{p.pts.correct}</span>
             </div>
           )}
           {!p.isMe && (
@@ -3477,7 +3477,7 @@ function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isM
               {pts.total} <span style={{fontSize:13, color:"#666", fontWeight:400}}>{t('pts_label')}</span>
             </div>
             {pts.played > 0 && (
-              <div style={{fontSize:10, color:"#666", marginTop:2}}>
+              <div style={{fontSize:10, color:"#999", marginTop:2}}>
                 {t('pts_played_summary').replace('{played}',pts.played).replace('{exact}',pts.exact).replace('{correct}',pts.correct).replace('{wrong}',pts.wrong)}
               </div>
             )}


### PR DESCRIPTION
## Summary

- The `🎯 exact` and `✅ correct` counts in leaderboard rows were rendered at `fontSize:9` with `color:#444` — nearly invisible against the dark card background
- Numbers are now color-coded: exact count in gold, correct count in green, both bold at `fontSize:10`
- Lifted the `pts_played_summary` text color from `#666` → `#999` for better readability
- Lifted the `pts` label color in leaderboard rows from `#555` → `#777`

---
_Generated by [Claude Code](https://claude.ai/code/session_01C62X6VRD178P6txmvRjEKD)_