### PR TITLE
fix(personal-trainer): keep achievement progress bars in color pre-unlock

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1081,12 +1081,17 @@ permalink: /personal-trainer/
 
         .ach.locked {
             opacity: 0.6;
-            filter: grayscale(1);
         }
 
         .ach .em {
             font-size: 1.6rem;
             flex-shrink: 0;
+        }
+
+        /* Grayscale just the badge icon, not the whole card — the progress bar
+           should still show its real color even before the badge is earned. */
+        .ach.locked .em {
+            filter: grayscale(1);
         }
 
         .ach-main {


### PR DESCRIPTION
## What

On the Achievements screen, every badge you haven't earned yet showed its progress bar in flat gray, no matter how close you were to unlocking it (even a 9/10 progress bar looked the same dull gray as a 0/10 one).

## Why

`.ach.locked { filter: grayscale(1); }` applied to the whole card — badge icon, text, *and* the progress bar fill — so the bar's accent-green color got desaturated right along with everything else meant to look "inactive until earned."

## Fix

Moved the grayscale filter off the card and onto just the badge emoji (`.ach.locked .em`), which is the part that should look dormant until unlocked. The progress bar now always renders in its real color (`var(--accent)`, green) and only switches to the brighter `--accent-bright` shade once the achievement is actually unlocked (via the existing `.ach.unlocked .mini-bar > div` rule) — so there's now a subtle, meaningful color shift between "in progress" and "done."

## Testing

Injected some partial workout history into `state` and confirmed via computed styles that locked-card progress bars have `filter: none` (rendering as green `rgb(16, 185, 129)`) while the badge icon still shows `filter: grayscale(1)`. Screenshotted the achievements list with mixed progress (1/1, 7/10, 3/3, 4/30, etc.) — all bars render in color, proportional to progress. Re-ran all five existing Playwright regression suites — no failures. `bundle exec jekyll build` passes (only the known benign `feed` layout warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_