### PR TITLE
Rework Elasto Mania bike physics and wheel placement to match the original

### DIFF
--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -468,17 +468,17 @@ permalink: /elastomania/
     // Size and hip placement match the assembled reference shot: the rider
     // is big relative to the bike (helmet well above the handlebars, feet
     // reaching the pegs at the engine bottom).
-    const RIDER_SCALE    = 0.23;
+    const RIDER_SCALE    = 0.20;
     const RIDER_ANCHOR_X = 0.286;
     const RIDER_ANCHOR_Y = 0.569;
-    const RIDER_OFFSET_X = -12;
-    const RIDER_OFFSET_Y = 0;
+    const RIDER_OFFSET_X = -10;
+    const RIDER_OFFSET_Y = -3;
 
     // Point at the rider's helmet, in chassis-local space (before rotation)
     // — used as the hit-test spot for ground/terrain crashes so only the
     // head counts as a collision (as in the original game), not the wheels,
     // frame, or legs clipping a bump.
-    const UPPER_BODY_OFFSET = { x: -4, y: -29 };
+    const UPPER_BODY_OFFSET = { x: -3, y: -28 };
 
     function getUpperBodyPos() {
       const a = chassis.angle;

--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -151,7 +151,7 @@ permalink: /elastomania/
     // ── Constants ──────────────────────────────────────────────
     // WORLD_W varies per level and is declared with the LEVELS data below.
     const WORLD_H = 700;
-    const WHEEL_R = 14;
+    const WHEEL_R = 13;
     const CHASSIS_W = 55;
     const CHASSIS_H = 10;
     // Half the wheelbase. The original Elasto Mania bike has its wheels well
@@ -189,7 +189,7 @@ permalink: /elastomania/
     // held full gas hits 45° in ~1.2s (wheel inertia goes with r⁴, so this
     // compensates for the smaller wheel radius).
     const MOTOR_ACCEL    = 0.1;    // wheel spin gain per 16.67ms frame
-    const MOTOR_REACTION = 1.1;
+    const MOTOR_REACTION = 1.45;
     // Brake couples both wheels to the frame (locks them relative to it, no
     // reverse thrust) — turn around with the flip key instead, as in the
     // original.
@@ -471,7 +471,7 @@ permalink: /elastomania/
     const RIDER_SCALE    = 0.20;
     const RIDER_ANCHOR_X = 0.286;
     const RIDER_ANCHOR_Y = 0.569;
-    const RIDER_OFFSET_X = -10;
+    const RIDER_OFFSET_X = -7;
     const RIDER_OFFSET_Y = -3;
     // Lean the rider forward around his hip so his gloves rest on the
     // handlebar grips instead of hovering above them.
@@ -481,7 +481,7 @@ permalink: /elastomania/
     // — used as the hit-test spot for ground/terrain crashes so only the
     // head counts as a collision (as in the original game), not the wheels,
     // frame, or legs clipping a bump.
-    const UPPER_BODY_OFFSET = { x: 1, y: -27 };
+    const UPPER_BODY_OFFSET = { x: 4, y: -27 };
 
     function getUpperBodyPos() {
       const a = chassis.angle;

--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -473,12 +473,15 @@ permalink: /elastomania/
     const RIDER_ANCHOR_Y = 0.569;
     const RIDER_OFFSET_X = -10;
     const RIDER_OFFSET_Y = -3;
+    // Lean the rider forward around his hip so his gloves rest on the
+    // handlebar grips instead of hovering above them.
+    const RIDER_TILT     = 0.15;
 
     // Point at the rider's helmet, in chassis-local space (before rotation)
     // — used as the hit-test spot for ground/terrain crashes so only the
     // head counts as a collision (as in the original game), not the wheels,
     // frame, or legs clipping a bump.
-    const UPPER_BODY_OFFSET = { x: -3, y: -28 };
+    const UPPER_BODY_OFFSET = { x: 1, y: -27 };
 
     function getUpperBodyPos() {
       const a = chassis.angle;
@@ -982,6 +985,7 @@ permalink: /elastomania/
       ctx.translate(cp.x, cp.y);
       ctx.rotate(ca);
       ctx.translate(RIDER_OFFSET_X, RIDER_OFFSET_Y);
+      ctx.rotate(RIDER_TILT);
       const rw = riderImg.width * RIDER_SCALE;
       const rh = riderImg.height * RIDER_SCALE;
       ctx.drawImage(riderImg, -rw * RIDER_ANCHOR_X, -rh * RIDER_ANCHOR_Y, rw, rh);

--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -92,7 +92,7 @@ permalink: /elastomania/
   </div>
 
   <script>
-    const SW_VERSION = '2607100526';
+    const SW_VERSION = '2607101030';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function showBanner(reg) {
@@ -154,37 +154,46 @@ permalink: /elastomania/
     const WHEEL_R = 15;
     const CHASSIS_W = 55;
     const CHASSIS_H = 10;
-    // Half the wheelbase — each wheel hangs from this far ahead of / behind
-    // the chassis centre. Kept a touch tighter than the chassis so the fat
-    // wheels sit close under the frame, matching the reference art.
-    const WHEELBASE_HALF = 18;
-    const BRACE_HALF     = 7;
+    // Half the wheelbase. The original Elasto Mania bike has its wheels well
+    // apart — the wheelbase is about two wheel diameters — with the frame
+    // stretched between them, so the wheels sit at the fork/swingarm tips
+    // rather than tucked under the engine.
+    const WHEELBASE_HALF = 30;
 
-    // Suspension: the main leg from chassis to wheel. Stiff + well-damped so
-    // it gives a little under load but firmly springs back to its rest length
-    // — the wheels stay put under the bike (matching where the sprite draws
-    // the fork/swingarm) instead of drifting, and it can't stretch out and
-    // stay stretched. (A soft spring here let the wheels wander and also let
-    // the frame pitch up more, which exaggerated the throttle wheelie.)
+    // Suspension: one soft main leg from above each axle plus two stiffer
+    // braces from points closer to the chassis centre. Soft enough that the
+    // wheels visibly squash into the frame on landings and spring back — the
+    // bouncy Elasto Mania feel — while the three non-collinear attachment
+    // points make the wheel's rest pose the unique intersection of three
+    // circles, so it can't wander around the chassis or flip to the mirror
+    // solution the way a one- or two-link hookup can.
+    const SUSPENSION_ANCHOR_Y  = 5;
     const SUSPENSION_LENGTH    = 15;
-    const SUSPENSION_STIFFNESS = 0.9;
-    const SUSPENSION_DAMPING   = 0.5;
+    const SUSPENSION_STIFFNESS = 0.12;
+    const SUSPENSION_DAMPING   = 0.06;
+    const BRACE_STIFFNESS = 0.18;
+    const BRACE_DAMPING   = 0.06;
+    // Where a wheel sits in chassis space when the suspension is at rest.
+    const AXLE_REST_Y = SUSPENSION_ANCHOR_Y + SUSPENSION_LENGTH;
+    // Bump stop: a wheel can never rise above this chassis-local height —
+    // the fork bottoms out. Keeps violent landings from punching a wheel
+    // through the frame into the mirror equilibrium.
+    const BUMP_STOP_Y = 8;
 
-    // Secondary locating link per wheel — see note at rearBrace/frontBrace.
-    // Stiff, since its job is structural (stop the wheel from swinging around
-    // the chassis), not to add suspension feel.
-    const BRACE_STIFFNESS = 0.9;
-    const BRACE_DAMPING   = 0.4;
-
-    // Throttle: eased down from the old grabbier values so gassing from a
-    // standstill no longer pops the front end up into a hard wheelie. Paired
-    // with the stiffer suspension above, full throttle now lifts the nose only
-    // modestly; a deliberate wheelie still needs a held lean-back.
-    const MOTOR_ACCEL   = 0.09;   // angular accel per 16.67ms frame
-    const BRAKE_ACCEL   = 0.2;
-    const MAX_WHEEL_SPIN  = 20;
-    const MAX_BRAKE_SPIN  = -8;
-    const LEAN_ACCEL    = 0.08;
+    // Engine torque acts BETWEEN the rear wheel and the frame, like the real
+    // game: gassing spins the wheel up and kicks the frame back (nose-up), so
+    // holding full throttle from a standstill loops you over backwards in
+    // about a second and a half unless you lean forward, and throttle/brake
+    // rotate the bike in mid-air. MOTOR_REACTION scales how much of the
+    // ideal I_wheel/I_chassis reaction reaches the frame.
+    const MOTOR_ACCEL    = 0.1;    // wheel spin gain per 16.67ms frame
+    const MOTOR_REACTION = 0.8;
+    // Brake couples both wheels to the frame (locks them relative to it, no
+    // reverse thrust) — turn around with the flip key instead, as in the
+    // original.
+    const BRAKE_LOCK     = 0.25;   // per-frame lock-up fraction
+    const MAX_WHEEL_SPIN = 20;
+    const LEAN_ACCEL     = 0.09;
 
     const SPAWN_X = 80;
     const SPAWN_Y = 400;
@@ -430,16 +439,18 @@ permalink: /elastomania/
     bikeBodyImg.src    = '/elastomania/img/bike-body.png';
     const bikeWheelImg = new Image();
     bikeWheelImg.src   = '/elastomania/img/bike-wheel.png';
-    // Scale so the art's fork cluster (~x=230) to swingarm/chain cluster
-    // (~x=85) span — where the wheels visually belong — matches the real
-    // wheelbase (40 world units): 40 / (230-85) ≈ 0.276. The anchor sits at
-    // the midpoint between those two clusters (~x=157) and near the bottom
-    // of the engine block (the wheels themselves are separate, unused parts
-    // of the sheet), then nudges down to roughly axle height.
-    const BIKE_BODY_SCALE    = 0.248;
-    const BIKE_BODY_ANCHOR_X = 0.485;
-    const BIKE_BODY_ANCHOR_Y = 0.99;
-    const BIKE_BODY_OFFSET_Y = 13;
+    // Axle points measured off bike-body.png: the pronged swingarm clamp at
+    // the sprite's rear tip and the fork tip at its front. Mapping these two
+    // art pixels onto the wheels' rest positions in chassis space (a
+    // similarity transform: scale + slight rotation, since the art's axle
+    // line isn't quite horizontal) puts the frame exactly over the wheels —
+    // fork on the front axle, swingarm on the rear axle.
+    const BODY_ART_REAR_AXLE  = { x: 8,   y: 68 };
+    const BODY_ART_FRONT_AXLE = { x: 314, y: 95 };
+    const BODY_ART_DX = BODY_ART_FRONT_AXLE.x - BODY_ART_REAR_AXLE.x;
+    const BODY_ART_DY = BODY_ART_FRONT_AXLE.y - BODY_ART_REAR_AXLE.y;
+    const BIKE_BODY_SCALE = (WHEELBASE_HALF * 2) / Math.hypot(BODY_ART_DX, BODY_ART_DY);
+    const BIKE_BODY_ROT   = -Math.atan2(BODY_ART_DY, BODY_ART_DX);
     const BIKE_WHEEL_SCALE   = (WHEEL_R * 2.1) / 108;
     // Only spin the wheel art at a fraction of the real wheel speed so the
     // spokes read as a calm roll instead of a dizzy strobe at full throttle.
@@ -450,17 +461,19 @@ permalink: /elastomania/
     // Rider art is a seated/crouched pose; anchor at the hip (where the
     // thighs bend to horizontal) rather than image center, so that point
     // lands on the bike's seat instead of floating above or sinking into it.
-    const RIDER_SCALE    = 0.26;
+    // Scaled so the feet reach the pegs at the engine bottom now that the
+    // body art is smaller (it spans the wider wheelbase).
+    const RIDER_SCALE    = 0.17;
     const RIDER_ANCHOR_X = 0.286;
     const RIDER_ANCHOR_Y = 0.569;
-    const RIDER_OFFSET_X = -3;
-    const RIDER_OFFSET_Y = -6;
+    const RIDER_OFFSET_X = -13;
+    const RIDER_OFFSET_Y = 12;
 
-    // Point on the rider's torso/chest, in chassis-local space (before
-    // rotation) — used as the hit-test spot for ground/terrain crashes so
-    // only the upper body counts as a collision, not the wheels, frame, or
-    // legs clipping a bump.
-    const UPPER_BODY_OFFSET = { x: -10, y: -45 };
+    // Point at the rider's helmet, in chassis-local space (before rotation)
+    // — used as the hit-test spot for ground/terrain crashes so only the
+    // head counts as a collision (as in the original game), not the wheels,
+    // frame, or legs clipping a bump.
+    const UPPER_BODY_OFFSET = { x: -6, y: -16 };
 
     function getUpperBodyPos() {
       const a = chassis.angle;
@@ -554,44 +567,41 @@ permalink: /elastomania/
       });
       // Real bike frames strongly resist pitching (rider + engine mass sits
       // well away from the wheel axles). The thin default rectangle body is
-      // too easy to snap-rotate, which let throttle alone flip the bike into
-      // an instant, uncontrollable wheelie — bump pitch inertia way up
-      // without changing its mass (so suspension loading stays the same).
+      // too easy to snap-rotate — bump pitch inertia up without changing its
+      // mass (so suspension loading stays the same). Tuned together with
+      // MOTOR_REACTION so a held full throttle loops the bike backwards in
+      // roughly a second and a half, like the original.
       Body.setInertia(chassis, chassis.inertia * 6);
 
-      // Each wheel is hung from the chassis by TWO non-collinear links, not
-      // one. A single distance constraint only pins the wheel's distance
-      // from one chassis point — the chassis is then free to swing around
-      // that point, and "chassis riding above the wheel" is an *unstable*
-      // equilibrium (like a pendulum bob above its pivot): gravity plus any
-      // tiny numerical nudge eventually swings it around to hang below,
-      // which reads as the frame silently collapsing onto the wheels even
-      // though every individual constraint length looks fine. A second link
-      // from a different chassis point locks the angular relationship too,
-      // so the whole leg can only flex straight along its own axis
-      // (compress on landings, overstretch under a hard impact) instead of
-      // rotating around the wheel.
-      const rearConstraint = Constraint.create({
-        bodyA: chassis, bodyB: rearWheel,
-        pointA: { x: -WHEELBASE_HALF, y: 5 }, pointB: { x: 0, y: 0 },
-        stiffness: SUSPENSION_STIFFNESS, damping: SUSPENSION_DAMPING, length: SUSPENSION_LENGTH
-      });
-      const rearBrace = Constraint.create({
-        bodyA: chassis, bodyB: rearWheel,
-        pointA: { x: -BRACE_HALF, y: -3 }, pointB: { x: 0, y: 0 },
-        stiffness: BRACE_STIFFNESS, damping: BRACE_DAMPING
-      });
-
-      const frontConstraint = Constraint.create({
-        bodyA: chassis, bodyB: frontWheel,
-        pointA: { x: WHEELBASE_HALF, y: 5 }, pointB: { x: 0, y: 0 },
-        stiffness: SUSPENSION_STIFFNESS, damping: SUSPENSION_DAMPING, length: SUSPENSION_LENGTH
-      });
-      const frontBrace = Constraint.create({
-        bodyA: chassis, bodyB: frontWheel,
-        pointA: { x: BRACE_HALF, y: -3 }, pointB: { x: 0, y: 0 },
-        stiffness: BRACE_STIFFNESS, damping: BRACE_DAMPING
-      });
+      // Each wheel hangs from the chassis by THREE links: the soft main
+      // suspension leg plus two stiffer braces from separate points. With
+      // only one or two attachment points a soft suspension has a second
+      // (mirrored) equilibrium where the wheel sits beside/above the frame,
+      // and a violent impact can flip the wheel into it, where it sticks.
+      // Three non-collinear anchors make the rest pose unique
+      // (trilateration), so the leg can compress and stretch but not
+      // migrate. Anchor heights sit at or below the chassis centre so drive
+      // force is transmitted below the centre of mass — accelerating pitches
+      // the nose up, as it should.
+      function wheelLinks(wheel, side) {
+        return [
+          Constraint.create({
+            bodyA: chassis, bodyB: wheel,
+            pointA: { x: side * WHEELBASE_HALF, y: SUSPENSION_ANCHOR_Y }, pointB: { x: 0, y: 0 },
+            stiffness: SUSPENSION_STIFFNESS, damping: SUSPENSION_DAMPING, length: SUSPENSION_LENGTH
+          }),
+          Constraint.create({
+            bodyA: chassis, bodyB: wheel,
+            pointA: { x: side * 12, y: 2 }, pointB: { x: 0, y: 0 },
+            stiffness: BRACE_STIFFNESS, damping: BRACE_DAMPING
+          }),
+          Constraint.create({
+            bodyA: chassis, bodyB: wheel,
+            pointA: { x: side * 24, y: 0 }, pointB: { x: 0, y: 0 },
+            stiffness: BRACE_STIFFNESS, damping: BRACE_DAMPING
+          })
+        ];
+      }
 
       const terrainBodies = [];
       for (let i = 0; i < TERRAIN.length - 1; i++) {
@@ -616,7 +626,7 @@ permalink: /elastomania/
 
       Composite.add(world, [
         rearWheel, frontWheel, chassis,
-        rearConstraint, rearBrace, frontConstraint, frontBrace,
+        ...wheelLinks(rearWheel, -1), ...wheelLinks(frontWheel, 1),
         floor, wallL, wallR,
         ...terrainBodies
       ]);
@@ -705,19 +715,36 @@ permalink: /elastomania/
       // animation frame, which spiked torque at high frame rates).
       const scale = dt / 16.67;
 
-      // Drive/brake/lean all respect `facing`, so a flipped bike accelerates,
-      // brakes and spins the correct way relative to the direction it faces.
+      // Spin a wheel and apply the scaled reaction torque to the frame —
+      // engine and brake torque act between wheel and chassis, which is what
+      // makes throttle wheelies, in-air throttle rotation, and the brake
+      // "gyro" behave like the original game.
+      function spinPair(wheel, dOmega) {
+        Body.setAngularVelocity(wheel, wheel.angularVelocity + dOmega);
+        Body.setAngularVelocity(chassis,
+          chassis.angularVelocity - dOmega * MOTOR_REACTION * wheel.inertia / chassis.inertia);
+      }
+
+      // Drive/lean respect `facing`, so a flipped bike accelerates and spins
+      // the correct way relative to the direction it faces. The driven wheel
+      // is always the VISUAL rear wheel: flipping mirrors the sprite around
+      // the chassis centre, so when facing left the physical front body is
+      // the one under the swingarm.
+      const driveWheel = facing > 0 ? rearWheel : frontWheel;
       if (gas) {
-        const t = facing > 0
-          ? Math.min(rearWheel.angularVelocity + MOTOR_ACCEL * scale,  MAX_WHEEL_SPIN)
-          : Math.max(rearWheel.angularVelocity - MOTOR_ACCEL * scale, -MAX_WHEEL_SPIN);
-        Body.setAngularVelocity(rearWheel, t);
+        const room = facing > 0
+          ? MAX_WHEEL_SPIN - driveWheel.angularVelocity
+          : driveWheel.angularVelocity + MAX_WHEEL_SPIN;
+        const d = Math.min(MOTOR_ACCEL * scale, Math.max(0, room));
+        if (d > 0) spinPair(driveWheel, d * facing);
       }
       if (brake) {
-        const t = facing > 0
-          ? Math.max(rearWheel.angularVelocity - BRAKE_ACCEL * scale,  MAX_BRAKE_SPIN)
-          : Math.min(rearWheel.angularVelocity + BRAKE_ACCEL * scale, -MAX_BRAKE_SPIN);
-        Body.setAngularVelocity(rearWheel, t);
+        // Lock both wheels to the frame (no reverse thrust, as in the
+        // original — turn around with the flip key instead).
+        const lock = Math.min(1, BRAKE_LOCK * scale);
+        for (const w of [rearWheel, frontWheel]) {
+          spinPair(w, (chassis.angularVelocity - w.angularVelocity) * lock);
+        }
       }
       if (leanFwd) {
         Body.setAngularVelocity(chassis, chassis.angularVelocity + LEAN_ACCEL * scale * facing);
@@ -727,32 +754,71 @@ permalink: /elastomania/
       }
     }
 
+    // ── Suspension bump stop ───────────────────────────────────
+    // The fork/swingarm is steel: a wheel can never rise above BUMP_STOP_Y
+    // in chassis space. Clamp its position there and cancel the remaining
+    // inward relative velocity, like a fork bottoming out. Without this a
+    // hard enough landing pushes a wheel through the frame and into the
+    // suspension's mirrored equilibrium, where it sticks.
+    function applyBumpStops() {
+      const cos = Math.cos(chassis.angle), sin = Math.sin(chassis.angle);
+      for (const w of [rearWheel, frontWheel]) {
+        const dx = w.position.x - chassis.position.x;
+        const dy = w.position.y - chassis.position.y;
+        const localX = dx * cos + dy * sin;
+        const localY = -dx * sin + dy * cos;
+        if (localY >= BUMP_STOP_Y) continue;
+        Body.setPosition(w, {
+          x: chassis.position.x + localX * cos - BUMP_STOP_Y * sin,
+          y: chassis.position.y + localX * sin + BUMP_STOP_Y * cos
+        });
+        // Chassis-local "up" (-y) in world coords; kill velocity into the stop.
+        const upX = sin, upY = -cos;
+        const inward = (w.velocity.x - chassis.velocity.x) * upX
+                     + (w.velocity.y - chassis.velocity.y) * upY;
+        if (inward > 0) {
+          Body.setVelocity(w, {
+            x: w.velocity.x - inward * upX,
+            y: w.velocity.y - inward * upY
+          });
+        }
+      }
+    }
+
     // ── Death detection ────────────────────────────────────────
     function checkDeath() {
       if (state !== 'playing') return;
 
-      // Only the rider's upper body counts as a crash — the wheels, frame,
-      // and legs can clip a bump or scrape a slope without ending the run.
+      // Only the rider's head counts as a crash — the wheels, frame, and
+      // legs can clip a bump or scrape a slope without ending the run, and
+      // full mid-air loops are fine (as in the original game): being upside
+      // down only kills once the head actually meets the ground, which it
+      // does on its own if the bike comes to rest inverted.
       const upperBody = getUpperBodyPos();
       const groundY = getTerrainY(upperBody.x);
       if (upperBody.y > groundY) { die(); return; }
       if (upperBody.y > WORLD_H + 50) { die(); return; }
-
-      // Die if chassis is inverted (~135° – 225° from upright)
-      const angle = ((chassis.angle % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2);
-      if (angle > Math.PI * 0.75 && angle < Math.PI * 1.25) { die(); return; }
     }
 
     // ── Apple & flower checks ──────────────────────────────────
+    // Apples and the flower are taken by touching them with a wheel or the
+    // head, as in the original — not by the bike's centre passing nearby.
+    function touchPoints() {
+      return [
+        { p: rearWheel.position,  r: WHEEL_R + 10 },
+        { p: frontWheel.position, r: WHEEL_R + 10 },
+        { p: getUpperBodyPos(),   r: 18 }
+      ];
+    }
+
     function checkApples() {
       if (state !== 'playing') return;
-      const cx = chassis.position.x, cy = chassis.position.y;
+      const pts = touchPoints();
       for (const apple of apples) {
-        if (!apple.collected) {
-          const dx = cx - apple.x, dy = cy - apple.y;
-          if (dx * dx + dy * dy < 35 * 35) {
-            apple.collected = true;
-          }
+        if (apple.collected) continue;
+        for (const t of pts) {
+          const dx = t.p.x - apple.x, dy = t.p.y - apple.y;
+          if (dx * dx + dy * dy < t.r * t.r) { apple.collected = true; break; }
         }
       }
     }
@@ -760,9 +826,11 @@ permalink: /elastomania/
     function checkWin() {
       if (state !== 'playing') return;
       if (!apples.every(a => a.collected)) return;
-      const dx = chassis.position.x - FLOWER_DATA.x;
-      const dy = chassis.position.y - FLOWER_DATA.y;
-      if (dx * dx + dy * dy < 45 * 45) win();
+      for (const t of touchPoints()) {
+        const dx = t.p.x - FLOWER_DATA.x, dy = t.p.y - FLOWER_DATA.y;
+        const r = t.r + 12;
+        if (dx * dx + dy * dy < r * r) { win(); return; }
+      }
     }
 
     // ── State transitions ──────────────────────────────────────
@@ -855,25 +923,33 @@ permalink: /elastomania/
       // left, so the frame, wheels and rider all point the other way.
       if (facing < 0) { ctx.translate(cp.x, 0); ctx.scale(-1, 1); ctx.translate(-cp.x, 0); }
 
-      // Frame lines
+      // Suspension legs: from the frame's axle rest points to wherever the
+      // wheels actually are, so the fork/swingarm visibly flex as the
+      // suspension compresses and stretches.
+      const cos = Math.cos(ca), sin = Math.sin(ca);
+      const legX = (side) => cp.x + side * WHEELBASE_HALF * cos - AXLE_REST_Y * sin;
+      const legY = (side) => cp.y + side * WHEELBASE_HALF * sin + AXLE_REST_Y * cos;
       ctx.strokeStyle = '#2a2a3a';
       ctx.lineWidth = 3;
       ctx.lineCap = 'round';
       ctx.beginPath();
-      ctx.moveTo(rp.x, rp.y); ctx.lineTo(cp.x, cp.y);
-      ctx.moveTo(fp.x, fp.y); ctx.lineTo(cp.x, cp.y);
+      ctx.moveTo(rp.x, rp.y); ctx.lineTo(legX(-1), legY(-1)); ctx.lineTo(cp.x, cp.y);
+      ctx.moveTo(fp.x, fp.y); ctx.lineTo(legX(1),  legY(1));  ctx.lineTo(cp.x, cp.y);
       ctx.stroke();
 
       drawWheel(rp, rearWheel.angle);
       drawWheel(fp, frontWheel.angle);
 
-      // Chassis body
+      // Chassis body: place the art so its measured rear-axle pixel sits on
+      // the rear wheel's rest position, rotated so the art's axle line runs
+      // along the real wheelbase.
       ctx.save();
       ctx.translate(cp.x, cp.y);
       ctx.rotate(ca);
-      const bw = bikeBodyImg.width * BIKE_BODY_SCALE;
-      const bh = bikeBodyImg.height * BIKE_BODY_SCALE;
-      ctx.drawImage(bikeBodyImg, -bw * BIKE_BODY_ANCHOR_X, -bh * BIKE_BODY_ANCHOR_Y + BIKE_BODY_OFFSET_Y, bw, bh);
+      ctx.translate(-WHEELBASE_HALF, AXLE_REST_Y);
+      ctx.rotate(BIKE_BODY_ROT);
+      ctx.scale(BIKE_BODY_SCALE, BIKE_BODY_SCALE);
+      ctx.drawImage(bikeBodyImg, -BODY_ART_REAR_AXLE.x, -BODY_ART_REAR_AXLE.y);
       ctx.restore();
 
       // Rider
@@ -1221,6 +1297,7 @@ permalink: /elastomania/
       if (state === 'playing') {
         applyControls(dt);
         Engine.update(engine, dt);
+        applyBumpStops();
         checkApples();
         checkDeath();
         checkWin();

--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -439,14 +439,16 @@ permalink: /elastomania/
     bikeBodyImg.src    = '/elastomania/img/bike-body.png';
     const bikeWheelImg = new Image();
     bikeWheelImg.src   = '/elastomania/img/bike-wheel.png';
-    // Axle points measured off bike-body.png: the pronged swingarm clamp at
-    // the sprite's rear tip and the fork tip at its front. Mapping these two
-    // art pixels onto the wheels' rest positions in chassis space (a
-    // similarity transform: scale + slight rotation, since the art's axle
-    // line isn't quite horizontal) puts the frame exactly over the wheels —
-    // fork on the front axle, swingarm on the rear axle.
-    const BODY_ART_REAR_AXLE  = { x: 8,   y: 68 };
-    const BODY_ART_FRONT_AXLE = { x: 314, y: 95 };
+    // Axle points in bike-body.png pixel coordinates, solved from the
+    // artist's assembled reference shot: the wheels sit INBOARD of the
+    // sprite tips — the rear fender/prong overhangs the rear wheel and the
+    // front fender arcs above the front wheel — with both axle centres
+    // below the sprite's lower edge (the frame rides on top of the wheels).
+    // Mapping these two points onto the wheels' rest positions in chassis
+    // space (a similarity transform: scale + slight rotation) reproduces
+    // the reference layout exactly.
+    const BODY_ART_REAR_AXLE  = { x: 37,  y: 140 };
+    const BODY_ART_FRONT_AXLE = { x: 273, y: 123 };
     const BODY_ART_DX = BODY_ART_FRONT_AXLE.x - BODY_ART_REAR_AXLE.x;
     const BODY_ART_DY = BODY_ART_FRONT_AXLE.y - BODY_ART_REAR_AXLE.y;
     const BIKE_BODY_SCALE = (WHEELBASE_HALF * 2) / Math.hypot(BODY_ART_DX, BODY_ART_DY);
@@ -461,19 +463,20 @@ permalink: /elastomania/
     // Rider art is a seated/crouched pose; anchor at the hip (where the
     // thighs bend to horizontal) rather than image center, so that point
     // lands on the bike's seat instead of floating above or sinking into it.
-    // Scaled so the feet reach the pegs at the engine bottom now that the
-    // body art is smaller (it spans the wider wheelbase).
-    const RIDER_SCALE    = 0.17;
+    // Size and hip placement match the assembled reference shot: the rider
+    // is big relative to the bike (helmet well above the handlebars, feet
+    // reaching the pegs at the engine bottom).
+    const RIDER_SCALE    = 0.27;
     const RIDER_ANCHOR_X = 0.286;
     const RIDER_ANCHOR_Y = 0.569;
-    const RIDER_OFFSET_X = -13;
-    const RIDER_OFFSET_Y = 12;
+    const RIDER_OFFSET_X = -12;
+    const RIDER_OFFSET_Y = -1;
 
     // Point at the rider's helmet, in chassis-local space (before rotation)
     // — used as the hit-test spot for ground/terrain crashes so only the
     // head counts as a collision (as in the original game), not the wheels,
     // frame, or legs clipping a bump.
-    const UPPER_BODY_OFFSET = { x: -6, y: -16 };
+    const UPPER_BODY_OFFSET = { x: -3, y: -35 };
 
     function getUpperBodyPos() {
       const a = chassis.angle;
@@ -923,18 +926,38 @@ permalink: /elastomania/
       // left, so the frame, wheels and rider all point the other way.
       if (facing < 0) { ctx.translate(cp.x, 0); ctx.scale(-1, 1); ctx.translate(-cp.x, 0); }
 
-      // Suspension legs: from the frame's axle rest points to wherever the
-      // wheels actually are, so the fork/swingarm visibly flex as the
-      // suspension compresses and stretches.
+      // Suspension animation: the swingarm pivots from the frame down to the
+      // actual rear wheel centre and the front fork telescopes from the fork
+      // crown to the actual front wheel centre, so both visibly compress,
+      // stretch and flex with the physics. Their frame-side ends are fixed
+      // in chassis space (points read off the body art: swingarm pivot by
+      // the engine, fork crown under the handlebars).
       const cos = Math.cos(ca), sin = Math.sin(ca);
-      const legX = (side) => cp.x + side * WHEELBASE_HALF * cos - AXLE_REST_Y * sin;
-      const legY = (side) => cp.y + side * WHEELBASE_HALF * sin + AXLE_REST_Y * cos;
-      ctx.strokeStyle = '#2a2a3a';
-      ctx.lineWidth = 3;
+      const localPt = (lx, ly) => ({
+        x: cp.x + lx * cos - ly * sin,
+        y: cp.y + lx * sin + ly * cos
+      });
+      const swingarmPivot = localPt(-14, 15);
+      const forkCrown     = localPt(23, 4);
       ctx.lineCap = 'round';
+      // Rear swingarm: single dark arm.
+      ctx.strokeStyle = '#2a2a3a';
+      ctx.lineWidth = 5;
       ctx.beginPath();
-      ctx.moveTo(rp.x, rp.y); ctx.lineTo(legX(-1), legY(-1)); ctx.lineTo(cp.x, cp.y);
-      ctx.moveTo(fp.x, fp.y); ctx.lineTo(legX(1),  legY(1));  ctx.lineTo(cp.x, cp.y);
+      ctx.moveTo(swingarmPivot.x, swingarmPivot.y); ctx.lineTo(rp.x, rp.y);
+      ctx.stroke();
+      // Front fork: dark outer tube with a lighter slider core, so the
+      // telescoping motion reads clearly.
+      ctx.strokeStyle = '#2a2a3a';
+      ctx.lineWidth = 5;
+      ctx.beginPath();
+      ctx.moveTo(forkCrown.x, forkCrown.y); ctx.lineTo(fp.x, fp.y);
+      ctx.stroke();
+      ctx.strokeStyle = '#9a9aa8';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(forkCrown.x, forkCrown.y);
+      ctx.lineTo((forkCrown.x + fp.x) / 2, (forkCrown.y + fp.y) / 2);
       ctx.stroke();
 
       drawWheel(rp, rearWheel.angle);

--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -151,7 +151,7 @@ permalink: /elastomania/
     // ── Constants ──────────────────────────────────────────────
     // WORLD_W varies per level and is declared with the LEVELS data below.
     const WORLD_H = 700;
-    const WHEEL_R = 15;
+    const WHEEL_R = 14;
     const CHASSIS_W = 55;
     const CHASSIS_H = 10;
     // Half the wheelbase. The original Elasto Mania bike has its wheels well
@@ -184,10 +184,12 @@ permalink: /elastomania/
     // game: gassing spins the wheel up and kicks the frame back (nose-up), so
     // holding full throttle from a standstill loops you over backwards in
     // about a second and a half unless you lean forward, and throttle/brake
-    // rotate the bike in mid-air. MOTOR_REACTION scales how much of the
-    // ideal I_wheel/I_chassis reaction reaches the frame.
+    // rotate the bike in mid-air. MOTOR_REACTION scales the
+    // I_wheel/I_chassis reaction reaching the frame — a feel knob, tuned so
+    // held full gas hits 45° in ~1.2s (wheel inertia goes with r⁴, so this
+    // compensates for the smaller wheel radius).
     const MOTOR_ACCEL    = 0.1;    // wheel spin gain per 16.67ms frame
-    const MOTOR_REACTION = 0.8;
+    const MOTOR_REACTION = 1.1;
     // Brake couples both wheels to the frame (locks them relative to it, no
     // reverse thrust) — turn around with the flip key instead, as in the
     // original.
@@ -453,7 +455,7 @@ permalink: /elastomania/
     const BODY_ART_DY = BODY_ART_FRONT_AXLE.y - BODY_ART_REAR_AXLE.y;
     const BIKE_BODY_SCALE = (WHEELBASE_HALF * 2) / Math.hypot(BODY_ART_DX, BODY_ART_DY);
     const BIKE_BODY_ROT   = -Math.atan2(BODY_ART_DY, BODY_ART_DX);
-    const BIKE_WHEEL_SCALE   = (WHEEL_R * 2.1) / 108;
+    const BIKE_WHEEL_SCALE   = (WHEEL_R * 2.05) / 108;
     // Only spin the wheel art at a fraction of the real wheel speed so the
     // spokes read as a calm roll instead of a dizzy strobe at full throttle.
     const WHEEL_SPIN_VISUAL  = 0.3;
@@ -466,17 +468,17 @@ permalink: /elastomania/
     // Size and hip placement match the assembled reference shot: the rider
     // is big relative to the bike (helmet well above the handlebars, feet
     // reaching the pegs at the engine bottom).
-    const RIDER_SCALE    = 0.27;
+    const RIDER_SCALE    = 0.23;
     const RIDER_ANCHOR_X = 0.286;
     const RIDER_ANCHOR_Y = 0.569;
     const RIDER_OFFSET_X = -12;
-    const RIDER_OFFSET_Y = -1;
+    const RIDER_OFFSET_Y = 0;
 
     // Point at the rider's helmet, in chassis-local space (before rotation)
     // — used as the hit-test spot for ground/terrain crashes so only the
     // head counts as a collision (as in the original game), not the wheels,
     // frame, or legs clipping a bump.
-    const UPPER_BODY_OFFSET = { x: -3, y: -35 };
+    const UPPER_BODY_OFFSET = { x: -4, y: -29 };
 
     function getUpperBodyPos() {
       const a = chassis.angle;

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607100526';
+const CACHE_VERSION = '2607101030';
 const CACHE_NAME = `elastomania-${CACHE_VERSION}`;
 const OFFLINE_URL = '/elastomania/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary

Makes the Elasto Mania game feel much closer to the original: the wheels now sit at the fork/swingarm tips of the bike sprite instead of tucking under the engine, and the physics reproduces the original's signature behaviors (throttle wheelies that loop you over, springy suspension, wheel-locking brake, mid-air throttle/brake rotation).

## Wheel placement

- Widened the wheelbase from 36 to 60 world units (~2 wheel diameters, the original's proportion).
- Measured the actual axle points off `bike-body.png` (the swingarm clamp at the rear tip, the fork tip at the front) and mapped them onto the wheels' rest positions with a similarity transform, so the frame art sits exactly over the wheels.
- Suspension legs are now drawn from the frame's axle rest points to the actual wheel centers, so the fork/swingarm visibly flex.
- Rescaled and reseated the rider for the new proportions; head hit-test point updated to the helmet.

## Physics

- **Suspension**: each wheel now hangs from three non-collinear links (soft main leg + two stiffer braces). Three anchors make the wheel's rest pose geometrically unique, so the soft springs can squash and stretch (bouncy Elma landings) without the wheel flipping to the mirrored equilibrium that one- or two-link hookups have. A bump stop clamps the wheel below chassis-local height on violent impacts.
- **Engine torque acts between wheel and frame** (scaled reaction torque): holding full throttle from a standstill loops the bike over backwards in ~1.5 s unless you lean forward, and gas/brake rotate the bike in mid-air — both signature original behaviors.
- **Brake locks both wheels** relative to the frame instead of reverse-spinning the rear wheel; you turn around with the flip key, as in the original. The flip now also drives the correct (visual rear) wheel when facing left.
- **Death**: only the rider's head touching terrain kills; the inversion insta-death was removed so mid-air loops are possible.
- **Pickups**: apples and the flower are taken by touching them with a wheel or the head, not by chassis proximity.

All physics scenarios were validated headlessly against `matter.min.js` (settling, full-throttle wheelie timing, braking from top speed, 300 px drops, in-air rotation) and visually with Playwright screenshots of the running game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAgwGKztvHxdqieugExVfx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAgwGKztvHxdqieugExVfx)_