### PR TITLE
Move confederation performance below best defences on stats page

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -6082,7 +6082,6 @@ function GlobalStats({stats,groupMatches,ko,isMobile}){
           </div>
         ))}
       </div>
-      <ConfederationChart groupMatches={groupMatches} ko={ko} isMobile={isMobile}/>
       <div style={{background:CARD,border:`1px solid ${BORDER}`,borderRadius:12,padding:"12px 14px",marginBottom:13}}>
         <div style={{fontSize:11,color:"#555",letterSpacing:2,textTransform:"uppercase",marginBottom:10,fontWeight:700}}>{t('top_scoring_nations')}</div>
         {stats.topScorers.length===0
@@ -6098,6 +6097,7 @@ function GlobalStats({stats,groupMatches,ko,isMobile}){
         }
       </div>
       <BestDefenceLeaderboard groupMatches={groupMatches} ko={ko}/>
+      <ConfederationChart groupMatches={groupMatches} ko={ko} isMobile={isMobile}/>
       <HistoricalGoalsChart stats={stats}/>
       <PastChampions isMobile={isMobile}/>
       <TeamHistorySection isMobile={isMobile}/>


### PR DESCRIPTION
## Summary

- Reorders the stats page sections so that **Confederation Performance** (`ConfederationChart`) appears after **Best Defences** (`BestDefenceLeaderboard`), rather than before it.
- New order: Total Goals / Goals per Game → Top Scoring Nations → Best Defences → Confederation Performance → Historical Goals → Past Champions → Team History → Fun Facts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY4yYtK3pBGk8iD2A4xtxM)_