### PR TITLE
fantasy: default to current tournament phase tab on load

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -3353,7 +3353,8 @@ function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isM
 
   const isUnlocked = key => isPhaseUnlocked(key, ko);
 
-  const [phase, setPhase] = useState('group');
+  const defaultPhase = [...PHASES].reverse().find(p => isUnlocked(p.key))?.key ?? 'group';
+  const [phase, setPhase] = useState(defaultPhase);
   const pts = useMemo(()=>calcPoints(groupMatches,ko,predictions),[groupMatches,ko,predictions]);
   // Group stage being complete unlocks "Copy All" / proximity sharing for good —
   // a later phase still in progress doesn't re-lock it. Late joiners who missed


### PR DESCRIPTION
## Summary

- The Guesses (fantasy) view previously always opened on the **Group Stage** tab, regardless of where the tournament actually was.
- Now it computes the default by finding the last phase that `isPhaseUnlocked` returns `true` for, so users land directly on the current active phase (Round of 32 today, and automatically correct as later rounds unlock).
- Only the initial `useState` default is affected — manual tab navigation continues to work exactly as before.

## Change

`worldcup-2026/index.html` — one line added before the `useState` call:

```js
const defaultPhase = [...PHASES].reverse().find(p => isUnlocked(p.key))?.key ?? 'group';
const [phase, setPhase] = useState(defaultPhase);
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01F22ySAuB9Nvnvg59qzCMk4)_