### PR TITLE
Only count the rider's upper body as a crash collision

### DIFF
--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -392,6 +392,21 @@ permalink: /elastomania/
     const RIDER_OFFSET_X = -6;
     const RIDER_OFFSET_Y = -18;
 
+    // Point on the rider's torso/chest, in chassis-local space (before
+    // rotation) — used as the hit-test spot for ground/terrain crashes so
+    // only the upper body counts as a collision, not the wheels, frame, or
+    // legs clipping a bump.
+    const UPPER_BODY_OFFSET = { x: -10, y: -45 };
+
+    function getUpperBodyPos() {
+      const a = chassis.angle;
+      const cos = Math.cos(a), sin = Math.sin(a);
+      return {
+        x: chassis.position.x + UPPER_BODY_OFFSET.x * cos - UPPER_BODY_OFFSET.y * sin,
+        y: chassis.position.y + UPPER_BODY_OFFSET.x * sin + UPPER_BODY_OFFSET.y * cos
+      };
+    }
+
     // ── Physics engine ─────────────────────────────────────────
     const engine = Engine.create();
     engine.gravity.y = 1.8;
@@ -619,9 +634,12 @@ permalink: /elastomania/
     function checkDeath() {
       if (state !== 'playing') return;
 
-      const groundY = getTerrainY(chassis.position.x);
-      if (chassis.position.y + 8 > groundY) { die(); return; }
-      if (chassis.position.y > WORLD_H + 50) { die(); return; }
+      // Only the rider's upper body counts as a crash — the wheels, frame,
+      // and legs can clip a bump or scrape a slope without ending the run.
+      const upperBody = getUpperBodyPos();
+      const groundY = getTerrainY(upperBody.x);
+      if (upperBody.y > groundY) { die(); return; }
+      if (upperBody.y > WORLD_H + 50) { die(); return; }
 
       // Die if chassis is inverted (~135° – 225° from upright)
       const angle = ((chassis.angle % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2);

--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -89,7 +89,7 @@ permalink: /elastomania/
   </div>
 
   <script>
-    const SW_VERSION = '2607030231';
+    const SW_VERSION = '2607030300';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function showBanner(reg) {

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607030231';
+const CACHE_VERSION = '2607030300';
 const CACHE_NAME = `elastomania-${CACHE_VERSION}`;
 const OFFLINE_URL = '/elastomania/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary

- Death was previously triggered by the chassis (frame) point dipping close to the terrain, which could end a run just from the wheels/legs clipping a bump or scraping a steep slope.
- Added `getUpperBodyPos()`, which computes a point on the rider's torso/chest in world space (rotated with the chassis), and switched `checkDeath()` to hit-test against that point instead of the chassis position directly.
- The frame, wheels, and legs can now clip terrain without ending the run — only an actual upper-body-to-ground hit (or a full inversion, unchanged) counts as a crash.
- Bumped the PWA cache version, same as prior gameplay/content changes, so it actually reaches already-installed clients.

## Test plan

- [x] Verified idle stability is unaffected (bike still settles and stays put indefinitely)
- [x] Verified normal driving/jumping across levels still crashes appropriately on real face-plants and full flips, with no console/page errors
- [x] Verified `node --check` on the extracted script block passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01KiXbpesGGMW27sfjRzZ49v)_