### PR TITLE
Harden storage error handling, fix stale PWA cache, cut audio-loop allocations

### DIFF
--- a/.github/workflows/bump-pwa-cache-version.yml
+++ b/.github/workflows/bump-pwa-cache-version.yml
@@ -58,6 +58,7 @@ jobs:
           echo "elastomania=$(check 'elastomania/sw.js elastomania/index.html elastomania/manifest.json')" >> "${GITHUB_OUTPUT}"
           echo "squeak_the_geek=$(check 'squeak-the-geek-sw.js squeak-the-geek.html squeak-the-geek-manifest.json')" >> "${GITHUB_OUTPUT}"
           echo "personal_trainer=$(check 'personal-trainer/sw.js personal-trainer/index.html personal-trainer/manifest.json')" >> "${GITHUB_OUTPUT}"
+          echo "tennis_planner=$(check 'tennis-planner-sw.js tennis-planner.html tennis-planner-manifest.json')" >> "${GITHUB_OUTPUT}"
 
       - name: Update PWA version constants
         run: |
@@ -83,6 +84,7 @@ jobs:
               "elastomania":  "${{ steps.changed.outputs.elastomania }}" == "true",
               "squeak_the_geek": "${{ steps.changed.outputs.squeak_the_geek }}" == "true",
               "personal_trainer": "${{ steps.changed.outputs.personal_trainer }}" == "true",
+              "tennis_planner": "${{ steps.changed.outputs.tennis_planner }}" == "true",
           }
 
           # On tag/dispatch, bump everything; on push to main, only bump changed PWAs
@@ -132,6 +134,9 @@ jobs:
           if bump_all or changed["personal_trainer"]:
               versioned_files["personal-trainer/sw.js"] = ("CACHE_VERSION", version)
               versioned_files["personal-trainer/index.html"] = ("SW_VERSION", version)
+          if bump_all or changed["tennis_planner"]:
+              versioned_files["tennis-planner-sw.js"] = ("CACHE_VERSION", version)
+              versioned_files["tennis-planner.html"] = ("SW_VERSION", version)
 
           for relative_path, (const_name, ver) in versioned_files.items():
               path = repo / relative_path
@@ -179,6 +184,8 @@ jobs:
             squeak-the-geek-sw.js \
             squeak-the-geek.html \
             personal-trainer/sw.js \
-            personal-trainer/index.html
+            personal-trainer/index.html \
+            tennis-planner-sw.js \
+            tennis-planner.html
           git commit -m "chore: bump PWA cache version to ${{ steps.version.outputs.value }} [skip ci]"
           git push origin "HEAD:${{ github.event.repository.default_branch }}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '37 5 * * 0'
 
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
 jobs:
   analyze:
     name: Analyze

--- a/auto-runner/index.html
+++ b/auto-runner/index.html
@@ -104,7 +104,11 @@ permalink: /auto-runner/
     let stars, groundX;
     let reviveStars, reviveStarCooldown;
 
-    bestScore = parseInt(localStorage.getItem('ar-best') || '0', 10);
+    try {
+      bestScore = parseInt(localStorage.getItem('ar-best') || '0', 10);
+    } catch (e) {
+      bestScore = 0;
+    }
 
     // ── Players ────────────────────────────────────────────────
     let players;
@@ -432,7 +436,11 @@ permalink: /auto-runner/
       flashAlpha = 0.85;
       if (score > bestScore) {
         bestScore = score;
-        localStorage.setItem('ar-best', bestScore);
+        try {
+          localStorage.setItem('ar-best', bestScore);
+        } catch (e) {
+          // localStorage unavailable (private browsing / quota) — best score just won't persist
+        }
       }
     }
 

--- a/drum-machine/index.html
+++ b/drum-machine/index.html
@@ -1264,12 +1264,27 @@ function playWoodblock(time, pitch, dest = masterGain) {
     osc.connect(bpf); bpf.connect(g); g.connect(dest); osc.start(time); osc.stop(time + 0.075);
 }
 
+// Small pool of pre-rendered noise buffers per duration, reused across hits
+// instead of re-rendering a fresh buffer (up to ~1.8s / ~79k samples) on every
+// single hit — that generation used to run synchronously on the main thread
+// each time a crash/shaker triggered, causing avoidable GC churn at high BPM.
+// Picking randomly from a small pool keeps hit-to-hit variation.
+const noiseBufferPool = new Map();
+const NOISE_POOL_SIZE = 4;
 function noiseBuffer(dur) {
-    const size = Math.ceil(audioCtx.sampleRate * dur);
-    const buf  = audioCtx.createBuffer(1, size, audioCtx.sampleRate);
-    const data = buf.getChannelData(0);
-    for (let i = 0; i < size; i++) data[i] = Math.random() * 2 - 1;
-    return buf;
+    let pool = noiseBufferPool.get(dur);
+    if (!pool) {
+        pool = [];
+        const size = Math.ceil(audioCtx.sampleRate * dur);
+        for (let p = 0; p < NOISE_POOL_SIZE; p++) {
+            const buf = audioCtx.createBuffer(1, size, audioCtx.sampleRate);
+            const data = buf.getChannelData(0);
+            for (let i = 0; i < size; i++) data[i] = Math.random() * 2 - 1;
+            pool.push(buf);
+        }
+        noiseBufferPool.set(dur, pool);
+    }
+    return pool[(Math.random() * pool.length) | 0];
 }
 
 // ─── Sample banks ─────────────────────────────────────────────────────────────

--- a/f1-championship/index.html
+++ b/f1-championship/index.html
@@ -540,7 +540,8 @@ function load(key, fallback) {
   catch { return fallback; }
 }
 function save(key, val) {
-  localStorage.setItem(`${NS}:${key}`, JSON.stringify(val));
+  try { localStorage.setItem(`${NS}:${key}`, JSON.stringify(val)); }
+  catch (e) { /* localStorage unavailable (private browsing / quota exceeded) */ }
 }
 
 // ============================================================

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ ref: home
     {% for post in site.posts %}
     <article class="postitem">
         <ul class="meta">
-            <li class="category"><a href="">{{ post.tags }}</a></li>
+            <li class="category">{% for tag in post.tags %}<a href="/search.html">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}</li>
             <li class="date"><a href="{{ post.url }}"><time datetime="{{post.date}}">{{ post.date | date: "%b %d, %Y" }}</time></a></li>
         </ul>
         <h2 class="title">

--- a/tennis-planner-sw.js
+++ b/tennis-planner-sw.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = "tennis-planner-v1";
+const CACHE_VERSION = '2607171200';
+const CACHE_NAME = `tennis-planner-${CACHE_VERSION}`;
 const OFFLINE_URL = "/tennis-planner/";
 const PRECACHE_URLS = [
   "/tennis-planner/",

--- a/tennis-planner.html
+++ b/tennis-planner.html
@@ -185,22 +185,28 @@ permalink: /tennis-planner/
         const copyTooltipText = document.getElementById('copy-tooltip-text');
         // --- localStorage Helpers ---
         function loadSettings() {
-            return JSON.parse(localStorage.getItem('tennis-planner:settings') || '{}');
+            try { return JSON.parse(localStorage.getItem('tennis-planner:settings') || '{}'); }
+            catch (e) { return {}; }
         }
         function saveSettings(data) {
-            localStorage.setItem('tennis-planner:settings', JSON.stringify(data));
+            try { localStorage.setItem('tennis-planner:settings', JSON.stringify(data)); }
+            catch (e) { /* localStorage unavailable (private browsing / quota exceeded) */ }
         }
         function loadPlayers() {
-            return JSON.parse(localStorage.getItem('tennis-planner:players') || '{}');
+            try { return JSON.parse(localStorage.getItem('tennis-planner:players') || '{}'); }
+            catch (e) { return {}; }
         }
         function savePlayers(data) {
-            localStorage.setItem('tennis-planner:players', JSON.stringify(data));
+            try { localStorage.setItem('tennis-planner:players', JSON.stringify(data)); }
+            catch (e) { /* localStorage unavailable (private browsing / quota exceeded) */ }
         }
         function loadAvailability(monthId) {
-            return JSON.parse(localStorage.getItem(`tennis-planner:availability:${monthId}`) || '{}');
+            try { return JSON.parse(localStorage.getItem(`tennis-planner:availability:${monthId}`) || '{}'); }
+            catch (e) { return {}; }
         }
         function saveAvailability(monthId, data) {
-            localStorage.setItem(`tennis-planner:availability:${monthId}`, JSON.stringify(data));
+            try { localStorage.setItem(`tennis-planner:availability:${monthId}`, JSON.stringify(data)); }
+            catch (e) { /* localStorage unavailable (private browsing / quota exceeded) */ }
         }
         // --- Utility Functions ---
         function escapeHtml(str) {
@@ -417,9 +423,10 @@ permalink: /tennis-planner/
     <!-- PWA: Service Worker Registration & Install Prompt -->
     <script>
         // Service worker registration
+        const SW_VERSION = '2607171200';
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('/tennis-planner-sw.js').then(reg => {
+                navigator.serviceWorker.register(`/tennis-planner-sw.js?v=${encodeURIComponent(SW_VERSION)}`).then(reg => {
                     reg.addEventListener('updatefound', () => {
                         const newWorker = reg.installing;
                         newWorker.addEventListener('statechange', () => {

--- a/tuner/index.html
+++ b/tuner/index.html
@@ -515,6 +515,7 @@ permalink: /tuner/
         let silenceFrames = 0, inTuneFrames = 0;
         let wasInTune = false;
         const timeBuf = new Float32Array(FFT_SIZE);
+        let corrBuf = null;
 
         // ─── Pitch detection ─────────────────────────────────────────────────────
         function detectPitch(buf, sampleRate) {
@@ -524,7 +525,10 @@ permalink: /tuner/
 
             const minLag = Math.floor(sampleRate / 1500);
             const maxLag = Math.ceil(sampleRate / 70);
-            const corr = new Float32Array(maxLag);
+            // Reused across calls (sampleRate is constant for the session) to avoid
+            // per-frame allocation inside the requestAnimationFrame loop.
+            if (!corrBuf || corrBuf.length < maxLag) corrBuf = new Float32Array(maxLag);
+            const corr = corrBuf;
 
             for (let lag = minLag; lag < maxLag; lag++) {
                 let c = 0;


### PR DESCRIPTION
## Summary

Scheduled codebase review across all the site's apps. Fixed a bounded set of concrete, verified issues rather than attempting a sweeping rewrite:

- **Missing error handling around `localStorage`** in `auto-runner`, `f1-championship`, and `tennis-planner.html` — these calls were unguarded, so private-browsing storage blocks or `QuotaExceededError` would throw uncaught. In `auto-runner` this ran at module-init time, so it could crash the entire game before it ever rendered; in `f1-championship`'s `save()`, an uncaught throw mid-handler could leave in-memory state (`players`/`results`) out of sync with what's persisted.
- **`tennis-planner-sw.js` cache never actually versioned** — `CACHE_NAME` was a static string (`"tennis-planner-v1"`), unlike every other app's timestamped `CACHE_VERSION` convention (see `AGENTS.md`). Since the name never changed, `caches.open()` reused the same cache object across deploys and the cleanup-old-caches logic in `activate` never had anything to clean. Also folded `tennis-planner-sw.js`/`tennis-planner.html` into the existing `bump-pwa-cache-version.yml` automation, which every other PWA in the repo already gets but this one was missing from.
- **Broken homepage tag link** — `index.html` rendered `<a href="">{{ post.tags }}</a>`, an empty link dumping the raw Liquid array (e.g. `["recommendations"]`) as visible text. Now loops over `post.tags` and links each to `/search.html`.
- **CodeQL workflow had no `permissions:` block**, so it inherited the default (broader) token scope instead of least privilege. Added explicit `contents: read`, `security-events: write`, `actions: read`.
- **Perf: per-frame/per-hit allocation in hot loops** —
  - `tuner/index.html`: `detectPitch()` allocated a new `Float32Array` on every call inside the `requestAnimationFrame` loop (~60 Hz); now reuses a buffer across calls.
  - `drum-machine/index.html`: crash/shaker hits re-rendered a fresh noise buffer (up to ~1.8s / ~79k samples) from scratch on *every* single hit, run synchronously on the main thread — real GC pressure at high BPM. Replaced with a small per-duration pool of pre-rendered buffers, picked at random per hit, keeping audible hit-to-hit variation while cutting the steady-state allocation to ~zero.

## Not included (flagged but out of scope for this pass)

Broader/riskier items surfaced during review that weren't safe to land without more design/testing time: World Cup 2026's in-browser Babel/JSX transpilation and missing SRI on its React/Babel CDN tags, keyboard accessibility for the synth/music-theory on-screen pianos, the unpinned `unpkg.com/@chenglou/pretext` import in `_layouts/wrapperhome.html`, and the vendored Matter.js version in `elastomania`.

## Test plan

- [x] `bundle exec jekyll build` — succeeds (only the known-benign `Layout 'feed'` warning)
- [x] Verified rendered homepage HTML shows proper tag links (`<a href="/search.html">recommendations</a>`) instead of the raw array dump
- [x] `node --check` on every inline `<script>` block in each edited HTML file — all parse cleanly
- [x] Validated both edited GitHub Actions YAML files parse correctly
- [ ] Manual smoke-test of auto-runner/f1-championship/tennis-planner/tuner/drum-machine in a browser (not done in this environment — recommend a quick check before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCfJZ1YMKDVmRuAk1uHxc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCfJZ1YMKDVmRuAk1uHxc2)_