### PR TITLE
Auto-scale progression chart to fit visible lines

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -2644,8 +2644,11 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
 
   const W = 640, H = 210, padL = 6, padR = 6, padT = 16, padB = 6;
   const plotW = W - padL - padR, plotH = H - padT - padB;
-  const maxY = Math.max(3, ...data.frames.map(f => Math.max(...f.cum)));
-  const xAt = i => total <= 1 ? padL + plotW / 2 : padL + (plotW * i) / (total - 1);
+  const visibleMax = revealIdx > 0
+    ? Math.max(...data.frames.slice(0, revealIdx).map(f => Math.max(...f.cum)))
+    : 0;
+  const maxY = Math.ceil(Math.max(3, visibleMax) * 1.12);
+  const xAt = i => revealIdx <= 1 ? padL + plotW / 2 : padL + (plotW * i) / (revealIdx - 1);
   const yAt = v => padT + plotH - (plotH * v) / maxY;
 
   const shown = revealIdx;


### PR DESCRIPTION
## Summary

- **Y-axis** now dynamically scales to the maximum value of currently revealed frames (with 12% headroom), instead of being fixed at the global maximum. Lines fill the chart area at every point in the animation, making differences between players visible from the very first match.
- **X-axis** spreads visible data points across the full chart width, so early matches aren't bunched on the left side of a mostly-empty graph.

## Test plan

- [ ] Open the Points Progression modal and let the animation play from the start — lines should fill the chart vertically and horizontally at every step
- [ ] Scrub the slider back and forth — the chart should smoothly rescale to fit the visible data
- [ ] Verify the chart still looks correct at the end (all 72 matches revealed)
- [ ] Test with different numbers of rivals to ensure scaling works with varying line counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WhC3pJiUC3dhZoKS7NVPk

---
_Generated by [Claude Code](https://claude.ai/code/session_013WhC3pJiUC3dhZoKS7NVPk)_