### PR TITLE
feat(f1-championship): steady car speed in the Championship Race

### DIFF
--- a/f1-championship/index.html
+++ b/f1-championship/index.html
@@ -1377,8 +1377,6 @@ const chase = {
 };
 
 function lerp(a, b, t) { return a + (b - a) * t; }
-function easeInOutCubic(t) { return t < 0.5 ? 4*t*t*t : 1 - Math.pow(-2*t + 2, 3) / 2; }
-function easeOutBack(t) { const c1 = 1.70158, c3 = c1 + 1; return 1 + c3*Math.pow(t-1,3) + c1*Math.pow(t-1,2); }
 
 function buildChaseLUT() {
   chase.lut = [];
@@ -1418,7 +1416,7 @@ function distOf(pts, roundNum) {
 // Cars launch from a staggered starting grid; the offset blends out over round 1.
 function staggerFactor(seg, u) {
   if (seg <= 0) return 1;
-  if (seg === 1) return 1 - easeInOutCubic(u);
+  if (seg === 1) return 1 - u;
   return 0;
 }
 
@@ -1489,11 +1487,11 @@ function renderChaseFrame(seg, u, snap) {
   chase.cars.forEach((car, i) => {
     const fPrev = chase.frames[Math.max(seg - 1, 0)];
     const fNext = chase.frames[seg];
-    const overtaking = seg > 0 && fNext.pos[car.pid] < fPrev.pos[car.pid];
-    const e = overtaking ? easeOutBack(u) : easeInOutCubic(u);
     const dPrev = distOf(fPrev.points[car.pid], fPrev.round);
     const dNext = distOf(fNext.points[car.pid], fNext.round);
-    const d = lerp(dPrev, dNext, e) - i * CHASE.GRID_GAP * stag;
+    // Linear interpolation keeps the cars moving at a steady speed between races
+    // rather than easing to a stop at every race result.
+    const d = lerp(dPrev, dNext, u) - i * CHASE.GRID_GAP * stag;
     const lat = laneOffsetOf(i, n, car.pid, seg, u);
     placeCar(car, d, lat);
     const pts = Math.round(lerp(fPrev.points[car.pid], fNext.points[car.pid], u));
@@ -1879,7 +1877,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (migrated) save('players', players);
 
   if ('serviceWorker' in navigator) {
-    const SW_VERSION = '2607181007';
+    const SW_VERSION = '2607181241';
     let hasRefreshedForUpdate = false;
 
     function showUpdateBanner(registration) {

--- a/f1-championship/sw.js
+++ b/f1-championship/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607181007';
+const CACHE_VERSION = '2607181241';
 const CACHE_NAME = `f1-championship-${CACHE_VERSION}`;
 const OFFLINE_URL = '/f1-championship/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Summary

Makes the cars in the Championship Race replay move at a **steady speed** instead of stopping at every race result.

## Change

Previously each car eased in and out of every round (cubic easing, with an overshoot for overtakes), which meant its velocity dropped to zero at every race boundary — a visible stop-start on each result. Cars now **interpolate linearly** between race waypoints, so motion is continuous from one race to the next. The starting-grid launch also blends out linearly, and the now-unused easing helpers are removed. The lateral overtake swerve is unchanged, so passes still read clearly.

## Verification

Driven with Playwright over a full 24-race season: sampled the leader's position every 120 ms across several race boundaries — **75 mid-run steps, zero near-zero (stall) steps**, confirming continuous motion with no stopping. Full playback still completes with the winner banner, and landscape/portrait plus scrub paths run with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNaAiQiWwgX27BXdzHnVqt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNaAiQiWwgX27BXdzHnVqt)_