### PR TITLE
Fix knockout score refresh swapping teams (France/Morocco bug)

### DIFF
--- a/worldcup-2026/index.html
+++ b/worldcup-2026/index.html
@@ -4740,13 +4740,21 @@ function App(){
         ['r32','r16','qf','sf','final','third'].forEach(round=>{
           next[round].forEach((m,idx)=>{
             if(!m.teamA||!m.teamB) return;
-            const key=[m.teamA,m.teamB].sort().join('|');
+            const sorted=[m.teamA,m.teamB].sort();
+            const key=sorted.join('|');
             const s=data.ko[key];
             if(!s) return;
-            if(s.scoreA!=null) next[round][idx].scoreA=s.scoreA;
-            if(s.scoreB!=null) next[round][idx].scoreB=s.scoreB;
-            next[round][idx].penA=s.penA??null;
-            next[round][idx].penB=s.penB??null;
+            // scores.json stores scoreA/scoreB relative to the sorted team
+            // order, which may not match this match's teamA/teamB order.
+            const swap=m.teamA!==sorted[0];
+            const sA=swap?s.scoreB:s.scoreA;
+            const sB=swap?s.scoreA:s.scoreB;
+            const pA=swap?s.penB:s.penA;
+            const pB=swap?s.penA:s.penB;
+            if(sA!=null) next[round][idx].scoreA=sA;
+            if(sB!=null) next[round][idx].scoreB=sB;
+            next[round][idx].penA=pA??null;
+            next[round][idx].penB=pB??null;
           });
         });
         return propagateKO(next,groupMatches);

--- a/worldcup-2026/scripts/fetch-scores.js
+++ b/worldcup-2026/scripts/fetch-scores.js
@@ -138,10 +138,15 @@ async function main() {
       const appRound = STAGE_MAP[stage];
       if (!appRound) { console.warn(`Unknown stage: "${stage}"`); continue; }
 
-      // Store by sorted team pair; the app resolves to the correct match at read time
-      const key  = [apiHome, apiAway].sort().join('|');
+      // Store by sorted team pair, with scoreA/scoreB relative to that sorted
+      // order (not home/away) — the app looks up by sorted key and has no
+      // other way to know which team was home.
+      const sorted = [apiHome, apiAway].sort();
+      const key    = sorted.join('|');
+      const [sA, sB] = apiHome === sorted[0] ? [scoreH, scoreA] : [scoreA, scoreH];
+      const [pA, pB] = apiHome === sorted[0] ? [penH, penA] : [penA, penH];
       const prev = newKO[key] || {};
-      const next = { scoreA: scoreH, scoreB: scoreA, penA: penH, penB: penA };
+      const next = { scoreA: sA, scoreB: sB, penA: pA, penB: pB };
       if (JSON.stringify(prev) !== JSON.stringify(next)) {
         newKO[key] = next;
         changed = true;


### PR DESCRIPTION
## Summary
- Refreshing scores in the World Cup 2026 app could show the wrong team as the winner of a knockout match (reported case: France 2–0 Morocco displayed as a Morocco win).
- Root cause: `worldcup-2026/scores.json` keys knockout results by an alphabetically-sorted `"TeamA|TeamB"` pair, but `applyAutoScores()` in `worldcup-2026/index.html` assigned `scoreA -> m.teamA` and `scoreB -> m.teamB` unconditionally — flipping the score whenever the bracket's `teamA`/`teamB` slot order didn't match alphabetical order.
- Fixed `applyAutoScores()` to swap the stored scores back onto the match's actual `teamA`/`teamB` when they differ from the sorted key order.
- Also fixed `worldcup-2026/scripts/fetch-scores.js` to store `scoreA`/`scoreB` relative to the same sorted order (instead of home/away), so both sides agree on what the stored values represent.

## Test plan
- [x] Simulated `applyAutoScores` swap logic against both bracket orderings (`teamA=France,teamB=Morocco` and `teamA=Morocco,teamB=France`) using the stored `France|Morocco` score (2–0) — confirmed France now always ends up with 2 and Morocco with 0, regardless of slot order.
- [ ] Manually verify in the running app that refreshing scores shows the correct winner for this and other knockout matches.


---
_Generated by [Claude Code](https://claude.ai/code/session_013Zd1HHnGJvJ3sF2CRLcrj2)_