### PR TITLE
Default knockout tab to current stage when scores are up to date

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -5398,7 +5398,6 @@ function StandingsView({groupMatches,isMobile,onShowFixtures}){
 // ─── KNOCKOUT VIEW ─────────────────────────────────────────────────────────────
 function KnockoutView({ko,onScore,isMobile,navHeight,groupMatches,onRefreshScores,refreshing,lastUpdated}){
   const { t } = useLang();
-  const [round,setRound]=useState("r32");
   const ROUNDS=[
     {key:"r32",label:"R32",fullLabel:t('round_r32')},
     {key:"r16",label:"R16",fullLabel:t('round_r16')},
@@ -5407,6 +5406,17 @@ function KnockoutView({ko,onScore,isMobile,navHeight,groupMatches,onRefreshScore
     {key:"third",label:t('finish_3rd'),fullLabel:t('round_third')},
     {key:"final",label:"🏆 Final",fullLabel:t('round_final')},
   ];
+  const [round,setRound]=useState(()=>{
+    const now=Date.now();
+    const allPastScored=ROUNDS.every(r=>ko[r.key].every(m=>{
+      if(!m.date||m.date==="TBD") return true;
+      if(matchToUTC(m.date,m.time).getTime()>now) return true;
+      return m.scoreA!==null&&m.scoreB!==null;
+    }));
+    if(!allPastScored) return "r32";
+    const current=ROUNDS.find(r=>ko[r.key].some(m=>m.scoreA===null||m.scoreB===null));
+    return current?current.key:"r32";
+  });
   const matches=ko[round];
   const currentRound=ROUNDS.find(r=>r.key===round);
   const dateRefs=useRef({});


### PR DESCRIPTION
## Summary\n\n- On the knockout page, the default tab is now the current active round instead of always R32\n- Only activates when all past-kickoff matches have scores set (i.e. scores are being kept up to date)\n- Falls back to R32 if any finished game is missing a score (manual/prediction mode)\n\n## How it works\n\nOn mount, the `useState` initializer checks every knockout match across all rounds:\n1. If a match hasn't kicked off yet or has no date → skip (not expected to have a score)\n2. If a match has kicked off but has no score → scores aren't up to date, fall back to R32\n3. If all past matches are scored, select the first round that still has unfinished matches\n\nThis means users following the tournament live will automatically land on the round currently being played, while users in prediction/manual mode (who haven't filled in past scores) still start at R32.\n\n## Test plan\n\n- [ ] With no scores set, knockout page defaults to R32\n- [ ] With all past-kickoff matches scored, knockout page defaults to the first incomplete round\n- [ ] Manual tab switching still works as before

---
_Generated by [Claude Code](https://claude.ai/code/session_0147ootnPNaVYoKEfFRWSeG1)_