### PR TITLE
Slow down rival name transition in progression modal

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -2840,7 +2840,7 @@ function PointsProgressionModal({ groupMatches, ko, myName, predictions, rivals,
                       borderRadius:8, padding:'4px 8px',
                       height:26, boxSizing:'border-box', flexShrink:0, width:'100%',
                       transform:`translateY(${(rank - pi) * ROW_STRIDE}px)`,
-                      transition:'transform 0.35s ease-out',
+                      transition:'transform 0.6s ease-out',
                     }}>
                       <span style={{ display:'flex', alignItems:'center', gap:5, minWidth:0 }}>
                         <span style={{ width:8, height:8, borderRadius:'50%', background:colors[pi], flexShrink:0 }}/>


### PR DESCRIPTION
## Summary

- Increases the rival name slide transition from 0.35s to 0.6s for a smoother, more readable animation when rankings change in the progression modal legend

## Test plan

- [ ] Open Progression modal with rivals and watch rank changes — names should slide noticeably slower than before


---
_Generated by [Claude Code](https://claude.ai/code/session_018CrSYJmEZhGfTz9JVramB9)_