### PR TITLE
Animate rival name transitions in progression modal

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -2826,15 +2826,21 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
                its own in landscape so the controls below stay pinned and
                reachable however many rivals are in the list. */}
             <div className="pp-legend-scroll">
-              <div className="pp-legend" style={{ display:'flex', flexWrap:'wrap', gap:6 }}>
-                {rankedPlayers.map(({ p, pi, val }) => {
+              <div className="pp-legend" style={{ display:'flex', flexDirection:'column', gap:6 }}>
+                {data.players.map((p, pi) => {
+                  const rank = rankedPlayers.findIndex(r => r.pi === pi);
+                  const val = shown > 0 ? data.frames[shown - 1].cum[pi] : 0;
                   const isExact = exactNames.includes(p.n);
+                  const ROW_STRIDE = 32;
                   return (
                     <div key={p.n} style={{
                       display:'flex', alignItems:'center', justifyContent:'space-between', gap:8,
                       background: isExact ? 'rgba(255,215,0,0.14)' : 'rgba(255,255,255,0.04)',
                       border:`1px solid ${isExact ? 'rgba(255,215,0,0.55)' : BORDER}`,
                       borderRadius:8, padding:'4px 8px',
+                      height:26, boxSizing:'border-box', flexShrink:0, width:'100%',
+                      transform:`translateY(${(rank - pi) * ROW_STRIDE}px)`,
+                      transition:'transform 0.35s ease-out',
                     }}>
                       <span style={{ display:'flex', alignItems:'center', gap:5, minWidth:0 }}>
                         <span style={{ width:8, height:8, borderRadius:'50%', background:colors[pi], flexShrink:0 }}/>


### PR DESCRIPTION
## Summary

- Animate the legend panel in the Points Progression modal so rival names smoothly slide to their new positions when rankings change, instead of instantly snapping into place
- Renders legend items in stable data order (by player index) and uses CSS `translateY` transforms based on current rank, with a `0.35s ease-out` transition for smooth movement
- Fixed item height ensures deterministic row stride for accurate transform calculations

## Test plan

- [ ] Open the Progression modal with 2+ rivals
- [ ] Watch the animation play — when a rival overtakes another, their legend entries should smoothly slide past each other
- [ ] Scrub the timeline back and forth — legend items should animate to their new ranked positions
- [ ] Verify layout looks correct in both portrait and landscape orientations


---
_Generated by [Claude Code](https://claude.ai/code/session_018CrSYJmEZhGfTz9JVramB9)_