### PR TITLE
Elasto Mania: fix bike falling through the ground on hard landings

### DIFF
--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -121,7 +121,7 @@ permalink: /elastomania/
   </div>
 
   <script>
-    const SW_VERSION = '2607112358';
+    const SW_VERSION = '2607120040';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function showBanner(reg) {
@@ -252,6 +252,10 @@ permalink: /elastomania/
     // original.
     const BRAKE_LOCK     = 0.25;   // per-frame lock-up fraction
     const MAX_WHEEL_SPIN = 20;
+    // Terminal velocity for every bike body (px per 16.67ms step). Long
+    // free-falls and monster jumps otherwise build impact speeds that
+    // outrun the collision solver.
+    const MAX_SPEED = 22;
     // Lean ("spin") input: kept very subtle — it nudges the bike's rotation
     // for balance corrections rather than whipping it around. Still strong
     // enough (about 5× the throttle's reaction torque) to hold a wheelie
@@ -601,12 +605,16 @@ permalink: /elastomania/
     }
 
     // ── Terrain segment body ───────────────────────────────────
+    // The collision slab extends 62px below the surface line (only the top
+    // face matters visually — terrain is drawn as a filled polygon). Thick
+    // slabs are cheap insurance against fast bodies stepping across a thin
+    // slab between frames, since Matter has no continuous collision.
     function makeSegment(x1, y1, x2, y2) {
       const cx    = (x1 + x2) / 2;
       const cy    = (y1 + y2) / 2;
       const len   = Math.hypot(x2 - x1, y2 - y1);
       const angle = Math.atan2(y2 - y1, x2 - x1);
-      return Bodies.rectangle(cx, cy + 11, len, 22, {
+      return Bodies.rectangle(cx, cy + 31, len, 62, {
         isStatic: true,
         angle,
         friction: 0.85,
@@ -893,30 +901,32 @@ permalink: /elastomania/
 
     // ── Suspension bump stop ───────────────────────────────────
     // The fork/swingarm is steel: a wheel can never rise above BUMP_STOP_Y
-    // in chassis space. Clamp its position there and cancel the remaining
-    // inward relative velocity, like a fork bottoming out. Without this a
-    // hard enough landing pushes a wheel through the frame and into the
-    // suspension's mirrored equilibrium, where it sticks.
+    // in chassis space. When the suspension bottoms out, push the CHASSIS
+    // away from the wheel and cancel its approach velocity — like the stop
+    // transmitting the blow to the frame. It must never move the WHEEL
+    // downward instead: the wheel is sitting on the ground, and re-embedding
+    // it below the surface every frame while the chassis keeps falling
+    // ratchets the whole bike through the floor on hard landings.
     function applyBumpStops() {
       const cos = Math.cos(chassis.angle), sin = Math.sin(chassis.angle);
       for (const w of [rearWheel, frontWheel]) {
         const dx = w.position.x - chassis.position.x;
         const dy = w.position.y - chassis.position.y;
-        const localX = dx * cos + dy * sin;
         const localY = -dx * sin + dy * cos;
         if (localY >= BUMP_STOP_Y) continue;
-        Body.setPosition(w, {
-          x: chassis.position.x + localX * cos - BUMP_STOP_Y * sin,
-          y: chassis.position.y + localX * sin + BUMP_STOP_Y * cos
-        });
-        // Chassis-local "up" (-y) in world coords; kill velocity into the stop.
+        // Chassis-local "up" (-y) in world coords.
         const upX = sin, upY = -cos;
+        const violation = BUMP_STOP_Y - localY;
+        Body.setPosition(chassis, {
+          x: chassis.position.x + violation * upX,
+          y: chassis.position.y + violation * upY
+        });
         const inward = (w.velocity.x - chassis.velocity.x) * upX
                      + (w.velocity.y - chassis.velocity.y) * upY;
         if (inward > 0) {
-          Body.setVelocity(w, {
-            x: w.velocity.x - inward * upX,
-            y: w.velocity.y - inward * upY
+          Body.setVelocity(chassis, {
+            x: chassis.velocity.x + inward * upX,
+            y: chassis.velocity.y + inward * upY
           });
         }
       }
@@ -1508,6 +1518,15 @@ permalink: /elastomania/
 
       if (state === 'playing') {
         applyControls(dt);
+        for (const b of [rearWheel, frontWheel, chassis]) {
+          const sp = Math.hypot(b.velocity.x, b.velocity.y);
+          if (sp > MAX_SPEED) {
+            Body.setVelocity(b, {
+              x: b.velocity.x * MAX_SPEED / sp,
+              y: b.velocity.y * MAX_SPEED / sp
+            });
+          }
+        }
         Engine.update(engine, dt);
         applyBumpStops();
         alignWheelAxes();

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607112358';
+const CACHE_VERSION = '2607120040';
 const CACHE_NAME = `elastomania-${CACHE_VERSION}`;
 const OFFLINE_URL = '/elastomania/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary

Fixes the bike falling into/through the ground.

### Root cause

The suspension bump stop was the culprit. When a landing bottomed the suspension out, the stop teleported the **wheel** down to the stop position in the still-falling chassis's frame — re-embedding it below the terrain surface every frame and overriding the collision solver's separation, so the whole bike ratcheted through the floor. Reproduced headlessly: any impact above ~16 px/frame (drops over ~300 px) fell out of the world. This became visible now because the gentler ramps from #235 allow much bigger jumps than the old geometry ever did.

### Fix

- The bump stop now pushes the **chassis** away from the wheel and cancels its approach velocity — like a real bottom-out transmitting the blow to the frame. The wheel (which is sitting on the ground) is never forced downward.
- Terrain collision slabs thickened 22 → 62 px (purely defensive; visuals unchanged since terrain renders as a filled polygon).
- Terminal velocity cap of 22 px/step on all bike bodies so extreme free-falls can't outrun the solver.

### Verification

- Drop matrix: 200–1300 px falls, with and without forward speed — all land and settle at rest height (previously everything above 300 px fell through).
- Full physics regression suite passes; the 300 px drop actually settles cleaner than before (off-axis transient 1.8 px vs 7.6 px).
- The section-adaptive bot still completes Level 5 end-to-end.

PWA service-worker version bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAgwGKztvHxdqieugExVfx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAgwGKztvHxdqieugExVfx)_