### PR TITLE
fix(personal-trainer): stop white flash in safe area on back navigation

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1850,6 +1850,15 @@ permalink: /personal-trainer/
         // =====================================================
         // Screens / navigation
         // =====================================================
+        // The browser's own scroll-position restoration on history back/forward
+        // fights with the manual scrollTo(0,0) below, and in standalone iOS PWAs
+        // that mismatch is what flashes the native (white) layer underneath for
+        // a frame during a back navigation — most visible in the bottom safe
+        // area since the rest of the screen is usually covered by content.
+        if ('scrollRestoration' in history) {
+            history.scrollRestoration = 'manual';
+        }
+
         function show(id) {
             document.querySelectorAll('.screen').forEach((s) => s.classList.toggle('active', s.id === id));
             window.scrollTo(0, 0);


### PR DESCRIPTION
## What

The bottom safe area flashes white when returning from any screen in the Personal Trainer PWA.

## Why

The app pushes one history entry per screen (`home` → `preview` → `player`) so the Android hardware back button and Safari's edge swipe-back gesture both work for in-app navigation. In a standalone iOS PWA, the browser's own automatic scroll-position restoration on history back/forward races against this app's manual `window.scrollTo(0, 0)` inside `show()`. During that brief mismatch, the native layer underneath the page shows through — most visible along the bottom safe area, since the rest of the screen is normally covered by opaque content.

## Fix

Set `history.scrollRestoration = 'manual'` once at load, so the browser never attempts its own scroll restoration on back/forward — only this app's own reset in `show()` runs.

## Verification

- Confirmed `history.scrollRestoration` is `'manual'` after load.
- Smoke-tested every navigation path, including the multi-level jump (`home → preview → player → quit`, which calls `history.go(-2)`) — all still land on the correct screen.
- Re-ran both existing Playwright regression suites (library video, achievements/records) — no failures.
- `bundle exec jekyll build` passes (only the known benign `feed` layout warning).

**Caveat:** the flash itself is a native WebKit rendering behavior in standalone iOS home-screen apps and can't be reproduced in this sandboxed headless testing environment (no real iOS/Safari available). This is the standard, well-documented fix for exactly this symptom, but please confirm on your device that it's resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_