### PR TITLE
Code quality review: fix stale CI, escaping gaps, and CI/README gaps

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/update-wc-scores.yml
+++ b/.github/workflows/update-wc-scores.yml
@@ -160,6 +160,11 @@ jobs:
         with:
           ref: master
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Fetch scores
         env:
           FOOTBALL_DATA_API_KEY: ${{ secrets.FOOTBALL_DATA_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-"# jorgecensi.github.io" 
+# jorgecensi.github.io
+
+Personal portfolio/blog built with Jekyll, plus a collection of small standalone
+client-side apps and games (each is a self-contained page, often installable as
+a PWA).
+
+## Apps
+
+- `crossfit-timer/` — CrossFit workout timer (PWA)
+- `personal-trainer/` — Adaptive workout generator (PWA)
+- `flappy/` — Flappy Bird clone (PWA)
+- `auto-runner/` — Endless runner game (PWA)
+- `elastomania/` — Elasto Mania–style physics game (PWA)
+- `f1-championship/` — F1 championship tracker (PWA)
+- `worldcup-2026/` — World Cup 2026 tracker (PWA)
+- `curator/` — YouTube playlist curator (PWA)
+- `drum-machine/` — Step-sequencer drum machine (PWA)
+- `synth/` — Web audio synthesizer (PWA)
+- `tuner/` — Instrument tuner (PWA)
+- `music-theory/` — Music theory trainer (PWA)
+- `binary/` — Binary number trainer (PWA, also available in `pt-BR/binary/`)
+- `tennis-planner.html` — Tennis match/availability planner (PWA)
+- `squeak-the-geek.html` — Browser game (PWA)
+
+## Development
+
+See [`AGENTS.md`](AGENTS.md) for local dev server instructions and
+project-specific caveats (bundler setup, PWA cache-version bumping, etc).

--- a/curator/index.html
+++ b/curator/index.html
@@ -789,7 +789,8 @@ function escHtml(str) {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function activatePlayer() {

--- a/f1-championship/index.html
+++ b/f1-championship/index.html
@@ -610,7 +610,7 @@ function esc(s) { return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&
 // ============================================================
 function avatarInner(player, fontSize) {
   if (player.photo) return `<img class="avatar-img" src="${player.photo}" alt="${esc(player.name)}">`;
-  return `<div class="avatar-letter" style="background:${player.color};font-size:${fontSize}px">${esc(player.avatar)}</div>`;
+  return `<div class="avatar-letter" style="background:${esc(player.color)};font-size:${fontSize}px">${esc(player.avatar)}</div>`;
 }
 
 function avatarHtml(player, size = 36) {
@@ -696,7 +696,7 @@ function renderStandings() {
     standings.forEach((s, i) => {
       h += `<tr>
         <td class="td-pos">${i + 1}</td>
-        <td><div class="driver-cell"><span class="player-dot" style="background:${s.player.color}"></span>${esc(s.player.name)}</div></td>
+        <td><div class="driver-cell"><span class="player-dot" style="background:${esc(s.player.color)}"></span>${esc(s.player.name)}</div></td>
         <td class="td-pts"><strong>${s.points}</strong></td>
         <td class="td-c">${s.races}</td>
         <td class="td-c">${bestFinish(s.positions)}</td>
@@ -713,7 +713,7 @@ function renderStandings() {
     });
     h += '</tr></thead><tbody>';
     players.forEach(p => {
-      h += `<tr><td class="sticky-col"><div class="driver-cell"><span class="player-dot" style="background:${p.color}"></span>${esc(p.name)}</div></td>`;
+      h += `<tr><td class="sticky-col"><div class="driver-cell"><span class="player-dot" style="background:${esc(p.color)}"></span>${esc(p.name)}</div></td>`;
       CALENDAR.forEach(r => {
         const key  = String(r.round);
         const data = getPlayerRound(p.id, key);
@@ -950,7 +950,7 @@ function openModal(round) {
     const val = existing?.entries?.[p.id]?.lapTime || '';
     h += `<div class="te-row">
       <div class="te-player">
-        <span class="te-pdot" style="background:${p.color}"></span>
+        <span class="te-pdot" style="background:${esc(p.color)}"></span>
         <span class="te-pname">${esc(p.name)}</span>
       </div>
       <input type="text" class="time-input" data-pid="${p.id}"
@@ -1023,7 +1023,7 @@ function updatePreview() {
   entries.forEach((e, i) => {
     h += `<div class="pv-row">
       <span class="pv-pos">${med[i] || 'P'+(i+1)}</span>
-      <span class="pv-name" style="color:${e.player.color}">${esc(e.player.name)}</span>
+      <span class="pv-name" style="color:${esc(e.player.color)}">${esc(e.player.name)}</span>
       <span class="pv-time">${e.lapTime}</span>
       <span class="pv-pts">+${F1_POINTS[i] ?? 0} pts</span>
     </div>`;

--- a/tennis-planner.html
+++ b/tennis-planner.html
@@ -273,6 +273,7 @@ permalink: /tennis-planner/
                     playerEl.innerHTML = `<span class="font-medium">${escapeHtml(player.name)}</span>`;
                     const deleteBtn = document.createElement('button');
                     deleteBtn.innerHTML = '&times;';
+                    deleteBtn.setAttribute('aria-label', `Remove ${player.name}`);
                     deleteBtn.className = 'text-red-500 font-bold text-xl hover:text-red-700 px-2';
                     deleteBtn.onclick = () => deletePlayer(player.id);
                     playerEl.appendChild(deleteBtn);


### PR DESCRIPTION
## Summary

Reviewed the whole site (Jekyll portfolio + ~16 standalone client-side apps/games) for code quality, security, performance, and maintainability. This PR lands the safe, mechanical fixes; everything else is listed below for discussion since it needs a design decision or touches the auto-bump CI workflow.

## Changes in this PR

- **`codeql-analysis.yml`**: bumped `actions/checkout` and `github/codeql-action` from v1/v2 to v4/v3. GitHub sunset CodeQL Action v1 a while ago, so this workflow was almost certainly failing silently on every push/PR/weekly schedule — meaning there's been no actual code scanning running despite the workflow existing.
- **`update-wc-scores.yml`**: added `actions/setup-node` with a pinned version, since the score-fetch script previously ran on whatever Node the runner image happened to ship.
- **f1-championship**: `player.color` is imported from user-supplied JSON backup files with no field validation (`importData()` only checks `d.players`/`d.results` exist), then interpolated unescaped into 5 different `style="..."` attributes. A crafted backup file shared between users could inject arbitrary HTML/JS. Now escaped via the existing `esc()` helper, consistent with how `name`/`avatar` are already handled.
- **curator**: `escHtml()` was missing `'` (single-quote) escaping, inconsistent with every other escaping helper in the repo.
- **tennis-planner**: the icon-only player delete button (`&times;`) had no accessible name; added `aria-label`.
- **README.md**: was a single placeholder line; replaced with an index of the ~16 apps and a pointer to `AGENTS.md` for dev setup.

## Other findings (not fixed here — flagging for a follow-up)

**Worth doing, bigger effort / needs a decision:**
- ~16 `sw.js` files are hand-duplicated near-verbatim across apps (drifting indentation and feature sets). Any future SW bugfix has to be manually re-applied everywhere. Worth extracting to a shared template.
- 5 apps' service-worker registration calls don't use a cache-busting `?v=` query param (`synth`, `curator`, `f1-championship`, `tennis-planner`, `worldcup-2026`), unlike the other ~9 apps. Fixing this "properly" means adding a versioned constant and wiring it into `.github/workflows/bump-pwa-cache-version.yml`, which auto-commits to `master` on merge — didn't want to touch that without a heads up.
- `tennis-planner` and `worldcup-2026` are both absent from `bump-pwa-cache-version.yml`'s auto-bump list despite being real PWAs; `tennis-planner-sw.js` has no `CACHE_VERSION` constant at all. `AGENTS.md` also undersells the PWA surface (only mentions 3 of ~16 apps as PWAs).
- `crossfit-timer` and `personal-trainer`'s countdown timers use plain `setInterval`/`setTimeout` decrementing with no wall-clock reconciliation — the displayed time silently drifts if the tab is backgrounded and later regains focus. `elastomania`'s `loop()` does this correctly (delta-time based, clamped) and is a good reference implementation.
- `flappy` and `auto-runner` advance physics per-rendered-frame with no delta-time normalization, so gameplay runs measurably faster on high-refresh-rate (90/120Hz) displays than on 60Hz. Same root-cause bug in both games.
- `worldcup-2026/index.html` inlines ~48KB of base64 image data directly in two JS constants (`BALL_DATA_URL` and a sibling), parsed synchronously on load — inconsistent with the same file's own pattern of loading flag SVGs via `<img src>`. Extracting to real image files would let them be cached/lazy-loaded.
- `curator` stores the user's YouTube Data API key in `localStorage` in plaintext and sends it as a URL query param on every request — inherent to a client-only app with a user-supplied key, but worth a README note recommending the key be restricted to HTTP referrers in Google Cloud Console.

**Low priority / cosmetic:**
- Several apps use blocking `alert()`/`confirm()` for validation and update prompts (`crossfit-timer`, `personal-trainer`, `f1-championship`, `tennis-planner`) where the rest of the app otherwise uses styled inline banners.
- `esc`/`escapeHtml`/`escHtml` helpers are reimplemented independently in `f1-championship`, `curator`, `tennis-planner`, `personal-trainer`, and `js/jorge-cli.js` — same logic, no shared `utils.js`.
- No `package.json` anywhere in the repo despite ~15 apps sharing near-identical boilerplate, so there's no shared lint/format story — this is the root cause letting the duplication above drift further as more apps are added.

## Test plan

- [x] `git diff` reviewed for all 6 changed files — mechanical, self-contained changes
- [x] YAML validity of both edited workflow files confirmed with `yaml.safe_load`
- [ ] Since this environment has no bundler install and no JS test/lint tooling (per `AGENTS.md`), the HTML/JS edits weren't exercised in a browser — worth a manual smoke test of f1-championship's standings/entry views and tennis-planner's player list before merging

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01XkUYy3Bds93ZPhiRQuvYgr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkUYy3Bds93ZPhiRQuvYgr)_