### PR TITLE
fix(personal-trainer): buttons on tall screens still hit the bottom edge

### DIFF
--- a/.claude/commands/create-pwa.md
+++ b/.claude/commands/create-pwa.md
@@ -228,6 +228,8 @@ Every button or control near the bottom of the screen — a CTA at the end of a 
 
 Check every place the new app touches the bottom of the viewport, not just one global rule — a fixed bottom nav needs it as much as a single "Start" button at the end of a form.
 
+**Gotcha — verify the padding can actually apply.** Reserving the safe area only works if the element carrying that padding is free to grow with its content. If you center a max-width app shell with `body { display: flex; justify-content: center; }` (no `flex-direction`/`align-items` override), the shell becomes a *stretched* flex item clamped to `body`'s height — on any screen taller than one viewport, its content (and the bottom padding) overflows the box instead of growing it, so the page scrolls right past the reserved padding and buttons end up flush against the edge again. This bit `personal-trainer/index.html` after it already had the `env(safe-area-inset-bottom)` padding in place. If you use this centering pattern, add `align-items: flex-start;` to `body` (or use `margin: 0 auto` on the shell instead of flex centering) — then check a screen with enough content to require scrolling, not just the first short screen, since the bug is invisible until content overflows.
+
 ### `<slug>.html`
 
 This is a **standalone** HTML file (not using Jekyll layouts) that is self-contained, similar to `flappy.html`. Include the service worker registration script and implement the app content described by the user. Structure:

--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -61,6 +61,12 @@ permalink: /personal-trainer/
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
             display: flex;
             justify-content: center;
+            /* Without this, #app is a stretched flex item clamped to body's height —
+               its content (and bottom safe-area padding) then overflows the box
+               instead of growing it, so the page scrolls past the padding entirely
+               on any screen taller than one viewport. flex-start lets #app size to
+               its own content so the padding always wraps the true bottom edge. */
+            align-items: flex-start;
         }
 
         #app {


### PR DESCRIPTION
## What

Follow-up to #257 — the bottom safe-area padding didn't quite work on the Personal Trainer PWA. You were right: the `env(safe-area-inset-bottom)` padding on `#app` was correct, but it was never actually reachable on any screen taller than one viewport (workout preview, exercise library, a populated home screen) — exactly where a "bottom button" needs it most.

## Root cause

`body { display: flex; justify-content: center; }` has no `flex-direction`/`align-items` override, so `#app` is treated as a **stretched flex item clamped to body's height**. When a screen's content is taller than the viewport, `#app`'s content — including its own bottom padding — overflows that clamped box instead of growing it. The page still scrolls (the overflow is visually painted), but it scrolls right past the reserved padding, so the last button on a long screen lands flush against the physical bottom edge again, safe-area fix or not.

## Fix

Add `align-items: flex-start;` to `body`. This stops the vertical stretch-clamp so `#app` sizes to its own content, letting the bottom padding wrap the true end of the scrolled content on every screen. `justify-content: center` still centers the shell horizontally on wide viewports — verified unaffected.

## Verification

Used Chrome DevTools Protocol's `Emulation.setSafeAreaInsetsOverride` to simulate a real 34px bottom safe-area inset (something a normal browser/emulator can't fake), then measured the gap between the last button and the viewport bottom on every screen after scrolling to the true end of content:

| Screen | Before fix | After fix |
|---|---|---|
| Preview ("Start workout") | **0px** (flush) | 62px (28 base + 34 safe-area) ✓ |
| Player (controls) | 31px (only correct by luck — no overflow yet) | 62px ✓ |
| Library | negative/off-screen artifacts | 107px ✓ |
| Home | ~17px | 79px ✓ |

Also confirmed: horizontal centering on a wide (1400px) desktop viewport is unaffected (`#app` still perfectly centered), and re-ran the existing Playwright regression suite for the exercise library video feature — all checks still pass.

Documented the gotcha in `.claude/commands/create-pwa.md` so any future centered app shell in this repo doesn't repeat it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_