### PR TITLE
Elasto Mania: procedural levels with ramp-cliff-wall obstacles

### DIFF
--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -92,7 +92,7 @@ permalink: /elastomania/
   </div>
 
   <script>
-    const SW_VERSION = '2607060146';
+    const SW_VERSION = '2607091500';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function showBanner(reg) {
@@ -189,158 +189,147 @@ permalink: /elastomania/
     const SPAWN_X = 80;
     const SPAWN_Y = 400;
 
-    // ── Levels ─────────────────────────────────────────────────
-    // Each level is progressively longer, with steeper slopes and bigger
-    // elevation swings, so momentum management and jump timing both get
-    // harder as you advance. Apples sit just above local hill crests, so
-    // higher levels increasingly reward catching air rather than just
-    // riding through.
-    const LEVELS = [
-      {
-        name: 'Green Hills',
-        worldW: 2800,
-        terrain: [
-          [0,420],[100,420],[160,415],[230,390],[300,360],[370,370],
-          [430,400],[480,408],[540,370],[610,330],[670,308],[720,330],
-          [780,370],[840,400],[900,370],[950,320],[1000,270],[1050,248],
-          [1100,258],[1160,285],[1220,330],[1280,382],[1340,400],
-          [1400,380],[1460,340],[1520,300],[1560,270],[1600,258],
-          [1650,280],[1710,320],[1780,370],[1840,400],[1920,410],
-          [2000,400],[2060,370],[2120,328],[2180,298],[2240,278],
-          [2300,292],[2360,322],[2420,360],[2480,392],[2540,402],
-          [2600,408],[2660,408],[2750,420],[2800,420]
-        ],
-        apples: [
-          { x: 670,  y: 278 },
-          { x: 1050, y: 222 },
-          { x: 1600, y: 232 },
-          { x: 1920, y: 382 },
-          { x: 2240, y: 252 }
-        ],
-        flower: { x: 2600, y: 378 }
-      },
-      {
-        name: 'Rolling Ridge',
-        worldW: 3200,
-        terrain: [
-          [0,400],[60,400],[120,400],[180,337],[240,340],[300,366],
-          [360,429],[420,430],[480,430],[540,430],[600,430],[660,407],
-          [720,423],[780,406],[840,399],[900,356],[960,301],[1020,308],
-          [1080,323],[1140,383],[1200,430],[1260,430],[1320,430],[1380,430],
-          [1440,430],[1500,430],[1560,430],[1620,430],[1680,395],[1740,332],
-          [1800,313],[1860,309],[1920,351],[1980,393],[2040,387],[2100,401],
-          [2160,398],[2220,423],[2280,430],[2340,430],[2400,430],[2460,430],
-          [2520,372],[2580,354],[2640,335],[2700,356],[2760,372],[2820,345],
-          [2880,348],[2940,345],[3000,400],[3060,400],[3120,400],[3180,400],
-          [3200,400]
-        ],
-        apples: [
-          { x: 960,  y: 269 },
-          { x: 1786, y: 286 },
-          { x: 1860, y: 277 },
-          { x: 2157, y: 366 },
-          { x: 2529, y: 337 },
-          { x: 2640, y: 303 }
-        ],
-        flower: { x: 3060, y: 378 }
-      },
-      {
-        name: 'Canyon Run',
-        worldW: 3800,
-        terrain: [
-          [0,400],[60,400],[120,400],[180,430],[240,430],[300,430],
-          [360,430],[420,430],[480,430],[540,360],[600,288],[660,306],
-          [720,315],[780,350],[840,379],[900,340],[960,364],[1020,396],
-          [1080,430],[1140,430],[1200,430],[1260,430],[1320,430],[1380,361],
-          [1440,363],[1500,360],[1560,352],[1620,362],[1680,299],[1740,288],
-          [1800,322],[1860,364],[1920,430],[1980,430],[2040,430],[2100,430],
-          [2160,427],[2220,429],[2280,430],[2340,414],[2400,406],[2460,334],
-          [2520,264],[2580,276],[2640,291],[2700,363],[2760,430],[2820,430],
-          [2880,430],[2940,430],[3000,430],[3060,430],[3120,430],[3180,430],
-          [3240,407],[3300,335],[3360,292],[3420,276],[3480,323],[3540,383],
-          [3600,400],[3660,400],[3720,400],[3780,400],[3800,400]
-        ],
-        apples: [
-          { x: 600,  y: 254 },
-          { x: 1740, y: 254 },
-          { x: 2160, y: 393 },
-          { x: 2300, y: 391 },
-          { x: 2700, y: 329 },
-          { x: 3100, y: 396 },
-          { x: 3420, y: 242 }
-        ],
-        flower: { x: 3660, y: 378 }
-      },
-      {
-        name: 'Cliffside Dash',
-        worldW: 4400,
-        terrain: [
-          [0,400],[60,400],[120,400],[180,319],[240,350],[300,375],
-          [360,393],[420,417],[480,385],[540,430],[600,430],[660,430],
-          [720,430],[780,430],[840,367],[900,328],[960,272],[1020,320],
-          [1080,350],[1140,312],[1200,328],[1260,299],[1320,335],[1380,416],
-          [1440,430],[1500,430],[1560,430],[1620,430],[1680,430],[1740,382],
-          [1800,372],[1860,408],[1920,338],[1980,295],[2040,258],[2100,223],
-          [2160,304],[2220,385],[2280,430],[2340,430],[2400,430],[2460,430],
-          [2520,430],[2580,430],[2640,430],[2700,430],[2760,356],[2820,302],
-          [2880,221],[2940,236],[3000,317],[3060,363],[3120,430],[3180,430],
-          [3240,407],[3300,430],[3360,430],[3420,430],[3480,430],[3540,430],
-          [3600,406],[3660,325],[3720,246],[3780,305],[3840,315],[3900,342],
-          [3960,363],[4020,310],[4080,360],[4140,427],[4200,400],[4260,400],
-          [4320,400],[4380,400],[4400,400]
-        ],
-        apples: [
-          { x: 960,  y: 236 },
-          { x: 2100, y: 187 },
-          { x: 2411, y: 394 },
-          { x: 2833, y: 248 },
-          { x: 2880, y: 185 },
-          { x: 3256, y: 377 },
-          { x: 3678, y: 266 },
-          { x: 3720, y: 210 }
-        ],
-        flower: { x: 4260, y: 378 }
-      },
-      {
-        name: 'Volcano Peak',
-        worldW: 5000,
-        terrain: [
-          [0,400],[60,400],[120,400],[180,422],[240,398],[300,396],
-          [360,430],[420,430],[480,430],[540,430],[600,430],[660,430],
-          [720,351],[780,261],[840,288],[900,271],[960,328],[1020,343],
-          [1080,270],[1140,312],[1200,345],[1260,427],[1320,430],[1380,430],
-          [1440,430],[1500,430],[1560,388],[1620,385],[1680,381],[1740,351],
-          [1800,372],[1860,282],[1920,205],[1980,240],[2040,261],[2100,351],
-          [2160,430],[2220,430],[2280,430],[2340,430],[2400,430],[2460,430],
-          [2520,430],[2580,430],[2640,410],[2700,320],[2760,230],[2820,199],
-          [2880,239],[2940,329],[3000,419],[3060,430],[3120,430],[3180,421],
-          [3240,430],[3300,430],[3360,430],[3420,430],[3480,430],[3540,340],
-          [3600,267],[3660,217],[3720,286],[3780,353],[3840,317],[3900,349],
-          [3960,335],[4020,362],[4080,430],[4140,430],[4200,430],[4260,430],
-          [4320,430],[4380,389],[4440,343],[4500,309],[4560,372],[4620,321],
-          [4680,263],[4740,260],[4800,350],[4860,400],[4920,400],[4980,400],
-          [5000,400]
-        ],
-        apples: [
-          { x: 300,  y: 356 },
-          { x: 780,  y: 221 },
-          { x: 1920, y: 165 },
-          { x: 2820, y: 159 },
-          { x: 3380, y: 390 },
-          { x: 3660, y: 177 },
-          { x: 3820, y: 289 },
-          { x: 4260, y: 390 },
-          { x: 4500, y: 269 }
-        ],
-        flower: { x: 4860, y: 378 }
-      }
+    // ── Seeded PRNG (mulberry32) ─────────────────────────────────
+    // Deterministic: same seed → same sequence, so every player gets
+    // identical levels.
+    function mulberry32(seed) {
+      let s = seed | 0;
+      return function () {
+        s = (s + 0x6D2B79F5) | 0;
+        let t = Math.imul(s ^ (s >>> 15), 1 | s);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    // ── Procedural level generator ────────────────────────────
+    const LEVEL_NAMES = [
+      'Green Hills', 'Rolling Ridge', 'Canyon Run', 'Cliffside Dash',
+      'Volcano Peak', 'Frozen Trail', 'Desert Storm', 'Jungle Rumble',
+      'Mountain Pass', 'Lava Fields', 'Crystal Caves', 'Thunder Ridge',
+      'Sunset Gorge', 'Broken Bridge', 'Sky Plateau', 'Shadow Valley'
     ];
+
+    function generateLevel(index) {
+      const rng = mulberry32(42 + index * 7919);
+
+      const difficulty = Math.min(index / 8, 1);
+      const worldW = Math.round(2800 + index * 440);
+      const name = LEVEL_NAMES[index % LEVEL_NAMES.length]
+        + (index >= LEVEL_NAMES.length ? ' ' + (Math.floor(index / LEVEL_NAMES.length) + 1) : '');
+
+      const FLAT_Y = 420;
+      const MIN_Y = 180 + Math.round((1 - difficulty) * 80);
+      const MAX_Y = 430;
+      const STEP = 60;
+      const segCount = Math.floor(worldW / STEP);
+
+      const terrain = [[0, FLAT_Y]];
+      let y = FLAT_Y;
+
+      // First few segments are flat for spawn safety
+      const flatStart = 2;
+      for (let i = 1; i <= flatStart; i++) terrain.push([i * STEP, FLAT_Y]);
+
+      // Generate terrain with controlled randomness
+      const maxSlope = 30 + difficulty * 40;
+      const hillChance = 0.35 + difficulty * 0.15;
+
+      for (let i = flatStart + 1; i < segCount - 2; i++) {
+        const x = i * STEP;
+        const progress = i / segCount;
+
+        // Tendency toward valleys (low ground) then hills in waves
+        const wave = Math.sin(progress * Math.PI * (2 + rng() * 2)) * (60 + difficulty * 80);
+        const jitter = (rng() - 0.5) * maxSlope;
+
+        let target = FLAT_Y + wave + jitter;
+        target = Math.max(MIN_Y, Math.min(MAX_Y, target));
+
+        // Limit slope between consecutive points
+        const maxDelta = maxSlope * 0.8;
+        const delta = Math.max(-maxDelta, Math.min(maxDelta, target - y));
+        y = y + delta;
+        y = Math.max(MIN_Y, Math.min(MAX_Y, Math.round(y)));
+
+        terrain.push([x, y]);
+      }
+
+      // Flatten the last few segments for flower placement
+      const endY = Math.min(400, y);
+      for (let i = segCount - 2; i <= segCount; i++) {
+        terrain.push([i * STEP, endY]);
+      }
+      terrain.push([worldW, endY]);
+
+      // Find hill crests for apple placement
+      const crests = [];
+      for (let i = 2; i < terrain.length - 3; i++) {
+        const [, yPrev] = terrain[i - 1];
+        const [xC, yC] = terrain[i];
+        const [, yNext] = terrain[i + 1];
+        if (yC < yPrev && yC < yNext && yC < FLAT_Y - 10) {
+          crests.push({ x: xC, y: yC, depth: FLAT_Y - yC });
+        }
+      }
+      crests.sort((a, b) => b.depth - a.depth);
+
+      const appleCount = 5 + Math.min(Math.floor(index * 0.8), 7);
+      const apples = [];
+      const usedZones = new Set();
+
+      for (const c of crests) {
+        if (apples.length >= appleCount) break;
+        const zone = Math.floor(c.x / 300);
+        if (usedZones.has(zone)) continue;
+        usedZones.add(zone);
+        apples.push({ x: c.x, y: c.y - 30 });
+      }
+
+      // Fill remaining apples at random positions along the track
+      let attempts = 0;
+      while (apples.length < appleCount && attempts < 200) {
+        attempts++;
+        const seg = Math.floor(rng() * (terrain.length - 6)) + 3;
+        const [ax, ay] = terrain[seg];
+        const zone = Math.floor(ax / 300);
+        if (usedZones.has(zone)) continue;
+        usedZones.add(zone);
+        apples.push({ x: ax, y: ay - 30 });
+      }
+
+      apples.sort((a, b) => a.x - b.x);
+
+      const flowerX = terrain[terrain.length - 3][0];
+      const flowerY = terrain[terrain.length - 3][1] - 22;
+
+      return { name, worldW, terrain, apples, flower: { x: flowerX, y: flowerY } };
+    }
+
+    // Cache generated levels so re-selecting a level is instant and
+    // the same object is reused (same terrain, same apples).
+    const levelCache = {};
+    function getLevel(index) {
+      if (!levelCache[index]) levelCache[index] = generateLevel(index);
+      return levelCache[index];
+    }
+
+    // LEVELS is now a thin accessor; level count is unlimited.
+    const TOTAL_LEVELS = 999;
+    const LEVELS = new Proxy([], {
+      get(target, prop) {
+        if (prop === 'length') return TOTAL_LEVELS;
+        const i = Number(prop);
+        if (Number.isInteger(i) && i >= 0) return getLevel(i);
+        return target[prop];
+      }
+    });
 
     const PROGRESS_KEY = 'elastomania_unlocked';
     function loadUnlockedCount() {
       try {
         const n = parseInt(localStorage.getItem(PROGRESS_KEY), 10);
-        if (Number.isFinite(n)) return Math.min(Math.max(n, 1), LEVELS.length);
+        if (Number.isFinite(n)) return Math.min(Math.max(n, 1), TOTAL_LEVELS);
       } catch (e) { /* localStorage unavailable (private mode, etc.) */ }
       return 1;
     }
@@ -356,9 +345,6 @@ permalink: /elastomania/
     let APPLES_DATA = LEVELS[0].apples;
     let FLOWER_DATA = LEVELS[0].flower;
 
-    // Swaps in the given level's terrain/apples/flower/world size. Called
-    // before initPhysics()/initPickups() so every system downstream just
-    // reads the current values without needing to know levels exist.
     function loadLevel(index) {
       currentLevelIndex = index;
       const lvl = LEVELS[index];
@@ -1029,12 +1015,19 @@ permalink: /elastomania/
       ctx.fillText(`Level ${selectedLevel + 1}: ${lvl.name}`, cx, cy - 48);
 
       const dotSpacing = 18;
-      const dotStartX  = cx - (LEVELS.length - 1) * dotSpacing / 2;
-      for (let i = 0; i < LEVELS.length; i++) {
-        const locked = i >= unlockedCount;
+      const maxDots = 15;
+      const dotCount = Math.min(unlockedCount, maxDots);
+      const halfWin = Math.floor(dotCount / 2);
+      let dotFirst = Math.max(0, selectedLevel - halfWin);
+      if (dotFirst + dotCount > unlockedCount) dotFirst = Math.max(0, unlockedCount - dotCount);
+      const dotLast = Math.min(dotFirst + dotCount - 1, unlockedCount - 1);
+      const actualCount = dotLast - dotFirst + 1;
+      const dotStartX = cx - (actualCount - 1) * dotSpacing / 2;
+      for (let i = dotFirst; i <= dotLast; i++) {
+        const di = i - dotFirst;
         ctx.beginPath();
-        ctx.arc(dotStartX + i * dotSpacing, cy - 14, i === selectedLevel ? 5 : 3.5, 0, Math.PI * 2);
-        ctx.fillStyle = locked ? 'rgba(255,255,255,0.2)' : (i === selectedLevel ? '#ffe08a' : '#ffffff');
+        ctx.arc(dotStartX + di * dotSpacing, cy - 14, i === selectedLevel ? 5 : 3.5, 0, Math.PI * 2);
+        ctx.fillStyle = i === selectedLevel ? '#ffe08a' : '#ffffff';
         ctx.fill();
       }
 

--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -92,7 +92,7 @@ permalink: /elastomania/
   </div>
 
   <script>
-    const SW_VERSION = '2607091500';
+    const SW_VERSION = '2607091530';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function showBanner(reg) {
@@ -224,50 +224,110 @@ permalink: /elastomania/
       const STEP = 60;
       const segCount = Math.floor(worldW / STEP);
 
+      // Build terrain in segments; some stretches are rolling hills,
+      // others are ramp → cliff → wall obstacles the player must brake
+      // for or die.
       const terrain = [[0, FLAT_Y]];
       let y = FLAT_Y;
+      let i = 1;
 
-      // First few segments are flat for spawn safety
+      // Flat spawn zone
       const flatStart = 2;
-      for (let i = 1; i <= flatStart; i++) terrain.push([i * STEP, FLAT_Y]);
+      for (; i <= flatStart; i++) terrain.push([i * STEP, FLAT_Y]);
 
-      // Generate terrain with controlled randomness
       const maxSlope = 30 + difficulty * 40;
-      const hillChance = 0.35 + difficulty * 0.15;
 
-      for (let i = flatStart + 1; i < segCount - 2; i++) {
+      // How many ramp obstacles to place (scales with difficulty)
+      const rampCount = 1 + Math.floor(difficulty * 3 + rng() * 1.5);
+      // Spread ramp placements roughly evenly across the track
+      const rampZoneSize = Math.floor((segCount - flatStart - 4) / (rampCount + 1));
+      const rampPositions = new Set();
+      for (let r = 0; r < rampCount; r++) {
+        const base = flatStart + 2 + rampZoneSize * (r + 1);
+        const jitter = Math.floor((rng() - 0.5) * rampZoneSize * 0.4);
+        rampPositions.add(Math.max(flatStart + 3, Math.min(segCount - 8, base + jitter)));
+      }
+
+      while (i < segCount - 2) {
         const x = i * STEP;
-        const progress = i / segCount;
 
-        // Tendency toward valleys (low ground) then hills in waves
+        if (rampPositions.has(i) && i < segCount - 7) {
+          // ── Ramp → cliff → wall obstacle ──
+          // Approach: gentle upslope (ramp), then a cliff drop, then a
+          // steep wall rise. If the player is going too fast they'll
+          // smash into the wall; they need to brake before the ramp.
+          const rampHeight = 40 + Math.round(difficulty * 60 + rng() * 30);
+          const gapWidth = 2 + Math.floor(rng() * 1.5);
+          const wallHeight = 30 + Math.round(difficulty * 50 + rng() * 20);
+
+          // Ramp up (2 segments)
+          const rampBase = y;
+          const rampTop = Math.max(MIN_Y, rampBase - rampHeight);
+          terrain.push([x, Math.round(rampBase - rampHeight * 0.4)]);
+          i++;
+          terrain.push([i * STEP, rampTop]);
+          i++;
+
+          // Cliff edge — drop to floor
+          const cliffBottom = Math.min(MAX_Y, rampTop + rampHeight + 30);
+          terrain.push([i * STEP, cliffBottom]);
+          i++;
+
+          // Gap floor (1–2 segments)
+          for (let g = 0; g < gapWidth; g++) {
+            terrain.push([i * STEP, cliffBottom]);
+            i++;
+          }
+
+          // Wall — steep rise the player will crash into if too fast
+          const wallTop = Math.max(MIN_Y, cliffBottom - wallHeight - rampHeight * 0.5);
+          terrain.push([i * STEP, Math.round(cliffBottom - (cliffBottom - wallTop) * 0.7)]);
+          i++;
+          terrain.push([i * STEP, wallTop]);
+          i++;
+
+          // Gentle descent back to rideable terrain
+          y = wallTop;
+          const recover = Math.min(MAX_Y, wallTop + 40 + rng() * 30);
+          terrain.push([i * STEP, Math.round(y + (recover - y) * 0.5)]);
+          i++;
+          y = Math.round(recover);
+          terrain.push([i * STEP, y]);
+          i++;
+
+          continue;
+        }
+
+        // ── Regular rolling terrain ──
+        const progress = i / segCount;
         const wave = Math.sin(progress * Math.PI * (2 + rng() * 2)) * (60 + difficulty * 80);
         const jitter = (rng() - 0.5) * maxSlope;
 
         let target = FLAT_Y + wave + jitter;
         target = Math.max(MIN_Y, Math.min(MAX_Y, target));
 
-        // Limit slope between consecutive points
         const maxDelta = maxSlope * 0.8;
         const delta = Math.max(-maxDelta, Math.min(maxDelta, target - y));
         y = y + delta;
         y = Math.max(MIN_Y, Math.min(MAX_Y, Math.round(y)));
 
         terrain.push([x, y]);
+        i++;
       }
 
       // Flatten the last few segments for flower placement
       const endY = Math.min(400, y);
-      for (let i = segCount - 2; i <= segCount; i++) {
+      for (; i <= segCount; i++) {
         terrain.push([i * STEP, endY]);
       }
       terrain.push([worldW, endY]);
 
       // Find hill crests for apple placement
       const crests = [];
-      for (let i = 2; i < terrain.length - 3; i++) {
-        const [, yPrev] = terrain[i - 1];
-        const [xC, yC] = terrain[i];
-        const [, yNext] = terrain[i + 1];
+      for (let j = 2; j < terrain.length - 3; j++) {
+        const [, yPrev] = terrain[j - 1];
+        const [xC, yC] = terrain[j];
+        const [, yNext] = terrain[j + 1];
         if (yC < yPrev && yC < yNext && yC < FLAT_Y - 10) {
           crests.push({ x: xC, y: yC, depth: FLAT_Y - yC });
         }

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607091500';
+const CACHE_VERSION = '2607091530';
 const CACHE_NAME = `elastomania-${CACHE_VERSION}`;
 const OFFLINE_URL = '/elastomania/';
 const PRECACHE_URLS = [

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607060146';
+const CACHE_VERSION = '2607091500';
 const CACHE_NAME = `elastomania-${CACHE_VERSION}`;
 const OFFLINE_URL = '/elastomania/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary

- **Seeded PRNG**: Uses mulberry32 with a fixed seed per level index (`42 + index * 7919`), so all players get identical terrain for each level number
- **Progressive difficulty**: Tracks get longer (+440px/level), terrain swings get steeper, and apple count increases (5 at level 1, up to 12 at higher levels)
- **Ramp-cliff-wall obstacles**: Levels include upward ramps that launch the bike over a cliff drop into a steep wall — players must brake before the ramp or crash head-first into the wall. The number and severity scale with difficulty (1 on early levels, up to 4 on harder ones)
- **Unlimited levels**: 999 levels via a Proxy-backed LEVELS array; generated on demand and cached
- **16 themed names** cycle with suffix numbers for repeats
- **Scrolling dot selector**: Shows up to 15 dots windowed around the current selection

## Test plan

- [ ] Play level 1 — gentle rolling hills with 1 ramp obstacle and 5 apples
- [ ] Play level 5 — steeper terrain, longer track, more ramp obstacles, 8 apples
- [ ] Drive full speed into a ramp → crash into the wall (BOOM!)
- [ ] Brake before a ramp → clear the obstacle safely
- [ ] Reload the page and replay level 1 — terrain must be identical (deterministic)
- [ ] Unlock 20+ levels (localStorage) — dot selector should show 15 dots with scrolling
- [ ] Complete a level — next level should unlock and be selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiXbpesGGMW27sfjRzZ49v