### PR TITLE
Prevent double-tap/double-click zoom on Squeak the Geek

### DIFF
--- a/squeak-the-geek.html
+++ b/squeak-the-geek.html
@@ -356,6 +356,15 @@ permalink: /squeak-the-geek/
         (function () {
             'use strict';
 
+            // Block double-tap-to-zoom and double-click-to-zoom gestures
+            document.addEventListener('dblclick', (e) => e.preventDefault());
+            let lastTouchEnd = 0;
+            document.addEventListener('touchend', (e) => {
+                const now = Date.now();
+                if (now - lastTouchEnd <= 350) e.preventDefault();
+                lastTouchEnd = now;
+            }, { passive: false });
+
             const canvas = document.getElementById('canvas');
             const ctx = canvas.getContext('2d');
             const canvasWrap = document.getElementById('canvasWrap');


### PR DESCRIPTION
## Summary
- The `touch-action: none` CSS on Squeak the Geek wasn't enough to stop the browser's double-tap-to-zoom gesture on some mobile browsers.
- Added explicit JS listeners (`dblclick` and rapid successive `touchend`) that call `preventDefault()` to suppress the zoom, without interfering with normal single taps.

## Test plan
- [x] `bundle exec jekyll build` succeeds with no errors
- [x] Verified with Playwright (mobile viewport, touch emulation) that a single tap on the Play button still registers normally after the change
- [ ] Manual double-tap test on a real phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PabAKFXEUQx8Tw1qJABiPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PabAKFXEUQx8Tw1qJABiPP)_