### PR TITLE
Tune bike physics and match sprite placement to reference art

### DIFF
--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -89,7 +89,7 @@ permalink: /elastomania/
   </div>
 
   <script>
-    const SW_VERSION = '2607031200';
+    const SW_VERSION = '2607031300';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function showBanner(reg) {
@@ -386,7 +386,7 @@ permalink: /elastomania/
     const BIKE_BODY_ANCHOR_X = 0.485;
     const BIKE_BODY_ANCHOR_Y = 0.99;
     const BIKE_BODY_OFFSET_Y = 13;
-    const BIKE_WHEEL_SCALE   = (WHEEL_R * 2.1) / 108;
+    const BIKE_WHEEL_SCALE   = (WHEEL_R * 2.35) / 108;
 
     const riderImg = new Image();
     riderImg.src   = '/elastomania/img/rider.png';
@@ -396,8 +396,8 @@ permalink: /elastomania/
     const RIDER_SCALE    = 0.29;
     const RIDER_ANCHOR_X = 0.286;
     const RIDER_ANCHOR_Y = 0.569;
-    const RIDER_OFFSET_X = -6;
-    const RIDER_OFFSET_Y = -18;
+    const RIDER_OFFSET_X = -4;
+    const RIDER_OFFSET_Y = -11;
 
     // Point on the rider's torso/chest, in chassis-local space (before
     // rotation) — used as the hit-test spot for ground/terrain crashes so

--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -89,7 +89,7 @@ permalink: /elastomania/
   </div>
 
   <script>
-    const SW_VERSION = '2607030738';
+    const SW_VERSION = '2607031200';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function showBanner(reg) {
@@ -152,22 +152,29 @@ permalink: /elastomania/
     const CHASSIS_W = 55;
     const CHASSIS_H = 10;
 
-    // Suspension: the main leg from chassis to wheel. Soft + damped so it
-    // visibly compresses on landings and overstretches under a hard impact
-    // instead of acting like a rigid rod.
+    // Suspension: the main leg from chassis to wheel. Stiff + well-damped so
+    // it gives a little under load but firmly springs back to its rest length
+    // — the wheels stay put under the bike (matching where the sprite draws
+    // the fork/swingarm) instead of drifting, and it can't stretch out and
+    // stay stretched. (A soft spring here let the wheels wander and also let
+    // the frame pitch up more, which exaggerated the throttle wheelie.)
     const SUSPENSION_LENGTH    = 15;
-    const SUSPENSION_STIFFNESS = 0.35;
-    const SUSPENSION_DAMPING   = 0.25;
+    const SUSPENSION_STIFFNESS = 0.9;
+    const SUSPENSION_DAMPING   = 0.5;
 
     // Secondary locating link per wheel — see note at rearBrace/frontBrace.
-    // Stiffer than the main leg since its job is structural (stop the wheel
-    // from swinging around the chassis), not to add extra suspension feel.
-    const BRACE_STIFFNESS = 0.7;
-    const BRACE_DAMPING   = 0.2;
+    // Stiff, since its job is structural (stop the wheel from swinging around
+    // the chassis), not to add suspension feel.
+    const BRACE_STIFFNESS = 0.9;
+    const BRACE_DAMPING   = 0.4;
 
-    const MOTOR_ACCEL   = 0.12;   // angular accel per 16.67ms frame
+    // Throttle: eased down from the old grabbier values so gassing from a
+    // standstill no longer pops the front end up into a hard wheelie. Paired
+    // with the stiffer suspension above, full throttle now lifts the nose only
+    // modestly; a deliberate wheelie still needs a held lean-back.
+    const MOTOR_ACCEL   = 0.09;   // angular accel per 16.67ms frame
     const BRAKE_ACCEL   = 0.2;
-    const MAX_WHEEL_SPIN  = 22;
+    const MAX_WHEEL_SPIN  = 20;
     const MAX_BRAKE_SPIN  = -8;
     const LEAN_ACCEL    = 0.08;
 

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607030738';
+const CACHE_VERSION = '2607031200';
 const CACHE_NAME = `elastomania-${CACHE_VERSION}`;
 const OFFLINE_URL = '/elastomania/';
 const PRECACHE_URLS = [

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607031200';
+const CACHE_VERSION = '2607031300';
 const CACHE_NAME = `elastomania-${CACHE_VERSION}`;
 const OFFLINE_URL = '/elastomania/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary

Two rounds of bike work in one branch:

### 1. Physics tuning (suspension + throttle)
Three reported issues all traced back to a too-soft suspension plus a grabby motor:
- **Wheel positions looked wrong** — soft chassis↔wheel springs let the wheels wander from where the sprite draws the fork/swingarm.
- **Suspension stretched too much and didn't return** — same soft springs let the legs pull far from rest and stay stretched.
- **Full throttle reared the bike** — gassing from a standstill popped a hard ~50° wheelie.

Changes:
- Suspension stiffened: `SUSPENSION_STIFFNESS` 0.35→0.9, `SUSPENSION_DAMPING` 0.25→0.5; braces `BRACE_STIFFNESS` 0.7→0.9, `BRACE_DAMPING` 0.2→0.4. Legs now give a little under load but firmly spring back to their 15px rest length — wheels stay put and can't stay stretched. The firmer frame also roughly halves the launch wheelie.
- Throttle eased: `MOTOR_ACCEL` 0.12→0.09, `MAX_WHEEL_SPIN` 22→20. Deliberate wheelies (held lean-back) still work.
- (An explicit anti-wheelie assist was tried and removed — front-wheel lift is normal on rough terrain, so it fought climbing/jumps.)

### 2. Sprite placement to match reference art
Using the assembled-bike reference the user provided:
- Wheels drawn beefier (`BIKE_WHEEL_SCALE` factor 2.1→2.35 of `WHEEL_R`) so they read as the fat, nearly-touching motocross wheels the art intends, rather than small wheels set too far apart.
- Rider dropped onto the seat (`RIDER_OFFSET_Y` −18→−11, `RIDER_OFFSET_X` −6→−4) so he sits on the bike with hands on the bars instead of floating above it.
- Purely draw-time positioning/scaling — no physics or collision change.

- Bumped the PWA cache version (gameplay + visual change), same as prior updates.

## Test plan (headless-browser probes + visual comparison)

- [x] Launch wheelie: ~52° before → ~28° after
- [x] Suspension legs hold ~15px at idle and stay within ~1px under power (was swinging ~12–20px)
- [x] Climb reach on levels 1 and 5 at or above the previous build
- [x] Deliberate wheelie via held lean-back still lifts the front fully
- [x] Side-by-side vs the reference: wheel size/spacing and rider seating now match; verified at rest, driving, and cresting with no console/page errors
