### PR TITLE
Bump PWA cache version so the new app icon actually loads

### DIFF
--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -89,7 +89,7 @@ permalink: /elastomania/
   </div>
 
   <script>
-    const SW_VERSION = '2607022222';
+    const SW_VERSION = '2607030000';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function showBanner(reg) {

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607022222';
+const CACHE_VERSION = '2607030000';
 const CACHE_NAME = `elastomania-${CACHE_VERSION}`;
 const OFFLINE_URL = '/elastomania/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary

- The app icon PNGs were swapped in #209, but `elastomania/sw.js`'s `CACHE_VERSION` and `elastomania/index.html`'s `SW_VERSION` query string were left unchanged.
- The service worker uses a cache-first fetch strategy and precaches the icon URLs by cache name (`elastomania-${CACHE_VERSION}`). Since neither version string changed, browsers that already had the old service worker/cache installed never detected an update and kept serving the stale icon.
- Bumped both version constants to the same new value so the browser installs a fresh service worker, which purges the old cache and re-fetches the icons from the network.

## Note on already-installed home screens

This fixes it for the web app / browser tab going forward. If the game was already added to a phone's home screen, the OS-level shortcut icon (especially on iOS) is captured at "Add to Home Screen" time and generally does **not** auto-refresh — removing and re-adding the shortcut is the only way to pick up the new icon there.

## Test plan

- [x] Confirmed `CACHE_VERSION` in `sw.js` and `SW_VERSION` in `index.html` now match and differ from the previous value


---
_Generated by [Claude Code](https://claude.ai/code/session_01KiXbpesGGMW27sfjRzZ49v)_