### PR TITLE
fix: reserve bottom safe-area for fixed buttons/controls across all PWAs

### DIFF
--- a/.claude/commands/create-pwa.md
+++ b/.claude/commands/create-pwa.md
@@ -217,6 +217,17 @@ self.addEventListener('fetch', (event) => {
 });
 ```
 
+### Safe-area bottom padding (required — do not skip)
+
+Every button or control near the bottom of the screen — a CTA at the end of a scrolling page, a fixed/sticky control bar, a floating action button, an install banner — **must** reserve space for the device's home-indicator/gesture-bar safe area, or it ends up uncomfortably close to (or under) the bottom edge on notched iOS/Android phones. Several apps in this repo shipped without this and had to be patched later — bake it in from the start instead:
+
+- Define `--safe-bottom: env(safe-area-inset-bottom, 0px);` on `:root` (or `body`) in the new app's `<style>` block.
+- Give the outermost scrolling container (the `<body>` or a `#app`/`.container` wrapper) `padding-bottom: calc(<base>px + var(--safe-bottom));` — never a bare px value — so the last button on the page always clears the safe area. `<base>` is normally 16–28px depending on the app's spacing scale.
+- Any `position: fixed`/`sticky` bottom bar or floating button gets the same treatment: `padding-bottom: calc(<base>px + var(--safe-bottom));` or `bottom: calc(<base>px + var(--safe-bottom));` instead of a fixed value.
+- Reference implementations already in this repo: `tuner/index.html`, `personal-trainer/index.html`, `crossfit-timer/index.html`, `f1-championship/index.html` — all use this pattern (`env(safe-area-inset-bottom, ...)`) on both their outer container and any fixed bottom controls.
+
+Check every place the new app touches the bottom of the viewport, not just one global rule — a fixed bottom nav needs it as much as a single "Start" button at the end of a form.
+
 ### `<slug>.html`
 
 This is a **standalone** HTML file (not using Jekyll layouts) that is self-contained, similar to `flappy.html`. Include the service worker registration script and implement the app content described by the user. Structure:
@@ -249,6 +260,15 @@ permalink: /<slug>/
     <link rel="icon" href="/img/favicon.ico" type="image/x-icon">
 
     <style>
+        :root {
+            --safe-bottom: env(safe-area-inset-bottom, 0px);
+        }
+
+        /* Give the outermost container bottom padding like:
+           padding-bottom: calc(20px + var(--safe-bottom));
+           Apply the same calc() to any fixed/sticky bottom bar or button — see
+           "Safe-area bottom padding" above. Never use a bare px value at the bottom. */
+
         /* App styles here */
     </style>
 </head>

--- a/auto-runner/index.html
+++ b/auto-runner/index.html
@@ -42,7 +42,7 @@ permalink: /auto-runner/
         if (document.getElementById('sw-banner')) return;
         const b = document.createElement('div');
         b.id = 'sw-banner';
-        b.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:#1a1833;color:#fff;padding:10px 16px;display:flex;align-items:center;justify-content:space-between;z-index:9999;font-size:14px;border-top:2px solid #7c78ff';
+        b.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:#1a1833;color:#fff;padding:10px 16px;padding-bottom:calc(10px + env(safe-area-inset-bottom, 0px));display:flex;align-items:center;justify-content:space-between;z-index:9999;font-size:14px;border-top:2px solid #7c78ff';
         b.innerHTML = '<span>Update available.</span><button style="background:#7c78ff;color:#fff;border:none;padding:6px 14px;border-radius:4px;cursor:pointer;font-weight:bold">Refresh</button>';
         b.querySelector('button').onclick = () => reg.waiting && reg.waiting.postMessage({ type: 'SKIP_WAITING' });
         document.body.appendChild(b);

--- a/binary/binary.js
+++ b/binary/binary.js
@@ -544,6 +544,7 @@ document.addEventListener("DOMContentLoaded", () => {
             banner.style.cssText = [
                 "position:fixed", "bottom:0", "left:0", "right:0",
                 "background:#1e1d3a", "color:#e2e8f0", "padding:12px 16px",
+                "padding-bottom:calc(12px + env(safe-area-inset-bottom, 0px))",
                 "display:flex", "align-items:center", "justify-content:space-between",
                 "z-index:9999", "font-family:inherit", "font-size:14px",
                 "border-top:1px solid #6366f1"

--- a/css/main.css
+++ b/css/main.css
@@ -39,6 +39,10 @@ body {
 
 body.no-site-chrome {
   padding-top: 0;
+  /* Chrome-hidden pages skip the site footer, so their own bottom content
+     (buttons, controls) becomes the last thing on screen — reserve room
+     for the home-indicator/gesture-bar safe area so it isn't flush to it. */
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 body::before {

--- a/curator/index.html
+++ b/curator/index.html
@@ -459,7 +459,7 @@
     #install-banner {
       display: none;
       position: fixed;
-      bottom: 20px;
+      bottom: calc(20px + env(safe-area-inset-bottom, 0px));
       left: 50%;
       transform: translateX(-50%);
       background: var(--surface);
@@ -962,6 +962,7 @@ if ('serviceWorker' in navigator) {
     banner.style.cssText = [
       'position:fixed', 'bottom:0', 'left:0', 'right:0',
       'background:#1a1a1a', 'color:#e5e5e5', 'padding:12px 16px',
+      'padding-bottom:calc(12px + env(safe-area-inset-bottom, 0px))',
       'display:flex', 'align-items:center', 'justify-content:space-between',
       'z-index:9999', 'font-family:inherit', 'font-size:14px',
       'border-top:1px solid #333'

--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -38,7 +38,7 @@ permalink: /elastomania/
       height: 110px;
       display: flex;
       justify-content: space-between;
-      padding: 14px 20px;
+      padding: 14px 20px calc(14px + env(safe-area-inset-bottom, 0px));
       pointer-events: none;
       z-index: 10;
     }
@@ -92,6 +92,7 @@ permalink: /elastomania/
     #sw-banner {
       position: fixed; bottom: 0; left: 0; right: 0;
       background: #1e4d2b; color: #fff; padding: 12px 16px;
+      padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
       display: flex; align-items: center; justify-content: space-between;
       z-index: 9999; font-size: 14px;
       border-top: 2px solid #5c9a3a;

--- a/flappy/index.html
+++ b/flappy/index.html
@@ -104,6 +104,7 @@ permalink: /flappy/
                 banner.style.cssText = [
                     'position:fixed', 'bottom:0', 'left:0', 'right:0',
                     'background:#1a3a3f', 'color:#fff', 'padding:12px 16px',
+                    'padding-bottom:calc(12px + env(safe-area-inset-bottom, 0px))',
                     'display:flex', 'align-items:center', 'justify-content:space-between',
                     'z-index:9999', 'font-family:inherit', 'font-size:14px',
                     'border-top:2px solid #70c5ce'

--- a/squeak-the-geek.html
+++ b/squeak-the-geek.html
@@ -100,7 +100,7 @@ permalink: /squeak-the-geek/
         #dpad {
             position: fixed;
             right: 18px;
-            bottom: 18px;
+            bottom: calc(18px + env(safe-area-inset-bottom, 0px));
             width: 140px;
             height: 140px;
             display: none;
@@ -273,6 +273,7 @@ permalink: /squeak-the-geek/
             background: #1e3a8a;
             color: #fff;
             padding: 12px 16px;
+            padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
             display: flex;
             align-items: center;
             justify-content: space-between;


### PR DESCRIPTION
## What

Buttons/controls pinned to the bottom of the screen sit too close to the device edge on notched/home-indicator phones when they don't account for `env(safe-area-inset-bottom)`. This was already fixed in a few apps (`tuner`, `crossfit-timer`, `f1-championship`, `personal-trainer`, etc.) but not consistently — this PR closes the gap everywhere else and prevents it from recurring in future apps.

## Audited every PWA in the repo

Found and fixed real bottom-anchored elements missing safe-area padding in:

- **Elasto Mania** — the on-screen throttle/brake touch controls (`#touch-controls`), the highest-impact fix since these are actual gameplay buttons
- **Squeak the Geek** — the on-screen d-pad (`#dpad`)
- **Curator** — the install banner (`#install-banner`)
- **Binary Puzzle, Curator, Auto Runner, Elasto Mania, Squeak the Geek, Flappy Bird** — the shared "update available" service-worker banner pattern (`#sw-banner`/`#sw-update-banner`), each copy-pasted with a hardcoded `bottom:0` + flat padding

`tennis-planner.html` was checked and has no real bottom-anchored element (its only fixed banner is pinned to the *top*), so it's untouched.

## Defense in depth

- `css/main.css`: `body.no-site-chrome` (used by any Jekyll-layout page that hides the site footer, like Binary Puzzle) now reserves `padding-bottom: env(safe-area-inset-bottom, 0px)` globally, so a future page in that mode gets this for free even if its own CSS forgets.
- `.claude/commands/create-pwa.md` (the scaffold used to generate new PWAs in this repo): added a required "Safe-area bottom padding" section explaining the pattern with reference implementations, and baked a `--safe-bottom` custom property + inline comment directly into the generated boilerplate's `<style>` block, so new apps start with it instead of needing a follow-up fix.

## Testing

- `bundle exec jekyll build` passes (only the known benign `feed` layout warning).
- Verified via Playwright on an iPhone 14 Pro emulation profile that the changed elements render identically to before (no visual regression — `env()` correctly falls back to its base value when there's no real safe-area inset), and that the `calc()` expressions resolve to valid computed CSS.
- All touched pages (`binary/`, `elastomania/`, `squeak-the-geek/`, `curator/`, `auto-runner/`, `flappy/`) load with HTTP 200 from a local Jekyll server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_