### PR TITLE
Elasto Mania: make level 5+ obstacles actually passable

### DIFF
--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -121,7 +121,7 @@ permalink: /elastomania/
   </div>
 
   <script>
-    const SW_VERSION = '2607101358';
+    const SW_VERSION = '2607101615';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function showBanner(reg) {
@@ -317,25 +317,32 @@ permalink: /elastomania/
       for (let r = 0; r < rampCount; r++) {
         const base = flatStart + 2 + rampZoneSize * (r + 1);
         const jitter = Math.floor((rng() - 0.5) * rampZoneSize * 0.4);
-        rampPositions.add(Math.max(flatStart + 3, Math.min(segCount - 8, base + jitter)));
+        rampPositions.add(Math.max(flatStart + 3, Math.min(segCount - 10, base + jitter)));
       }
 
       while (i < segCount - 2) {
         const x = i * STEP;
 
-        if (rampPositions.has(i) && i < segCount - 7) {
+        if (rampPositions.has(i) && i < segCount - 9) {
           // ── Ramp → cliff → wall obstacle ──
-          // Approach: gentle upslope (ramp), then a cliff drop, then a
-          // steep wall rise. If the player is going too fast they'll
-          // smash into the wall; they need to brake before the ramp.
-          const rampHeight = 40 + Math.round(difficulty * 60 + rng() * 30);
+          // Approach: upslope (ramp), then a cliff drop, then a wall rise.
+          // Geometry is bounded by what the bike can actually do: the bike
+          // can't static-climb slopes past ~40° (tyre/ground friction) and
+          // tops out around 15 px/frame, so both the ramp and the wall are
+          // spread over three segments (≤ ~35° each) and the wall height is
+          // capped. Verified by simulating the bike over the generated
+          // obstacle at every difficulty — the old 2-segment, ~52° walls
+          // were impossible to pass at level 5+ no matter the approach.
+          const rampHeight = 40 + Math.round(difficulty * 50 + rng() * 25);
           const gapWidth = 2 + Math.floor(rng() * 1.5);
-          const wallHeight = 30 + Math.round(difficulty * 50 + rng() * 20);
+          const wallHeight = 20 + Math.round(difficulty * 25 + rng() * 12);
 
-          // Ramp up (2 segments)
+          // Ramp up (3 segments)
           const rampBase = y;
           const rampTop = Math.max(MIN_Y, rampBase - rampHeight);
-          terrain.push([x, Math.round(rampBase - rampHeight * 0.4)]);
+          terrain.push([x, Math.round(rampBase - rampHeight * 0.25)]);
+          i++;
+          terrain.push([i * STEP, Math.round(rampBase - rampHeight * 0.62)]);
           i++;
           terrain.push([i * STEP, rampTop]);
           i++;
@@ -351,9 +358,13 @@ permalink: /elastomania/
             i++;
           }
 
-          // Wall — steep rise the player will crash into if too fast
+          // Wall — a rise that punishes a too-fast approach but stays
+          // climbable with momentum (3 segments)
           const wallTop = Math.max(MIN_Y, cliffBottom - wallHeight - rampHeight * 0.5);
-          terrain.push([i * STEP, Math.round(cliffBottom - (cliffBottom - wallTop) * 0.7)]);
+          const wallRise = cliffBottom - wallTop;
+          terrain.push([i * STEP, Math.round(cliffBottom - wallRise * 0.35)]);
+          i++;
+          terrain.push([i * STEP, Math.round(cliffBottom - wallRise * 0.72)]);
           i++;
           terrain.push([i * STEP, wallTop]);
           i++;

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607101358';
+const CACHE_VERSION = '2607101615';
 const CACHE_NAME = `elastomania-${CACHE_VERSION}`;
 const OFFLINE_URL = '/elastomania/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary

Answers "is it possible to pass level 5?" — it wasn't, and this fixes it.

### The problem

The ramp → cliff → wall obstacles scale with difficulty, and from level 5 up the wall was a 2-segment, ~52° climb rising ~130–175 px out of a 120 px gap floor. The bike physically cannot pass that: tyre/ground friction caps static climbing near 40°, the 43° ramp face bleeds all approach speed so the gap+wall can't be jumped either, and on higher levels the gap becomes a soft-lock pit. Verified by simulating the game's exact physics over the generated obstacle at levels 5, 7 and 9 with sweeps of approach speeds and rider postures — every attempt failed.

### The fix

The generator keeps the same obstacle character (brake-check ramp, cliff, gap, wall) but spreads both the ramp and the wall over three segments (~35° max per face) and caps wall height (`20 + difficulty·25` instead of `30 + difficulty·50`).

### Verification

- The isolated obstacle now passes at level 5/7/9 difficulty in simulation.
- A section-adaptive rider bot (per-zone speed/posture, like a player learning sections) completes **Level 5 end-to-end** on the new terrain.
- Worst uphill face across levels 1–10 now stays ≤ 43° (momentum-climbable), obstacles included.

Level layouts change (they're procedurally generated), but seeds and progression are untouched. PWA service-worker version bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAgwGKztvHxdqieugExVfx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAgwGKztvHxdqieugExVfx)_