### PR TITLE
fix(personal-trainer): fill viewport with page background, not white

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -52,11 +52,15 @@ permalink: /personal-trainer/
         body {
             height: 100%;
             overscroll-behavior-y: none;
+            /* Same background as body: if the shell (#app) ever renders shorter
+               than the true visible viewport — mobile browsers resize their
+               toolbar dynamically, so 100% height can under- or over-shoot it —
+               this is what shows through instead of the browser's default white. */
+            background: linear-gradient(180deg, #131a27 0%, #0e131e 55%, #0b0f18 100%);
+            background-attachment: fixed;
         }
 
         body {
-            background: linear-gradient(180deg, #131a27 0%, #0e131e 55%, #0b0f18 100%);
-            background-attachment: fixed;
             color: var(--text);
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
             display: flex;
@@ -73,6 +77,7 @@ permalink: /personal-trainer/
             width: 100%;
             max-width: 520px;
             min-height: 100%;
+            min-height: 100dvh;
             display: flex;
             flex-direction: column;
             /* add margin ON TOP of the safe areas so the iOS home indicator never sits on a button */


### PR DESCRIPTION
## What

Follow-up to #261 — after that fix, some Personal Trainer screens showed white space at the bottom instead of the app's dark background.

## Why

The #261 fix (`align-items: flex-start` on `body`) was correct and necessary, but it had a side effect: `#app` no longer force-stretches to exactly match `body`'s height — it now sizes to its own content, using `min-height: 100%` only as a floor. On mobile browsers, a plain `100%`/`100vh`-style height can fall slightly short of the *true* visible viewport because the address bar/toolbar resizes dynamically. Before #261, the forced stretch masked this by hard-clamping `#app` to `body`'s box regardless of any mismatch; once that clamp was removed, any shortfall became visible as a gap — and since only `body` (not `html`) had the dark gradient background, that gap showed the browser's default white canvas underneath.

## Fix

- Give `html` the same gradient background as `body`, so any such gap is invisible no matter how the height math resolves.
- Use `min-height: 100dvh` on `#app` (in addition to the existing `100%` fallback) so it tracks the real dynamic viewport on mobile instead of the static layout viewport — the same pattern already used by `crossfit-timer`, `curator`, and `music-theory` elsewhere in this repo.

## Verification

- Artificially shrank `#app` to 50px via injected CSS and confirmed the entire viewport still renders the dark gradient with no white showing through (screenshot in testing).
- Re-ran the existing Playwright regression suite for the exercise-library video feature — all checks still pass.
- `bundle exec jekyll build` passes (only the known benign `feed` layout warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_