### PR TITLE
Fix cross-app cache wipe, flappy asset 404s, and several site bugs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,7 +29,7 @@
     <link rel="apple-touch-icon" href="/img/synth-icon-192.png">
     <link rel="manifest" href="/synth/manifest.json">
     {% endif %}
-    {% seo %}
+    {% seo title=false %}
 </head>
 
 <body{% if page.hide_site_chrome %} class="no-site-chrome"{% endif %}>
@@ -57,13 +57,13 @@
                         <a class="nav-link" href="{% if lang == 'pt-BR' %}/pt-BR/blog{% else %}/blog{% endif %}">{{ t.nav.blog }}</a>
                     </li>
                     <li class="nav-item ms-lg-3 nav-social">
-                        <a class="nav-link" href="https://github.com/jorgecensi" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
+                        <a class="nav-link" href="https://github.com/jorgecensi" target="_blank" rel="noopener noreferrer" title="GitHub"><i class="fab fa-github"></i></a>
                     </li>
                     <li class="nav-item nav-social">
-                        <a class="nav-link" href="https://linkedin.com/in/jorgecensi" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
+                        <a class="nav-link" href="https://linkedin.com/in/jorgecensi" target="_blank" rel="noopener noreferrer" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
                     </li>
                     <li class="nav-item nav-social">
-                        <a class="nav-link" href="https://x.com/jorgecensi" target="_blank" title="X"><i class="fab fa-x-twitter"></i></a>
+                        <a class="nav-link" href="https://x.com/jorgecensi" target="_blank" rel="noopener noreferrer" title="X"><i class="fab fa-x-twitter"></i></a>
                     </li>
                     <li class="nav-item ms-lg-2">
                         {% include lang-switcher.html %}
@@ -84,9 +84,9 @@
             </div>
             <p class="footer-tagline">{{ t.footer.tagline }}</p>
             <ul class="footer-social">
-                <li><a href="https://github.com/jorgecensi" target="_blank" title="GitHub"><i class="fab fa-github"></i></a></li>
-                <li><a href="https://linkedin.com/in/jorgecensi" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a></li>
-                <li><a href="https://x.com/jorgecensi" target="_blank" title="X"><i class="fab fa-x-twitter"></i></a></li>
+                <li><a href="https://github.com/jorgecensi" target="_blank" rel="noopener noreferrer" title="GitHub"><i class="fab fa-github"></i></a></li>
+                <li><a href="https://linkedin.com/in/jorgecensi" target="_blank" rel="noopener noreferrer" title="LinkedIn"><i class="fab fa-linkedin"></i></a></li>
+                <li><a href="https://x.com/jorgecensi" target="_blank" rel="noopener noreferrer" title="X"><i class="fab fa-x-twitter"></i></a></li>
             </ul>
             <p class="footer-copy">&copy; {{ 'now' | date: '%Y' }} Jorge Censi. {{ t.footer.copy_suffix }}</p>
         </div>

--- a/css/main.css
+++ b/css/main.css
@@ -1487,7 +1487,7 @@ footer .footer-copy {
 }
 
 .cli-boot {
-  color: var(--color-primary-light);
+  color: var(--primary-light);
 }
 
 .cli-echoed {
@@ -1502,29 +1502,29 @@ footer .footer-copy {
 }
 
 .cli-prompt {
-  color: var(--color-primary-light);
+  color: var(--primary-light);
   user-select: none;
   margin-right: 6px;
 }
 
 .cli-key {
-  color: var(--color-accent);
+  color: var(--accent);
   background: rgba(245, 158, 11, 0.1);
   padding: 1px 5px;
   border-radius: 3px;
   font-size: 0.8em;
 }
 
-.cli-accent  { color: var(--color-primary-light); }
+.cli-accent  { color: var(--primary-light); }
 .cli-comment { color: var(--text-muted); font-style: italic; }
 .cli-muted   { color: var(--text-muted); }
 .cli-error   { color: #fc8181; }
 
 .cli-link {
-  color: var(--color-cyan);
+  color: var(--cyan);
   text-decoration: none;
 }
-.cli-link:hover { text-decoration: underline; color: var(--color-cyan); }
+.cli-link:hover { text-decoration: underline; color: var(--cyan); }
 
 #jorge-cli-inputline {
   display: flex;
@@ -1543,7 +1543,7 @@ footer .footer-copy {
   color: var(--text-primary);
   font-family: inherit;
   font-size: 0.82rem;
-  caret-color: var(--color-primary-light);
+  caret-color: var(--primary-light);
   padding: 0;
 }
 

--- a/curator/sw.js
+++ b/curator/sw.js
@@ -26,7 +26,7 @@ self.addEventListener('message', e => {
 self.addEventListener('activate', e => {
   e.waitUntil(
     caches.keys().then(keys =>
-      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+      Promise.all(keys.filter(k => k !== CACHE && k.startsWith('curator-')).map(k => caches.delete(k)))
     )
   );
   self.clients.claim();

--- a/drum-machine/sw.js
+++ b/drum-machine/sw.js
@@ -17,7 +17,7 @@ self.addEventListener('activate', event => {
         caches.keys().then(keys =>
             Promise.all(
                 keys
-                    .filter(key => key !== CACHE_NAME)
+                    .filter(key => key !== CACHE_NAME && key.startsWith('drum-machine-'))
                     .map(key => caches.delete(key))
             )
         )

--- a/f1-championship/index.html
+++ b/f1-championship/index.html
@@ -883,7 +883,7 @@ function esc(s) { return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&
 // AVATAR HELPERS
 // ============================================================
 function avatarInner(player, fontSize) {
-  if (player.photo) return `<img class="avatar-img" src="${player.photo}" alt="${esc(player.name)}">`;
+  if (player.photo) return `<img class="avatar-img" src="${esc(player.photo)}" alt="${esc(player.name)}">`;
   return `<div class="avatar-letter" style="background:${esc(player.color)};font-size:${fontSize}px">${esc(player.avatar)}</div>`;
 }
 

--- a/flappy/flappyBird.js
+++ b/flappy/flappyBird.js
@@ -58,16 +58,16 @@ class FlappyBird {
     
     async loadAssets() {
         const imageFiles = [
-            { key: 'bird', src: 'img/bird.png' },
-            { key: 'bg', src: 'img/bg.png' },
-            { key: 'fg', src: 'img/fg.png' },
-            { key: 'pipeNorth', src: 'img/pipeNorth.png' },
-            { key: 'pipeSouth', src: 'img/pipeSouth.png' }
+            { key: 'bird', src: '/img/bird.png' },
+            { key: 'bg', src: '/img/bg.png' },
+            { key: 'fg', src: '/img/fg.png' },
+            { key: 'pipeNorth', src: '/img/pipeNorth.png' },
+            { key: 'pipeSouth', src: '/img/pipeSouth.png' }
         ];
-        
+
         const soundFiles = [
-            { key: 'fly', src: 'sounds/fly.mp3' },
-            { key: 'score', src: 'sounds/score.mp3' }
+            { key: 'fly', src: '/sounds/fly.mp3' },
+            { key: 'score', src: '/sounds/score.mp3' }
         ];
         
         // Load images

--- a/js/jorge-cli.js
+++ b/js/jorge-cli.js
@@ -85,7 +85,7 @@
 
   <span class="cli-accent">GigHub</span>
     App for freelancers to manage gigs and clients
-    <a href="https://github.com/jorgecensi" target="_blank" class="cli-link">github.com/jorgecensi</a>
+    <a href="https://github.com/jorgecensi" target="_blank" rel="noopener noreferrer" class="cli-link">github.com/jorgecensi</a>
 
   <span class="cli-accent">Marcador Canastra</span>
     Score tracker for the classic Brazilian card game
@@ -117,9 +117,9 @@
   const CONTACT_TEXT = `
 <span class="cli-comment"># get in touch</span>
 
-  <span class="cli-accent">GitHub</span>    <a href="https://github.com/jorgecensi" target="_blank" class="cli-link">github.com/jorgecensi</a>
-  <span class="cli-accent">LinkedIn</span>  <a href="https://linkedin.com/in/jorgecensi" target="_blank" class="cli-link">linkedin.com/in/jorgecensi</a>
-  <span class="cli-accent">X</span>         <a href="https://x.com/jorgecensi" target="_blank" class="cli-link">x.com/jorgecensi</a>
+  <span class="cli-accent">GitHub</span>    <a href="https://github.com/jorgecensi" target="_blank" rel="noopener noreferrer" class="cli-link">github.com/jorgecensi</a>
+  <span class="cli-accent">LinkedIn</span>  <a href="https://linkedin.com/in/jorgecensi" target="_blank" rel="noopener noreferrer" class="cli-link">linkedin.com/in/jorgecensi</a>
+  <span class="cli-accent">X</span>         <a href="https://x.com/jorgecensi" target="_blank" rel="noopener noreferrer" class="cli-link">x.com/jorgecensi</a>
 `;
 
   const COFFEE_TEXT = `
@@ -139,13 +139,13 @@
 
   Executing <span class="cli-accent">hire jorge</span>...
 
-  ✓ Checking availability............. <span style="color:var(--color-green)">OPEN</span>
-  ✓ Verifying skills.................. <span style="color:var(--color-green)">VERIFIED</span>
-  ✓ Confirming AI expertise........... <span style="color:var(--color-green)">CONFIRMED</span>
-  ✓ Calculating culture fit........... <span style="color:var(--color-green)">HIGH</span>
+  ✓ Checking availability............. <span style="color:var(--green)">OPEN</span>
+  ✓ Verifying skills.................. <span style="color:var(--green)">VERIFIED</span>
+  ✓ Confirming AI expertise........... <span style="color:var(--green)">CONFIRMED</span>
+  ✓ Calculating culture fit........... <span style="color:var(--green)">HIGH</span>
 
   <span class="cli-accent">Result:</span> Great idea. Reach out on LinkedIn.
-  <a href="https://linkedin.com/in/jorgecensi" target="_blank" class="cli-link">→ linkedin.com/in/jorgecensi</a>
+  <a href="https://linkedin.com/in/jorgecensi" target="_blank" rel="noopener noreferrer" class="cli-link">→ linkedin.com/in/jorgecensi</a>
 `;
 
   const LS_TEXT = `

--- a/pt-BR/index.html
+++ b/pt-BR/index.html
@@ -41,6 +41,12 @@ ref: home
             <p>Seu feed pessoal do YouTube. Sem algoritmo, sem recomendações — você decide o que entra. Funciona offline como PWA.</p>
             <span class="app-tag">PWA</span>
         </a>
+        <a class="app-card" href="/auto-runner/">
+            <span class="app-icon">🏃</span>
+            <h3>Auto Runner</h3>
+            <p>Jogo cooperativo para 2 jogadores em side-scroller. Toque no seu lado para pular. Um erro e os dois reiniciam — sobrevivam juntos.</p>
+            <span class="app-tag">Jogo</span>
+        </a>
         <a class="app-card" href="/flappy/">
             <span class="app-icon">🐦</span>
             <h3>{{ t.apps_page.flappy_title }}</h3>
@@ -65,11 +71,41 @@ ref: home
             <p>Um sequenciador circular inspirado no Dato Drum. Crie batidas com 4 vozes, efeitos e controle de BPM.</p>
             <span class="app-tag">PWA</span>
         </a>
+        <a class="app-card" href="/f1-championship/">
+            <span class="app-icon">🏎️</span>
+            <h3>F1 Championship</h3>
+            <p>Acompanhe seu campeonato de tempos de volta ao longo da temporada completa de F1 2026. Compita corrida a corrida, ganhe pontos e veja quem lidera a classificação.</p>
+            <span class="app-tag">PWA</span>
+        </a>
+        <a class="app-card" href="/worldcup-2026/">
+            <span class="app-icon">⚽</span>
+            <h3>World Cup 2026</h3>
+            <p>Placar interativo para as 48 seleções — classificação dos grupos, chave eliminatória com pênaltis e estatísticas ao vivo. Todos os horários em AEST.</p>
+            <span class="app-tag">PWA</span>
+        </a>
         <a class="app-card" href="/tuner/">
             <span class="app-icon">🎸</span>
             <h3>Tuner</h3>
             <p>Afine seu violão ou ukulele em tempo real. Detecção de tom por autocorrelação — preciso ao centésimo. Funciona offline como PWA.</p>
             <span class="app-tag">PWA</span>
+        </a>
+        <a class="app-card" href="/music-theory/">
+            <span class="app-icon">🎹</span>
+            <h3>Music Theory</h3>
+            <p>Aprenda escalas, acordes e intervalos em um teclado de piano interativo. Toque qualquer tecla para ouvir, selecione uma escala para vê-la acender. Funciona offline.</p>
+            <span class="app-tag">PWA de Música</span>
+        </a>
+        <a class="app-card" href="/elastomania/">
+            <span class="app-icon">🏍️</span>
+            <h3>Elasto Mania</h3>
+            <p>Um jogo de física de motocicleta. Colete todas as maçãs, alcance a flor — sem cair.</p>
+            <span class="app-tag">Jogo</span>
+        </a>
+        <a class="app-card" href="/squeak-the-geek/">
+            <span class="app-icon">🐸</span>
+            <h3>Squeak the Geek</h3>
+            <p>Um quebra-cabeça de labirinto de tijolos inspirado em Zeek the Geek. Colete as flores, empurre blocos de cristal e desvie do sapo.</p>
+            <span class="app-tag">Jogo</span>
         </a>
         <a class="app-card" href="/personal-trainer/">
             <span class="app-icon">💪</span>
@@ -84,7 +120,7 @@ ref: home
     {% for post in site.posts %}
     <article class="postitem">
         <ul class="meta">
-            <li class="category"><a href="">{{ post.tags }}</a></li>
+            <li class="category">{% for tag in post.tags %}<a href="/pt-BR/search.html">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}</li>
             <li class="date"><a href="{{ post.url }}"><time datetime="{{post.date}}">{{ post.date | date: "%d/%m/%Y" }}</time></a></li>
         </ul>
         <h2 class="title">

--- a/worldcup-2026/scripts/fetch-scores.js
+++ b/worldcup-2026/scripts/fetch-scores.js
@@ -89,6 +89,10 @@ function fetch_json(urlPath) {
       let raw = '';
       res.on('data', c => raw += c);
       res.on('end', () => {
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(`API request failed: ${res.statusCode}\nBody: ${raw.slice(0,300)}`));
+          return;
+        }
         try { resolve(JSON.parse(raw)); }
         catch(e) { reject(new Error(`JSON parse: ${e.message}\nBody: ${raw.slice(0,300)}`)); }
       });


### PR DESCRIPTION
## Summary

Routine codebase review across the Jekyll site and all ~15 standalone PWA apps. Three parallel reviews (core site, and two batches of apps) turned up a real cross-app bug plus several smaller correctness/security/UX issues. This PR fixes the highest-value, lowest-risk findings; a longer list of lower-priority items is included below for awareness (not fixed in this PR).

## Fixed in this PR

- **`drum-machine/sw.js`, `curator/sw.js`** — the `activate` handler deleted *every* Cache Storage entry on the origin except its own, instead of just its own app's old versions. Since Cache Storage is shared per-origin, visiting `/drum-machine/` or `/curator/` silently wiped the offline cache of every other installed PWA on the site. Scoped the deletion to the app's own cache-name prefix, matching the pattern already used by 6 of the other 8 apps.
- **`flappy/flappyBird.js`** — image/sound assets were loaded with page-relative paths (`img/bird.png`, `sounds/fly.mp3`); since the page is served at `/flappy/`, these resolved to `/flappy/img/...` and 404'd, so the game rendered a blank canvas with no sound. Switched to root-relative paths (`/img/...`, `/sounds/...`), matching every other app.
- **`f1-championship/index.html`** — `avatarInner()` interpolated `player.photo` into an `<img src>` without escaping (every other field in the function was already escaped). Since `photo` round-trips through the profile Export/Import feature, a crafted backup file could break out of the attribute — closed via `esc()`.
- **`pt-BR/index.html`** — the blog post tag markup was `<a href="">{{ post.tags }}</a>`, an empty link dumping the raw tags array as text. Fixed to loop per-tag and link to `/pt-BR/search.html`, matching the English page's pattern.
- **`pt-BR/index.html`** — the Portuguese homepage was missing 6 of the 15 "Things I've Built" app cards (Auto Runner, F1 Championship, World Cup 2026, Music Theory, Elasto Mania, Squeak the Geek). Added them with Portuguese copy so Portuguese-speaking visitors can discover/reach every app.
- **`_layouts/default.html`, `js/jorge-cli.js`** — added `rel="noopener noreferrer"` to the ~9 external `target="_blank"` links (GitHub/LinkedIn/X in nav, footer, and the terminal easter-egg), closing a reverse-tabnabbing gap.
- **`_layouts/default.html`** — removed the duplicate `<title>` tag: the layout hardcoded one and `{% seo %}` (jekyll-seo-tag) rendered a second one; now `{% seo title=false %}` so only one `<title>` is emitted.
- **`css/main.css`, `js/jorge-cli.js`** — `var(--color-primary-light)`, `var(--color-accent)`, `var(--color-cyan)`, `var(--color-green)` were referenced but never defined anywhere (`:root` only defines `--primary-light`, `--accent`, `--cyan`, `--green`), so the terminal easter-egg's accent/link/status colors silently fell back to inherited text color. Fixed the references to match the defined custom properties.
- **`worldcup-2026/scripts/fetch-scores.js`** — `fetch_json()` never checked the HTTP status code, so an API error (401/429/500) with a JSON error body was silently treated as "0 finished matches" / "No score changes," masking auth/rate-limit/outage failures as a successful run. Now rejects (and the script exits non-zero) on non-2xx responses.

## Also found, not fixed in this PR (lower priority / needs more design or is informational)

- Duplicated service-worker boilerplate across 8 apps has drifted (root cause of the cache-wipe bug above); worth factoring into a shared template.
- Several `sw.js` files don't use `{cache:'reload'}` on `cache.addAll`, so a version bump can re-cache a stale HTTP-cached response.
- `music-theory/sw.js` never updates the cached shell on navigation (opportunistic cache-put missing).
- `curator/index.html` interpolates `cur.thumb`/`cur.id` into attributes without escaping (low risk — YouTube-controlled data, but inconsistent with nearby escaped fields).
- Uncapped `requestAnimationFrame` loops without delta-time in `flappy` and `auto-runner` — gameplay speed varies with display refresh rate (120Hz vs 60Hz).
- `elastomania` rebuilds all physics bodies from scratch on every respawn and does an O(n) linear scan in `getTerrainY` where the data is already sorted (binary search would fit).
- Missing `onerror` fallbacks for images/scripts across several game apps (broken image icons, uncaught `ReferenceError` if `matter.min.js` fails to load).
- Custom dropdown/pad/slider controls in `drum-machine`, `synth`, `tuner`, and `worldcup-2026` likely aren't keyboard-accessible — needs a manual a11y pass.
- Two parallel, drifting content-authoring systems for EN/pt-BR copy (hardcoded HTML vs. `_data/translations/*.yml`, with several YAML keys now unused) — would benefit from consolidating onto one approach.
- No `hreflang` alternate links between the EN/pt-BR page pairs, and no fallback text/`aria-label` for the canvas-based rotating homepage subtitle (both SEO/accessibility gaps).
- `blog/atom.xml` is hand-maintained and hardcodes `http://jorgecensi.github.io` instead of the canonical `https://jorgecensi.com` domain; `jekyll-feed` (already enabled) generates a correct feed automatically and could replace it.
- Render-blocking Bootstrap/Font Awesome/Google Fonts loaded in full on every page, including tiny pages like `search.html`, when only a handful of icons/weights are used.

## Test plan

- [x] `bundle exec jekyll build` completes successfully with no new warnings (only the pre-existing, documented-benign `Layout 'feed'` warning).
- [x] Verified `_site/index.html` and `_site/pt-BR/index.html` each render exactly one `<title>` tag and 15 app cards.
- [x] Verified rendered pt-BR post tags link to `/pt-BR/search.html` instead of an empty href.
- [x] `node --check` passed on all edited `.js` files (`flappyBird.js`, `fetch-scores.js`, `jorge-cli.js`).
- [ ] Manual smoke test of `flappy`, `drum-machine`, `curator`, and `f1-championship` in a browser (not performed in this environment — recommend a quick check before merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JmaH7eht2nnxJ5CXS2Ae5

---
_Generated by [Claude Code](https://claude.ai/code/session_019JmaH7eht2nnxJ5CXS2Ae5)_