### PR TITLE
Fix knockout default tab to use time-based detection

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -5411,14 +5411,12 @@ function KnockoutView({ko,onScore,isMobile,navHeight,groupMatches,onRefreshScore
   ];
   const [round,setRound]=useState(()=>{
     const now=Date.now();
-    const allPastScored=ROUNDS.every(r=>ko[r.key].every(m=>{
-      if(!m.date||m.date==="TBD") return true;
-      if(matchToUTC(m.date,m.time).getTime()>now) return true;
-      return m.scoreA!==null&&m.scoreB!==null;
-    }));
-    if(!allPastScored) return "r32";
-    const current=ROUNDS.find(r=>ko[r.key].some(m=>m.scoreA===null||m.scoreB===null));
-    return current?current.key:"r32";
+    for(let i=ROUNDS.length-1;i>=0;i--){
+      const matches=ko[ROUNDS[i].key];
+      const hasKickedOff=matches.some(m=>m.date&&m.date!=="TBD"&&matchToUTC(m.date,m.time).getTime()<=now);
+      if(hasKickedOff) return ROUNDS[i].key;
+    }
+    return "r32";
   });
   const matches=ko[round];
   const currentRound=ROUNDS.find(r=>r.key===round);


### PR DESCRIPTION
## Summary\n\n- Fixes the knockout tab defaulting to R32 even when R32 matches have all kicked off\n- The previous approach required all past-kickoff matches to have scores set, which failed when scores.json hadn't fetched KO results yet\n- Now uses a purely time-based approach: finds the latest round that has at least one match whose kickoff time has passed, and defaults to that round\n\n## How it works\n\nIterates rounds in reverse order (final → r32) and picks the first one where any match has already kicked off. This means on July 5 when R16 matches start, the tab defaults to R16 — regardless of whether R32 scores have been entered.\n\n## Test plan\n\n- [ ] Before any knockout matches kick off, defaults to R32\n- [ ] When R32 matches have kicked off (even without scores), still shows R32 as current\n- [ ] When R16 matches start kicking off, defaults to R16\n- [ ] Manual tab switching still works

---
_Generated by [Claude Code](https://claude.ai/code/session_0147ootnPNaVYoKEfFRWSeG1)_