### PR TITLE
Add animated points progression modal to Fantasy

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -109,6 +109,19 @@
       70%  { transform: scale(1.25) translateY(-2px); opacity: 1; }
       100% { transform: scale(1) translateY(0); opacity: 1; }
     }
+    @keyframes ppExactRing {
+      0%   { r: 5; opacity: 0.9; stroke-width: 2.5; }
+      100% { r: 15; opacity: 0; stroke-width: 0.5; }
+    }
+    @keyframes ppExactBadge {
+      0%   { transform: scale(0) translateY(4px); opacity: 0; }
+      55%  { transform: scale(1.3) translateY(-3px); opacity: 1; }
+      100% { transform: scale(1) translateY(0); opacity: 1; }
+    }
+    @keyframes ppExactStrip {
+      0%   { opacity: 0; transform: translateY(-4px); }
+      100% { opacity: 1; transform: translateY(0); }
+    }
   </style>
 </head>
 <body>
@@ -323,6 +336,8 @@ const TRANSLATIONS = {
     progress_empty_desc: "Once results start coming in, watch the leaderboard race unfold here.",
     progress_replay: "↻ Replay",
     progress_match_count: "Match {i} of {n}",
+    progress_exact_one: "🎯 {names} nailed the exact score!",
+    progress_exact_many: "🎯 {names} all nailed the exact score!",
     first_place_kicker: "Top of the leaderboard",
     first_place_title: "YOU'RE #1!",
     first_place_subtitle: "{name} leads the bolão 🏆",
@@ -604,6 +619,8 @@ const TRANSLATIONS = {
     progress_empty_desc: "Assim que os resultados começarem a sair, acompanhe a corrida do ranking aqui.",
     progress_replay: "↻ Repetir",
     progress_match_count: "Jogo {i} de {n}",
+    progress_exact_one: "🎯 {names} cravou o placar exato!",
+    progress_exact_many: "🎯 {names} cravaram o placar exato!",
     first_place_kicker: "Topo do ranking",
     first_place_title: "VOCÊ É O 1º!",
     first_place_subtitle: "{name} lidera o bolão 🏆",
@@ -2546,6 +2563,11 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
   const shown = revealIdx;
   const currentFrame = shown > 0 ? data.frames[shown - 1] : null;
   const done = shown >= total && total > 0;
+  // Players who scored the full 3 points (exact scoreline) on the match that
+  // was just revealed — drives the gold highlight on their dot/legend chip.
+  const exactNames = currentFrame
+    ? data.players.filter((p, pi) => currentFrame.gains[pi] === 3).map(p => p.n)
+    : [];
 
   const gridLines = [0.25, 0.5, 0.75, 1].map(f => Math.round(maxY * f));
   const finalTotals = total > 0 ? data.frames[total - 1].cum : data.players.map(() => 0);
@@ -2590,17 +2612,25 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
           <>
             {/* current match / commentary strip */}
             <div style={{
-              minHeight:34, display:'flex', alignItems:'center', justifyContent:'center', gap:8,
-              background:'rgba(255,255,255,0.03)', border:`1px solid ${BORDER}`, borderRadius:10, padding:'6px 10px',
-              textAlign:'center', flexWrap:'wrap',
+              minHeight:34, display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', gap:4,
+              background: exactNames.length ? 'rgba(255,215,0,0.08)' : 'rgba(255,255,255,0.03)',
+              border:`1px solid ${exactNames.length ? 'rgba(255,215,0,0.4)' : BORDER}`, borderRadius:10, padding:'6px 10px',
+              textAlign:'center',
             }}>
               {currentFrame && (
-                <>
+                <div style={{ display:'flex', alignItems:'center', justifyContent:'center', gap:8, flexWrap:'wrap' }}>
                   <span style={{ fontSize:11, color:'#888', flexShrink:0 }}>{currentFrame.match.date}</span>
                   <span style={{ fontSize:12, fontWeight:700, color:'#eee' }}>
                     {currentFrame.match.home||'?'} {currentFrame.match.actualH}-{currentFrame.match.actualA} {currentFrame.match.away||'?'}
                   </span>
-                </>
+                </div>
+              )}
+              {exactNames.length > 0 && (
+                <div key={shown} style={{
+                  fontSize:11, fontWeight:800, color:GOLD, animation:'ppExactStrip 0.3s ease',
+                }}>
+                  {t(exactNames.length > 1 ? 'progress_exact_many' : 'progress_exact_one').replace('{names}', exactNames.join(' & '))}
+                </div>
               )}
             </div>
 
@@ -2616,13 +2646,22 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
                 const d = pts.map(([x,y],i) => `${i===0?'M':'L'}${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
                 const [lx, ly] = pts[pts.length-1];
                 const isLeader = done && pi === leaderIdx;
+                const isExact = exactNames.includes(p.n);
                 return (
                   <g key={p.n}>
                     <path d={d} fill="none" stroke={colors[pi]} strokeWidth={p.isMe?3:2}
                       strokeLinejoin="round" strokeLinecap="round" opacity={p.isMe?1:0.85}/>
+                    {isExact && (
+                      <circle key={`ring-${shown}`} cx={lx} cy={ly} r="5" fill="none" stroke={GOLD}
+                        style={{ animation:'ppExactRing 0.7s ease-out', transformBox:'fill-box', transformOrigin:'center' }}/>
+                    )}
                     <circle key={shown} cx={lx} cy={ly} r={p.isMe?5:4} fill={colors[pi]}
-                      stroke="#0d1a2e" strokeWidth="1.5"
+                      stroke={isExact?GOLD:"#0d1a2e"} strokeWidth={isExact?2.5:1.5}
                       style={{ animation:'ppDotPop 0.35s ease', transformBox:'fill-box', transformOrigin:'center' }}/>
+                    {isExact && !isLeader && (
+                      <text x={lx} y={ly-11} textAnchor="middle" fontSize="12"
+                        style={{ animation:'ppExactBadge 0.4s ease', transformBox:'fill-box', transformOrigin:'center' }}>🎯</text>
+                    )}
                     {isLeader && (
                       <text x={lx} y={ly-11} textAnchor="middle" fontSize="13"
                         style={{ animation:'ppTrophyPop 0.4s ease', transformBox:'fill-box', transformOrigin:'center' }}>🏆</text>
@@ -2636,17 +2675,20 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
             <div style={{ display:'flex', flexWrap:'wrap', gap:6 }}>
               {data.players.map((p,pi) => {
                 const val = shown > 0 ? data.frames[shown-1].cum[pi] : 0;
+                const isExact = exactNames.includes(p.n);
                 return (
                   <div key={p.n} style={{
                     display:'flex', alignItems:'center', gap:5,
-                    background:'rgba(255,255,255,0.04)', border:`1px solid ${BORDER}`,
+                    background: isExact ? 'rgba(255,215,0,0.14)' : 'rgba(255,255,255,0.04)',
+                    border:`1px solid ${isExact ? 'rgba(255,215,0,0.55)' : BORDER}`,
                     borderRadius:8, padding:'4px 8px',
                   }}>
                     <span style={{ width:8, height:8, borderRadius:'50%', background:colors[pi], flexShrink:0 }}/>
                     <span style={{ fontSize:11, fontWeight:700, color:p.isMe?ACCENT:'#ccc' }}>
                       {p.n}{p.isMe?t('you_suffix'):''}
                     </span>
-                    <span style={{ fontSize:11, fontWeight:900, color:'#fff' }}>{val}</span>
+                    <span style={{ fontSize:11, fontWeight:900, color: isExact ? GOLD : '#fff' }}>{val}</span>
+                    {isExact && <span style={{ fontSize:10 }}>🎯</span>}
                   </div>
                 );
               })}

--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -141,6 +141,25 @@
       0%   { transform: translateY(0) rotate(0deg); opacity: 1; }
       100% { transform: translateY(34px) rotate(280deg); opacity: 0; }
     }
+    .pp-overlay { display:flex; align-items:flex-end; justify-content:center; }
+    .pp-sheet {
+      display:flex; flex-direction:column; gap:12px;
+      width:100%; max-width:560px; max-height:88vh; overflow-y:auto;
+      border-radius:20px 20px 0 0;
+    }
+    .pp-body { display:flex; flex-direction:column; gap:12px; }
+    .pp-chart-col { display:flex; flex-direction:column; gap:12px; }
+    .pp-side-col { display:flex; flex-direction:column; gap:8px; }
+    /* Short, wide viewport (a rotated phone, not just any desktop window) —
+       swap the bottom sheet for a centered dialog and put the chart and the
+       legend/scrubber side by side so the whole thing fits without scrolling. */
+    @media (orientation: landscape) and (max-height: 560px) {
+      .pp-overlay { align-items:center; padding:16px; }
+      .pp-sheet { border-radius:20px; max-width:760px; max-height:92vh; }
+      .pp-body { flex-direction:row; align-items:stretch; }
+      .pp-chart-col { flex:1.5; min-width:0; justify-content:center; }
+      .pp-side-col { flex:1; min-width:0; justify-content:center; overflow-y:auto; max-height:78vh; }
+    }
     .pp-slider {
       -webkit-appearance: none; appearance: none;
       width: 100%; height: 4px; border-radius: 2px; outline: none; cursor: pointer;
@@ -2646,18 +2665,14 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
   const passName = isPassMoment ? data.players[liveLeaderIdx]?.n : null;
 
   return (
-    <div onClick={onClose} style={{
+    <div onClick={onClose} className="pp-overlay" style={{
       position:'fixed', inset:0, background:'rgba(0,0,0,0.88)', zIndex:500,
-      display:'flex', alignItems:'flex-end', justifyContent:'center',
       padding:'0 0 env(safe-area-inset-bottom,0)',
     }}>
-      <div onClick={e => e.stopPropagation()} style={{
+      <div onClick={e => e.stopPropagation()} className="pp-sheet" style={{
         background:'#0d1a2e', border:`1px solid rgba(0,208,132,0.35)`,
-        borderRadius:'20px 20px 0 0', padding:'16px 18px 24px',
-        width:'100%', maxWidth:560,
-        display:'flex', flexDirection:'column', gap:12,
+        padding:'16px 18px 24px',
         animation:'shareModalIn 0.3s ease',
-        maxHeight:'88vh', overflowY:'auto',
       }}>
         <div style={{ width:36, height:4, borderRadius:2, background:'rgba(255,255,255,0.12)', alignSelf:'center', marginBottom:2 }}/>
 
@@ -2681,7 +2696,8 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
             <div style={{ fontSize:11, color:'#555', lineHeight:1.5 }}>{t('progress_empty_desc')}</div>
           </div>
         ) : (
-          <>
+          <div className="pp-body">
+          <div className="pp-chart-col">
             {/* current match / commentary strip */}
             <div style={{
               minHeight:34, display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', gap:4,
@@ -2775,7 +2791,9 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
                 );
               })}
             </svg>
+          </div>
 
+          <div className="pp-side-col">
             {/* legend */}
             <div style={{ display:'flex', flexWrap:'wrap', gap:6 }}>
               {data.players.map((p,pi) => {
@@ -2822,7 +2840,8 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
                 fontSize:11, fontWeight:700, cursor:'pointer', fontFamily:'inherit',
               }}>{t('progress_replay')}</button>
             </div>
-          </>
+          </div>
+          </div>
         )}
       </div>
     </div>

--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -99,6 +99,16 @@
       0%   { transform: translateY(10px); opacity: 0; }
       100% { transform: translateY(0); opacity: 1; }
     }
+    @keyframes ppDotPop {
+      0%   { transform: scale(0); opacity: 0; }
+      60%  { transform: scale(1.5); opacity: 1; }
+      100% { transform: scale(1); opacity: 1; }
+    }
+    @keyframes ppTrophyPop {
+      0%   { transform: scale(0) translateY(6px); opacity: 0; }
+      70%  { transform: scale(1.25) translateY(-2px); opacity: 1; }
+      100% { transform: scale(1) translateY(0); opacity: 1; }
+    }
   </style>
 </head>
 <body>
@@ -306,6 +316,13 @@ const TRANSLATIONS = {
     compete_friends: "Compete with friends",
     compete_friends_desc: "Share your QR — anyone who scans it joins your leaderboard. The app flashes when someone nails a score.",
     leaderboard_locked_hint: "Fill in all your group stage picks to unlock the leaderboard and compare with friends",
+    progress_btn: "📈 Progression",
+    progress_title: "📈 Points Progression",
+    progress_subtitle: "How the leaderboard evolved, match by match",
+    progress_empty_title: "No matches played yet",
+    progress_empty_desc: "Once results start coming in, watch the leaderboard race unfold here.",
+    progress_replay: "↻ Replay",
+    progress_match_count: "Match {i} of {n}",
     first_place_kicker: "Top of the leaderboard",
     first_place_title: "YOU'RE #1!",
     first_place_subtitle: "{name} leads the bolão 🏆",
@@ -580,6 +597,13 @@ const TRANSLATIONS = {
     compete_friends: "Compita com amigos",
     compete_friends_desc: "Compartilhe seu QR — quem escanear entra no seu ranking. O app pisca quando alguém acerta um placar.",
     leaderboard_locked_hint: "Preencha todos os seus palpites da fase de grupos para liberar o ranking e a comparação com amigos",
+    progress_btn: "📈 Progressão",
+    progress_title: "📈 Progressão de Pontos",
+    progress_subtitle: "Como o ranking evoluiu, jogo a jogo",
+    progress_empty_title: "Nenhum jogo terminado ainda",
+    progress_empty_desc: "Assim que os resultados começarem a sair, acompanhe a corrida do ranking aqui.",
+    progress_replay: "↻ Repetir",
+    progress_match_count: "Jogo {i} de {n}",
     first_place_kicker: "Topo do ranking",
     first_place_title: "VOCÊ É O 1º!",
     first_place_subtitle: "{name} lidera o bolão 🏆",
@@ -2264,7 +2288,7 @@ function FirstPlaceCelebration({ name, onDismiss }) {
 }
 
 // ─── Rivals Leaderboard ───────────────────────────────────────────────────────
-function RivalsLeaderboard({ rivals, myName, myPts, groupMatches, ko, canShare, onShare, onRemove, compareRival, onToggleCompare }) {
+function RivalsLeaderboard({ rivals, myName, myPts, groupMatches, ko, canShare, onShare, onRemove, compareRival, onToggleCompare, onShowProgress }) {
   const { t } = useLang();
   const allPlayers = [
     { n: myName || t('you_default'), pts: myPts, isMe: true, rival: null },
@@ -2318,13 +2342,20 @@ function RivalsLeaderboard({ rivals, myName, myPts, groupMatches, ko, canShare, 
         <div style={{ fontSize:9, color:ACCENT, letterSpacing:2, fontWeight:700, textTransform:'uppercase' }}>
           {t('leaderboard_title')}
         </div>
-        {canShare && (
-          <button onClick={onShare} style={{
-            background:'transparent', border:`1px solid rgba(0,208,132,0.3)`,
-            color:ACCENT, borderRadius:7, padding:'4px 10px',
+        <div style={{ display:'flex', gap:6, flexShrink:0 }}>
+          <button onClick={onShowProgress} style={{
+            background:'transparent', border:`1px solid rgba(167,139,250,0.3)`,
+            color:PURPLE, borderRadius:7, padding:'4px 10px',
             fontSize:10, fontWeight:700, cursor:'pointer', fontFamily:'inherit',
-          }}>{t('add_rival_btn')}</button>
-        )}
+          }}>{t('progress_btn')}</button>
+          {canShare && (
+            <button onClick={onShare} style={{
+              background:'transparent', border:`1px solid rgba(0,208,132,0.3)`,
+              color:ACCENT, borderRadius:7, padding:'4px 10px',
+              fontSize:10, fontWeight:700, cursor:'pointer', fontFamily:'inherit',
+            }}>{t('add_rival_btn')}</button>
+          )}
+        </div>
       </div>
 
       <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', gap:6, marginBottom:8 }}>
@@ -2422,6 +2453,218 @@ function RivalsLeaderboard({ rivals, myName, myPts, groupMatches, ko, canShare, 
           )}
         </div>
       );})}
+    </div>
+  );
+}
+
+// ─── Points Progression Animation ──────────────────────────────────────────────
+// Fixed categorical order for rival lines — "me" always uses ACCENT (the app's
+// established "you" color), so this set only needs to stay distinguishable from
+// that green and from itself (checked with dataviz's palette validator against
+// the app's dark surface #080d16).
+const PROGRESS_RIVAL_COLORS = ['#3987e5','#c98500','#9085e9','#e66767','#d55181','#d95926','#199e70'];
+
+// Chronological list of every match with a final score, paired with each
+// player's per-match points — the raw material the animation plays back.
+function buildProgressionSeries(groupMatches, ko, myName, myPredictions, rivals, t) {
+  const matches = [];
+  Object.values(groupMatches).flat().forEach(m => {
+    matches.push({
+      id: m.id, sortKey: (m.dk||0)*10000 + (m.tk||0), predType: 'group',
+      played: m.homeScore !== null && m.awayScore !== null,
+      home: m.home, away: m.away, actualH: m.homeScore, actualA: m.awayScore, date: m.date,
+    });
+  });
+  ['r32','r16','qf','sf','final','third'].forEach(round => {
+    (ko[round]||[]).forEach(m => {
+      matches.push({
+        id: m.id, sortKey: (m.dk||0)*10000 + timeKey(m.time||'0:00 AM'), predType: 'ko',
+        played: m.scoreA !== null && m.scoreB !== null,
+        home: m.teamA, away: m.teamB, actualH: m.scoreA, actualA: m.scoreB, date: m.date,
+      });
+    });
+  });
+  const played = matches.filter(m => m.played).sort((a,b) => a.sortKey - b.sortKey);
+
+  const players = [
+    { n: myName || t('you_default'), isMe: true, predictions: myPredictions || { group:{}, ko:{} } },
+    ...rivals.map(r => ({ n: r.n, isMe: false, predictions: r.predictions || { group:{}, ko:{} } })),
+  ];
+
+  const cum = players.map(() => 0);
+  const frames = played.map(m => {
+    const gains = players.map((p, i) => {
+      const pred = m.predType === 'group' ? p.predictions.group?.[m.id] : p.predictions.ko?.[m.id];
+      let pts = 0;
+      if (pred) {
+        const ph = m.predType === 'group' ? pred.home : pred.a;
+        const pa = m.predType === 'group' ? pred.away : pred.b;
+        pts = scorePrediction(ph, pa, m.actualH, m.actualA) || 0;
+      }
+      cum[i] += pts;
+      return pts;
+    });
+    return { match: m, gains, cum: [...cum] };
+  });
+
+  return { players, frames };
+}
+
+function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals, onClose }) {
+  const { t } = useLang();
+  const data = useMemo(
+    () => buildProgressionSeries(groupMatches, ko, myName, predictions, rivals, t),
+    [groupMatches, ko, myName, predictions, rivals, t]
+  );
+  const total = data.frames.length;
+  const [revealIdx, setRevealIdx] = useState(0);
+  const timerRef = useRef(null);
+
+  const play = useCallback(() => {
+    clearInterval(timerRef.current);
+    setRevealIdx(0);
+    if (total === 0) return;
+    const stepMs = Math.min(550, Math.max(90, 3200 / total));
+    let i = 0;
+    timerRef.current = setInterval(() => {
+      i++;
+      setRevealIdx(i);
+      if (i >= total) clearInterval(timerRef.current);
+    }, stepMs);
+  }, [total]);
+
+  useEffect(() => { play(); return () => clearInterval(timerRef.current); }, [play]);
+
+  const colors = data.players.map((p, i) => p.isMe ? ACCENT : PROGRESS_RIVAL_COLORS[(i - 1) % PROGRESS_RIVAL_COLORS.length]);
+
+  const W = 640, H = 210, padL = 6, padR = 6, padT = 16, padB = 6;
+  const plotW = W - padL - padR, plotH = H - padT - padB;
+  const maxY = Math.max(3, ...data.frames.map(f => Math.max(...f.cum)));
+  const xAt = i => total <= 1 ? padL + plotW / 2 : padL + (plotW * i) / (total - 1);
+  const yAt = v => padT + plotH - (plotH * v) / maxY;
+
+  const shown = revealIdx;
+  const currentFrame = shown > 0 ? data.frames[shown - 1] : null;
+  const done = shown >= total && total > 0;
+
+  const gridLines = [0.25, 0.5, 0.75, 1].map(f => Math.round(maxY * f));
+  const finalTotals = total > 0 ? data.frames[total - 1].cum : data.players.map(() => 0);
+  const leaderIdx = finalTotals.indexOf(Math.max(...finalTotals));
+
+  return (
+    <div onClick={onClose} style={{
+      position:'fixed', inset:0, background:'rgba(0,0,0,0.88)', zIndex:500,
+      display:'flex', alignItems:'flex-end', justifyContent:'center',
+      padding:'0 0 env(safe-area-inset-bottom,0)',
+    }}>
+      <div onClick={e => e.stopPropagation()} style={{
+        background:'#0d1a2e', border:`1px solid rgba(0,208,132,0.35)`,
+        borderRadius:'20px 20px 0 0', padding:'16px 18px 24px',
+        width:'100%', maxWidth:560,
+        display:'flex', flexDirection:'column', gap:12,
+        animation:'shareModalIn 0.3s ease',
+        maxHeight:'88vh', overflowY:'auto',
+      }}>
+        <div style={{ width:36, height:4, borderRadius:2, background:'rgba(255,255,255,0.12)', alignSelf:'center', marginBottom:2 }}/>
+
+        <div style={{ display:'flex', alignItems:'flex-start', justifyContent:'space-between', gap:10 }}>
+          <div>
+            <div style={{ fontSize:11, color:ACCENT, letterSpacing:2, fontWeight:700, textTransform:'uppercase' }}>
+              {t('progress_title')}
+            </div>
+            <div style={{ fontSize:11, color:'#666', marginTop:3 }}>{t('progress_subtitle')}</div>
+          </div>
+          <button onClick={onClose} style={{
+            background:'transparent', border:'none', color:'#666',
+            fontSize:20, cursor:'pointer', padding:2, lineHeight:1, flexShrink:0,
+          }}>✕</button>
+        </div>
+
+        {total === 0 ? (
+          <div style={{ textAlign:'center', padding:'22px 10px' }}>
+            <div style={{ fontSize:26, marginBottom:8 }}>⏳</div>
+            <div style={{ fontSize:12, fontWeight:800, color:'#ccc', marginBottom:4 }}>{t('progress_empty_title')}</div>
+            <div style={{ fontSize:11, color:'#555', lineHeight:1.5 }}>{t('progress_empty_desc')}</div>
+          </div>
+        ) : (
+          <>
+            {/* current match / commentary strip */}
+            <div style={{
+              minHeight:34, display:'flex', alignItems:'center', justifyContent:'center', gap:8,
+              background:'rgba(255,255,255,0.03)', border:`1px solid ${BORDER}`, borderRadius:10, padding:'6px 10px',
+              textAlign:'center', flexWrap:'wrap',
+            }}>
+              {currentFrame && (
+                <>
+                  <span style={{ fontSize:11, color:'#888', flexShrink:0 }}>{currentFrame.match.date}</span>
+                  <span style={{ fontSize:12, fontWeight:700, color:'#eee' }}>
+                    {currentFrame.match.home||'?'} {currentFrame.match.actualH}-{currentFrame.match.actualA} {currentFrame.match.away||'?'}
+                  </span>
+                </>
+              )}
+            </div>
+
+            <svg viewBox={`0 0 ${W} ${H}`} style={{ width:'100%', height:'auto', display:'block' }}>
+              {gridLines.map((v,i) => (
+                <line key={i} x1={padL} x2={W-padR} y1={yAt(v)} y2={yAt(v)} stroke="rgba(255,255,255,0.06)" strokeWidth="1"/>
+              ))}
+              <line x1={padL} x2={W-padR} y1={yAt(0)} y2={yAt(0)} stroke="rgba(255,255,255,0.14)" strokeWidth="1"/>
+
+              {data.players.map((p, pi) => {
+                const pts = data.frames.slice(0, shown).map((f,fi) => [xAt(fi), yAt(f.cum[pi])]);
+                if (pts.length === 0) return null;
+                const d = pts.map(([x,y],i) => `${i===0?'M':'L'}${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
+                const [lx, ly] = pts[pts.length-1];
+                const isLeader = done && pi === leaderIdx;
+                return (
+                  <g key={p.n}>
+                    <path d={d} fill="none" stroke={colors[pi]} strokeWidth={p.isMe?3:2}
+                      strokeLinejoin="round" strokeLinecap="round" opacity={p.isMe?1:0.85}/>
+                    <circle key={shown} cx={lx} cy={ly} r={p.isMe?5:4} fill={colors[pi]}
+                      stroke="#0d1a2e" strokeWidth="1.5"
+                      style={{ animation:'ppDotPop 0.35s ease', transformBox:'fill-box', transformOrigin:'center' }}/>
+                    {isLeader && (
+                      <text x={lx} y={ly-11} textAnchor="middle" fontSize="13"
+                        style={{ animation:'ppTrophyPop 0.4s ease', transformBox:'fill-box', transformOrigin:'center' }}>🏆</text>
+                    )}
+                  </g>
+                );
+              })}
+            </svg>
+
+            {/* legend */}
+            <div style={{ display:'flex', flexWrap:'wrap', gap:6 }}>
+              {data.players.map((p,pi) => {
+                const val = shown > 0 ? data.frames[shown-1].cum[pi] : 0;
+                return (
+                  <div key={p.n} style={{
+                    display:'flex', alignItems:'center', gap:5,
+                    background:'rgba(255,255,255,0.04)', border:`1px solid ${BORDER}`,
+                    borderRadius:8, padding:'4px 8px',
+                  }}>
+                    <span style={{ width:8, height:8, borderRadius:'50%', background:colors[pi], flexShrink:0 }}/>
+                    <span style={{ fontSize:11, fontWeight:700, color:p.isMe?ACCENT:'#ccc' }}>
+                      {p.n}{p.isMe?t('you_suffix'):''}
+                    </span>
+                    <span style={{ fontSize:11, fontWeight:900, color:'#fff' }}>{val}</span>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginTop:2 }}>
+              <span style={{ fontSize:10, color:'#555' }}>
+                {t('progress_match_count').replace('{i}', Math.min(shown,total)).replace('{n}', total)}
+              </span>
+              <button onClick={play} style={{
+                background:'transparent', border:`1px solid rgba(0,208,132,0.3)`,
+                color:ACCENT, borderRadius:7, padding:'5px 12px',
+                fontSize:11, fontWeight:700, cursor:'pointer', fontFamily:'inherit',
+              }}>{t('progress_replay')}</button>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }
@@ -3464,6 +3707,7 @@ function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isM
     return [...PHASES].reverse().find(p => isUnlocked(p.key))?.key ?? 'group';
   })();
   const [phase, setPhase] = useState(defaultPhase);
+  const [showProgress, setShowProgress] = useState(false);
   const pts = useMemo(()=>calcPoints(groupMatches,ko,predictions),[groupMatches,ko,predictions]);
   // Group stage being complete unlocks "Copy All" / proximity sharing for good —
   // a later phase still in progress doesn't re-lock it. Late joiners who missed
@@ -3577,7 +3821,16 @@ function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isM
         groupMatches={groupMatches} ko={ko} canShare={canShare}
         onShare={onShare} onRemove={onRemoveRival}
         compareRival={compareRival} onToggleCompare={toggleCompare}
+        onShowProgress={() => setShowProgress(true)}
       />
+
+      {showProgress && (
+        <PointsProgressionModal
+          groupMatches={groupMatches} ko={ko}
+          myName={playerName} predictions={predictions} rivals={rivals}
+          onClose={() => setShowProgress(false)}
+        />
+      )}
 
       {/* Paste a sync link received in another storage context (e.g. browser vs. installed PWA) */}
       <PasteSyncLink onResolve={onResolveLink} />

--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -122,6 +122,28 @@
       0%   { opacity: 0; transform: translateY(-4px); }
       100% { opacity: 1; transform: translateY(0); }
     }
+    .pp-slider {
+      -webkit-appearance: none; appearance: none;
+      width: 100%; height: 4px; border-radius: 2px; outline: none; cursor: pointer;
+      background: linear-gradient(to right,
+        #00d084 0%, #00d084 var(--pp-fill, 0%),
+        rgba(255,255,255,0.14) var(--pp-fill, 0%), rgba(255,255,255,0.14) 100%);
+    }
+    .pp-slider::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      width: 14px; height: 14px; border-radius: 50%;
+      background: #00d084; border: 2px solid #0d1a2e;
+      box-shadow: 0 0 0 1px rgba(0,208,132,0.6);
+      cursor: pointer;
+    }
+    .pp-slider::-moz-range-track { height: 4px; border-radius: 2px; background: rgba(255,255,255,0.14); }
+    .pp-slider::-moz-range-progress { height: 4px; border-radius: 2px; background: #00d084; }
+    .pp-slider::-moz-range-thumb {
+      width: 14px; height: 14px; border-radius: 50%;
+      background: #00d084; border: 2px solid #0d1a2e;
+      box-shadow: 0 0 0 1px rgba(0,208,132,0.6);
+      cursor: pointer;
+    }
   </style>
 </head>
 <body>
@@ -338,6 +360,8 @@ const TRANSLATIONS = {
     progress_match_count: "Match {i} of {n}",
     progress_exact_one: "🎯 {names} nailed the exact score!",
     progress_exact_many: "🎯 {names} all nailed the exact score!",
+    progress_play: "Play",
+    progress_pause: "Pause",
     first_place_kicker: "Top of the leaderboard",
     first_place_title: "YOU'RE #1!",
     first_place_subtitle: "{name} leads the bolão 🏆",
@@ -621,6 +645,8 @@ const TRANSLATIONS = {
     progress_match_count: "Jogo {i} de {n}",
     progress_exact_one: "🎯 {names} cravou o placar exato!",
     progress_exact_many: "🎯 {names} cravaram o placar exato!",
+    progress_play: "Reproduzir",
+    progress_pause: "Pausar",
     first_place_kicker: "Topo do ranking",
     first_place_title: "VOCÊ É O 1º!",
     first_place_subtitle: "{name} lidera o bolão 🏆",
@@ -2535,22 +2561,29 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
   );
   const total = data.frames.length;
   const [revealIdx, setRevealIdx] = useState(0);
-  const timerRef = useRef(null);
+  const [playing, setPlaying] = useState(true);
+  const stepMs = total > 0 ? Math.min(550, Math.max(90, 3200 / total)) : 0;
 
-  const play = useCallback(() => {
-    clearInterval(timerRef.current);
-    setRevealIdx(0);
-    if (total === 0) return;
-    const stepMs = Math.min(550, Math.max(90, 3200 / total));
-    let i = 0;
-    timerRef.current = setInterval(() => {
-      i++;
-      setRevealIdx(i);
-      if (i >= total) clearInterval(timerRef.current);
+  // Auto-advance while playing; pauses itself once every match is revealed.
+  useEffect(() => {
+    if (!playing || total === 0) return;
+    const id = setInterval(() => {
+      setRevealIdx(i => {
+        if (i + 1 >= total) { setPlaying(false); return total; }
+        return i + 1;
+      });
     }, stepMs);
-  }, [total]);
+    return () => clearInterval(id);
+  }, [playing, stepMs, total]);
 
-  useEffect(() => { play(); return () => clearInterval(timerRef.current); }, [play]);
+  const replay = useCallback(() => { setRevealIdx(0); setPlaying(true); }, []);
+  const togglePlay = useCallback(() => {
+    setPlaying(p => {
+      if (!p && revealIdx >= total) { setRevealIdx(0); return true; }
+      return !p;
+    });
+  }, [revealIdx, total]);
+  const scrubTo = useCallback(idx => { setPlaying(false); setRevealIdx(idx); }, []);
 
   const colors = data.players.map((p, i) => p.isMe ? ACCENT : PROGRESS_RIVAL_COLORS[(i - 1) % PROGRESS_RIVAL_COLORS.length]);
 
@@ -2694,11 +2727,24 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
               })}
             </div>
 
-            <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginTop:2 }}>
+            {/* scrubber */}
+            <div style={{ display:'flex', alignItems:'center', gap:10 }}>
+              <button onClick={togglePlay} aria-label={playing?t('progress_pause'):t('progress_play')} style={{
+                background:'rgba(0,208,132,0.14)', border:`1px solid rgba(0,208,132,0.45)`,
+                color:ACCENT, borderRadius:'50%', width:28, height:28, flexShrink:0,
+                display:'flex', alignItems:'center', justifyContent:'center',
+                fontSize:12, cursor:'pointer', fontFamily:'inherit', padding:0,
+              }}>{playing ? '⏸' : '▶'}</button>
+              <input type="range" className="pp-slider" min={0} max={total} step={1} value={shown}
+                onChange={e => scrubTo(Number(e.target.value))}
+                style={{ '--pp-fill': `${total>0 ? (shown/total)*100 : 0}%`, flex:1 }}/>
+            </div>
+
+            <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginTop:-4 }}>
               <span style={{ fontSize:10, color:'#555' }}>
                 {t('progress_match_count').replace('{i}', Math.min(shown,total)).replace('{n}', total)}
               </span>
-              <button onClick={play} style={{
+              <button onClick={replay} style={{
                 background:'transparent', border:`1px solid rgba(0,208,132,0.3)`,
                 color:ACCENT, borderRadius:7, padding:'5px 12px',
                 fontSize:11, fontWeight:700, cursor:'pointer', fontFamily:'inherit',

--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -156,9 +156,18 @@
     @media (orientation: landscape) and (max-height: 560px) {
       .pp-overlay { align-items:center; padding:16px; }
       .pp-sheet { border-radius:20px; max-width:760px; max-height:92vh; }
-      .pp-body { flex-direction:row; align-items:stretch; }
-      .pp-chart-col { flex:1.5; min-width:0; justify-content:center; }
-      .pp-side-col { flex:1; min-width:0; justify-content:center; overflow-y:auto; max-height:78vh; }
+      /* flex + min-height:0 forces pp-body to actually fill (not just hug) the
+         remaining sheet height — without it the sheet's own scroll absorbs the
+         overflow instead of the inner legend list, and the controls end up
+         pushed out of view below the fold. */
+      .pp-body { flex:1 1 auto; min-height:0; flex-direction:row; align-items:stretch; }
+      .pp-chart-col { flex:2.2; min-width:0; justify-content:center; }
+      .pp-side-col { flex:1; min-width:0; min-height:0; justify-content:flex-start; }
+      /* Only the ranked list scrolls — the play/slider/replay controls below
+         it stay pinned and reachable no matter how many rivals there are. */
+      .pp-legend-scroll { flex:1; min-height:0; overflow-y:auto; }
+      .pp-legend { flex-direction:column; flex-wrap:nowrap; }
+      .pp-legend > div { width:100%; flex-shrink:0; }
     }
     .pp-slider {
       -webkit-appearance: none; appearance: none;
@@ -2666,6 +2675,16 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
   const isPassMoment = shown > 0 && leadChangeFrames.has(shown - 1);
   const passName = isPassMoment ? data.players[liveLeaderIdx]?.n : null;
 
+  // Legend rows read top-to-bottom by current standing (like the leaderboard),
+  // not by rival-add order — re-sorted every reveal so it tracks the race live.
+  const rankedPlayers = useMemo(() => {
+    const withVal = data.players.map((p, pi) => ({
+      p, pi, val: shown > 0 ? data.frames[shown - 1].cum[pi] : 0,
+    }));
+    withVal.sort((a, b) => b.val - a.val);
+    return withVal;
+  }, [data.players, data.frames, shown]);
+
   return (
     <div onClick={onClose} className="pp-overlay" style={{
       position:'fixed', inset:0, background:'rgba(0,0,0,0.88)', zIndex:500,
@@ -2796,27 +2815,34 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
           </div>
 
           <div className="pp-side-col">
-            {/* legend */}
-            <div style={{ display:'flex', flexWrap:'wrap', gap:6 }}>
-              {data.players.map((p,pi) => {
-                const val = shown > 0 ? data.frames[shown-1].cum[pi] : 0;
-                const isExact = exactNames.includes(p.n);
-                return (
-                  <div key={p.n} style={{
-                    display:'flex', alignItems:'center', gap:5,
-                    background: isExact ? 'rgba(255,215,0,0.14)' : 'rgba(255,255,255,0.04)',
-                    border:`1px solid ${isExact ? 'rgba(255,215,0,0.55)' : BORDER}`,
-                    borderRadius:8, padding:'4px 8px',
-                  }}>
-                    <span style={{ width:8, height:8, borderRadius:'50%', background:colors[pi], flexShrink:0 }}/>
-                    <span style={{ fontSize:11, fontWeight:700, color:p.isMe?ACCENT:'#ccc' }}>
-                      {p.n}{p.isMe?t('you_suffix'):''}
-                    </span>
-                    <span style={{ fontSize:11, fontWeight:900, color: isExact ? GOLD : '#fff' }}>{val}</span>
-                    {isExact && <span style={{ fontSize:10 }}>🎯</span>}
-                  </div>
-                );
-              })}
+            {/* legend — ranked top-to-bottom by current standing. Scrolls on
+               its own in landscape so the controls below stay pinned and
+               reachable however many rivals are in the list. */}
+            <div className="pp-legend-scroll">
+              <div className="pp-legend" style={{ display:'flex', flexWrap:'wrap', gap:6 }}>
+                {rankedPlayers.map(({ p, pi, val }) => {
+                  const isExact = exactNames.includes(p.n);
+                  return (
+                    <div key={p.n} style={{
+                      display:'flex', alignItems:'center', justifyContent:'space-between', gap:8,
+                      background: isExact ? 'rgba(255,215,0,0.14)' : 'rgba(255,255,255,0.04)',
+                      border:`1px solid ${isExact ? 'rgba(255,215,0,0.55)' : BORDER}`,
+                      borderRadius:8, padding:'4px 8px',
+                    }}>
+                      <span style={{ display:'flex', alignItems:'center', gap:5, minWidth:0 }}>
+                        <span style={{ width:8, height:8, borderRadius:'50%', background:colors[pi], flexShrink:0 }}/>
+                        <span style={{ fontSize:11, fontWeight:700, color:p.isMe?ACCENT:'#ccc', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>
+                          {p.n}{p.isMe?t('you_suffix'):''}
+                        </span>
+                      </span>
+                      <span style={{ display:'flex', alignItems:'center', gap:4, flexShrink:0 }}>
+                        <span style={{ fontSize:11, fontWeight:900, color: isExact ? GOLD : '#fff' }}>{val}</span>
+                        {isExact && <span style={{ fontSize:10 }}>🎯</span>}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
             </div>
 
             {/* scrubber */}

--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -2602,7 +2602,9 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
   const total = data.frames.length;
   const [revealIdx, setRevealIdx] = useState(0);
   const [playing, setPlaying] = useState(true);
-  const stepMs = total > 0 ? Math.min(550, Math.max(90, 3200 / total)) : 0;
+  // One second per match, regardless of how many were played — slow enough to
+  // actually read the commentary strip and watch the lines move.
+  const stepMs = 1000;
 
   // Auto-advance while playing; pauses itself once every match is revealed.
   useEffect(() => {

--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -122,6 +122,25 @@
       0%   { opacity: 0; transform: translateY(-4px); }
       100% { opacity: 1; transform: translateY(0); }
     }
+    @keyframes ppCrownPass {
+      0%   { transform: scale(0) rotate(-25deg) translateY(6px); opacity: 0; }
+      50%  { transform: scale(1.6) rotate(12deg) translateY(-8px); opacity: 1; }
+      75%  { transform: scale(0.85) rotate(-6deg) translateY(0); }
+      100% { transform: scale(1.05) rotate(0deg) translateY(-1px); opacity: 1; }
+    }
+    @keyframes ppCrownIdle {
+      0%   { transform: scale(0) translateY(4px); opacity: 0; }
+      100% { transform: scale(1) translateY(0); opacity: 1; }
+    }
+    @keyframes ppLeadBannerIn {
+      0%   { opacity: 0; transform: scale(0.7) translateY(-5px); }
+      60%  { opacity: 1; transform: scale(1.1) translateY(0); }
+      100% { opacity: 1; transform: scale(1) translateY(0); }
+    }
+    @keyframes ppConfettiBit {
+      0%   { transform: translateY(0) rotate(0deg); opacity: 1; }
+      100% { transform: translateY(34px) rotate(280deg); opacity: 0; }
+    }
     .pp-slider {
       -webkit-appearance: none; appearance: none;
       width: 100%; height: 4px; border-radius: 2px; outline: none; cursor: pointer;
@@ -362,6 +381,7 @@ const TRANSLATIONS = {
     progress_exact_many: "🎯 {names} all nailed the exact score!",
     progress_play: "Play",
     progress_pause: "Pause",
+    progress_lead_change: "👑 {name} takes the lead!",
     first_place_kicker: "Top of the leaderboard",
     first_place_title: "YOU'RE #1!",
     first_place_subtitle: "{name} leads the bolão 🏆",
@@ -647,6 +667,7 @@ const TRANSLATIONS = {
     progress_exact_many: "🎯 {names} cravaram o placar exato!",
     progress_play: "Reproduzir",
     progress_pause: "Pausar",
+    progress_lead_change: "👑 {name} assume a liderança!",
     first_place_kicker: "Topo do ranking",
     first_place_title: "VOCÊ É O 1º!",
     first_place_subtitle: "{name} lidera o bolão 🏆",
@@ -2603,8 +2624,26 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
     : [];
 
   const gridLines = [0.25, 0.5, 0.75, 1].map(f => Math.round(maxY * f));
-  const finalTotals = total > 0 ? data.frames[total - 1].cum : data.players.map(() => 0);
-  const leaderIdx = finalTotals.indexOf(Math.max(...finalTotals));
+
+  // Leader at every point in the timeline, plus the exact frames where the lead
+  // actually changed hands — drives the "takes the lead" celebration below.
+  // (Frame 0 is deliberately excluded from leadChangeFrames: the very first
+  // player to score isn't "passing" anyone.)
+  const leaderTimeline = useMemo(
+    () => data.frames.map(f => f.cum.indexOf(Math.max(...f.cum))),
+    [data.frames]
+  );
+  const leadChangeFrames = useMemo(() => {
+    const set = new Set();
+    for (let i = 1; i < leaderTimeline.length; i++) {
+      if (leaderTimeline[i] !== leaderTimeline[i - 1]) set.add(i);
+    }
+    return set;
+  }, [leaderTimeline]);
+  const leaderIdx = total > 0 ? leaderTimeline[total - 1] : -1;
+  const liveLeaderIdx = shown > 0 ? leaderTimeline[shown - 1] : -1;
+  const isPassMoment = shown > 0 && leadChangeFrames.has(shown - 1);
+  const passName = isPassMoment ? data.players[liveLeaderIdx]?.n : null;
 
   return (
     <div onClick={onClose} style={{
@@ -2646,9 +2685,9 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
             {/* current match / commentary strip */}
             <div style={{
               minHeight:34, display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', gap:4,
-              background: exactNames.length ? 'rgba(255,215,0,0.08)' : 'rgba(255,255,255,0.03)',
-              border:`1px solid ${exactNames.length ? 'rgba(255,215,0,0.4)' : BORDER}`, borderRadius:10, padding:'6px 10px',
-              textAlign:'center',
+              background: exactNames.length ? 'rgba(255,215,0,0.08)' : isPassMoment ? 'rgba(167,139,250,0.1)' : 'rgba(255,255,255,0.03)',
+              border:`1px solid ${exactNames.length ? 'rgba(255,215,0,0.4)' : isPassMoment ? 'rgba(167,139,250,0.5)' : BORDER}`,
+              borderRadius:10, padding:'6px 10px', textAlign:'center',
             }}>
               {currentFrame && (
                 <div style={{ display:'flex', alignItems:'center', justifyContent:'center', gap:8, flexWrap:'wrap' }}>
@@ -2659,10 +2698,17 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
                 </div>
               )}
               {exactNames.length > 0 && (
-                <div key={shown} style={{
+                <div key={`exact-${shown}`} style={{
                   fontSize:11, fontWeight:800, color:GOLD, animation:'ppExactStrip 0.3s ease',
                 }}>
                   {t(exactNames.length > 1 ? 'progress_exact_many' : 'progress_exact_one').replace('{names}', exactNames.join(' & '))}
+                </div>
+              )}
+              {isPassMoment && (
+                <div key={`lead-${shown}`} style={{
+                  fontSize:12, fontWeight:900, color:PURPLE, animation:'ppLeadBannerIn 0.4s ease',
+                }}>
+                  {t('progress_lead_change').replace('{name}', passName + (data.players[liveLeaderIdx]?.isMe ? t('you_suffix') : ''))}
                 </div>
               )}
             </div>
@@ -2678,8 +2724,10 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
                 if (pts.length === 0) return null;
                 const d = pts.map(([x,y],i) => `${i===0?'M':'L'}${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
                 const [lx, ly] = pts[pts.length-1];
-                const isLeader = done && pi === leaderIdx;
+                const isFinalWinner = done && pi === leaderIdx;
+                const isCurrentLeader = !done && pi === liveLeaderIdx;
                 const isExact = exactNames.includes(p.n);
+                const isPasser = isPassMoment && pi === liveLeaderIdx;
                 return (
                   <g key={p.n}>
                     <path d={d} fill="none" stroke={colors[pi]} strokeWidth={p.isMe?3:2}
@@ -2688,17 +2736,41 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
                       <circle key={`ring-${shown}`} cx={lx} cy={ly} r="5" fill="none" stroke={GOLD}
                         style={{ animation:'ppExactRing 0.7s ease-out', transformBox:'fill-box', transformOrigin:'center' }}/>
                     )}
+                    {isPasser && (
+                      <circle key={`passring-${shown}`} cx={lx} cy={ly} r="5" fill="none" stroke={PURPLE}
+                        style={{ animation:'ppExactRing 0.8s ease-out', transformBox:'fill-box', transformOrigin:'center' }}/>
+                    )}
                     <circle key={shown} cx={lx} cy={ly} r={p.isMe?5:4} fill={colors[pi]}
                       stroke={isExact?GOLD:"#0d1a2e"} strokeWidth={isExact?2.5:1.5}
                       style={{ animation:'ppDotPop 0.35s ease', transformBox:'fill-box', transformOrigin:'center' }}/>
-                    {isExact && !isLeader && (
+                    {isExact && !isCurrentLeader && (
                       <text x={lx} y={ly-11} textAnchor="middle" fontSize="12"
                         style={{ animation:'ppExactBadge 0.4s ease', transformBox:'fill-box', transformOrigin:'center' }}>🎯</text>
                     )}
-                    {isLeader && (
+                    {isCurrentLeader && (
+                      // Not keyed by `shown` on purpose — this node stays mounted
+                      // (and quiet) for as long as this player holds the lead, so
+                      // the flashy pop animation below only plays once, right when
+                      // they take over.
+                      <text x={lx} y={ly-11} textAnchor="middle" fontSize="13"
+                        style={{
+                          animation: isPasser ? 'ppCrownPass 0.6s ease' : 'ppCrownIdle 0.3s ease',
+                          transformBox:'fill-box', transformOrigin:'center',
+                        }}>👑</text>
+                    )}
+                    {isFinalWinner && (
                       <text x={lx} y={ly-11} textAnchor="middle" fontSize="13"
                         style={{ animation:'ppTrophyPop 0.4s ease', transformBox:'fill-box', transformOrigin:'center' }}>🏆</text>
                     )}
+                    {isPasser && [...Array(8)].map((_, ci) => (
+                      <rect key={`confetti-${shown}-${ci}`}
+                        x={lx + (ci - 3.5) * 4} y={ly - 6} width="3" height="6" rx="1"
+                        fill={[ACCENT, GOLD, PURPLE, RED][ci % 4]}
+                        style={{
+                          animation: `ppConfettiBit 0.8s ease-in ${ci * 0.02}s both`,
+                          transformBox:'fill-box', transformOrigin:'center',
+                        }}/>
+                    ))}
                   </g>
                 );
               })}

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026061501';
+const CACHE_VERSION = '2026070301';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = [

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026070302';
+const CACHE_VERSION = '2026070303';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = [

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026070305';
+const CACHE_VERSION = '2026070306';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = [

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026070301';
+const CACHE_VERSION = '2026070302';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = [

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026070306';
+const CACHE_VERSION = '2026070307';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = [

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026070304';
+const CACHE_VERSION = '2026070305';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = [

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026070303';
+const CACHE_VERSION = '2026070304';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary
- Adds a "📈 Progression" button to the Fantasy leaderboard header, next to "Share with friends"
- Opens a bottom-sheet modal with an animated SVG line chart replaying the whole bolão in chronological order (group stage → knockout), one line per player (you + every rival)
- Each match reveal shows a commentary strip ("Sat 13 Jun · United States 4-1 Paraguay"), pops the current point per line, and a live legend with running totals; a 🏆 lands on the leader once the animation finishes
- "↻ Replay" restarts the animation; closes via the ✕ button or tapping the backdrop
- Handles the empty state (no matches played yet) and is fully translated (EN/PT-BR)
- Rival line colors picked from `dataviz`'s categorical palette and validated for colorblind-safety against the app's dark surface (`scripts/validate_palette.js`); "you" keeps the app's existing green accent
- Bumped the PWA service worker cache version so the change ships to installed users

## Test plan
- [x] Verified with a local Playwright harness (seeded predictions/rivals/results) that the button opens the modal, the animation reveals matches in order with correct cumulative totals, replay resets it, and the backdrop click closes it
- [x] Confirmed the empty state renders correctly when no matches have been played yet
- [x] No console/JS errors during the flow
- [ ] Manual check on a real device/browser (screenshots were captured against a locally patched build since the CDN scripts are blocked in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01S5JqzFj2jnBrPypiifBFJs)_