### PR TITLE
Open the points progression animation in landscape by default

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -393,7 +393,6 @@ const TRANSLATIONS = {
     you_default: "You",
     you_suffix: " (you)",
     leaderboard_title: "🏆 Leaderboard",
-    add_rival_btn: "📲 Share with friends",
     remove_rival: "Remove rival",
     compete_friends: "Compete with friends",
     compete_friends_desc: "Share your QR — anyone who scans it joins your leaderboard. The app flashes when someone nails a score.",
@@ -679,7 +678,6 @@ const TRANSLATIONS = {
     you_default: "Você",
     you_suffix: " (você)",
     leaderboard_title: "🏆 Ranking",
-    add_rival_btn: "📲 Compartilhar com amigos",
     remove_rival: "Remover rival",
     compete_friends: "Compita com amigos",
     compete_friends_desc: "Compartilhe seu QR — quem escanear entra no seu ranking. O app pisca quando alguém acerta um placar.",
@@ -2434,20 +2432,11 @@ function RivalsLeaderboard({ rivals, myName, myPts, groupMatches, ko, canShare, 
         <div style={{ fontSize:9, color:ACCENT, letterSpacing:2, fontWeight:700, textTransform:'uppercase' }}>
           {t('leaderboard_title')}
         </div>
-        <div style={{ display:'flex', gap:6, flexShrink:0 }}>
-          <button onClick={onShowProgress} style={{
-            background:'transparent', border:`1px solid rgba(167,139,250,0.3)`,
-            color:PURPLE, borderRadius:7, padding:'4px 10px',
-            fontSize:10, fontWeight:700, cursor:'pointer', fontFamily:'inherit',
-          }}>{t('progress_btn')}</button>
-          {canShare && (
-            <button onClick={onShare} style={{
-              background:'transparent', border:`1px solid rgba(0,208,132,0.3)`,
-              color:ACCENT, borderRadius:7, padding:'4px 10px',
-              fontSize:10, fontWeight:700, cursor:'pointer', fontFamily:'inherit',
-            }}>{t('add_rival_btn')}</button>
-          )}
-        </div>
+        <button onClick={onShowProgress} style={{
+          background:'transparent', border:`1px solid rgba(167,139,250,0.3)`,
+          color:PURPLE, borderRadius:7, padding:'4px 10px',
+          fontSize:10, fontWeight:700, cursor:'pointer', fontFamily:'inherit', flexShrink:0,
+        }}>{t('progress_btn')}</button>
       </div>
 
       <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', gap:6, marginBottom:8 }}>

--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -2550,6 +2550,21 @@ function RivalsLeaderboard({ rivals, myName, myPts, groupMatches, ko, canShare, 
 }
 
 // ─── Points Progression Animation ──────────────────────────────────────────────
+// Best-effort landscape lock for the progression animation, so it opens
+// already in the wider layout instead of asking people to manually rotate.
+// Called synchronously from the button's onClick (not a useEffect on mount)
+// so it stays inside the user-gesture / transient-activation window most
+// browsers require. Android Chrome (incl. installed PWA) honors this; iOS
+// Safari has never implemented the Orientation Lock API at all, so it's a
+// silent no-op there and the modal just falls back to whatever orientation
+// the phone is already in — the manual-rotate landscape layout still works.
+function tryLockLandscape() {
+  try { screen.orientation?.lock?.('landscape')?.catch(() => {}); } catch (e) {}
+}
+function tryUnlockOrientation() {
+  try { screen.orientation?.unlock?.(); } catch (e) {}
+}
+
 // Fixed categorical order for rival lines — "me" always uses ACCENT (the app's
 // established "you" color), so this set only needs to stay distinguishable from
 // that green and from itself (checked with dataviz's palette validator against
@@ -4028,14 +4043,14 @@ function GuessesView({ groupMatches, ko, predictions, onGroupPred, onKOPred, isM
         groupMatches={groupMatches} ko={ko} canShare={canShare}
         onShare={onShare} onRemove={onRemoveRival}
         compareRival={compareRival} onToggleCompare={toggleCompare}
-        onShowProgress={() => setShowProgress(true)}
+        onShowProgress={() => { tryLockLandscape(); setShowProgress(true); }}
       />
 
       {showProgress && (
         <PointsProgressionModal
           groupMatches={groupMatches} ko={ko}
           myName={playerName} predictions={predictions} rivals={rivals}
-          onClose={() => setShowProgress(false)}
+          onClose={() => { tryUnlockOrientation(); setShowProgress(false); }}
         />
       )}
 

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026070308';
+const CACHE_VERSION = '2026070309';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = [

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2026070307';
+const CACHE_VERSION = '2026070308';
 const CACHE_NAME = `worldcup-2026-${CACHE_VERSION}`;
 const OFFLINE_URL = '/worldcup-2026/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary
- Tapping the "📈 Progression" button now also requests a landscape orientation lock (`screen.orientation.lock('landscape')`), so the animation opens directly into the wider landscape layout (bigger chart, ranked side list) added in #215/#217 instead of requiring people to manually rotate their phone
- The lock is released on close (✕ or backdrop tap), whichever path is used
- Called synchronously inside the button's `onClick` (not a `useEffect` on mount) to stay within the user-gesture / transient-activation window most browsers require for this API
- Progressive enhancement, not a hard requirement: wrapped in try/catch with the promise rejection swallowed — Android Chrome (including installed PWAs) honors it; iOS Safari has never implemented the Orientation Lock API at all, so it silently no-ops there and the modal simply opens in whatever orientation the phone is already in, same as before this change

## Test plan
- [x] Verified locally that clicking "Progression" and closing via both the ✕ button and backdrop tap produces no console/JS errors, with the lock attempt silently failing (as expected in a desktop headless browser, which doesn't support the API) and falling back cleanly to the existing portrait layout
- [ ] Real-device check on Android Chrome to confirm the rotation actually occurs — not possible to verify in this environment (no mobile device/sensor emulation available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01S5JqzFj2jnBrPypiifBFJs)_