### PR TITLE
feat(personal-trainer): progressive streak icon glow

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1015,50 +1015,19 @@ permalink: /personal-trainer/
             transition: filter 0.4s ease;
         }
 
-        /* Streak flame — grows more vibrant and shiny as the streak climbs, mirroring the
-           s3/s7/s14/s30/s60/s100 achievement milestones (🔥🧨🚀🌋☄️🌌). */
-        .streak-t0 {
-            filter: saturate(0.45) brightness(0.8) grayscale(0.25);
+        /* Streak flame — the glow strengthens roughly a day at a time through day 10,
+           then keeps growing but more gradually the longer the streak runs. The actual
+           filter values are computed per-render in streakGlowFilter() and applied as
+           inline style (continuous, not steppy); .streak-pulse just adds a gentle shine
+           animation once the streak is well established, animating between the two
+           filter strings the JS stores in --glow-a/--glow-b. */
+        .streak-pulse {
+            animation: streak-pulse 2.2s ease-in-out infinite;
         }
 
-        .streak-t1 {
-            filter: saturate(1) brightness(1) drop-shadow(0 0 3px rgba(239, 138, 95, 0.45));
-        }
-
-        .streak-t2 {
-            filter: saturate(1.3) brightness(1.08) drop-shadow(0 0 5px rgba(239, 138, 95, 0.6));
-        }
-
-        .streak-t3 {
-            filter: hue-rotate(-8deg) saturate(1.5) brightness(1.12) drop-shadow(0 0 7px rgba(248, 113, 90, 0.7));
-        }
-
-        .streak-t4 {
-            animation: streak-pulse-warm 2.2s ease-in-out infinite;
-        }
-
-        .streak-t5 {
-            animation: streak-pulse-cool 1.8s ease-in-out infinite;
-        }
-
-        .streak-t6 {
-            animation: streak-pulse-cosmic 2.4s linear infinite;
-        }
-
-        @keyframes streak-pulse-warm {
-            0%, 100% { filter: hue-rotate(-12deg) saturate(1.6) brightness(1.1) drop-shadow(0 0 6px rgba(251, 146, 60, 0.65)); }
-            50% { filter: hue-rotate(-12deg) saturate(1.8) brightness(1.3) drop-shadow(0 0 11px rgba(251, 146, 60, 0.9)); }
-        }
-
-        @keyframes streak-pulse-cool {
-            0%, 100% { filter: hue-rotate(150deg) saturate(1.8) brightness(1.2) drop-shadow(0 0 8px rgba(167, 139, 250, 0.7)); }
-            50% { filter: hue-rotate(150deg) saturate(2) brightness(1.4) drop-shadow(0 0 14px rgba(167, 139, 250, 0.95)); }
-        }
-
-        @keyframes streak-pulse-cosmic {
-            0% { filter: hue-rotate(0deg) saturate(2) brightness(1.3) drop-shadow(0 0 10px rgba(255, 255, 255, 0.8)); }
-            50% { filter: hue-rotate(180deg) saturate(2.2) brightness(1.5) drop-shadow(0 0 16px rgba(255, 215, 130, 0.95)); }
-            100% { filter: hue-rotate(360deg) saturate(2) brightness(1.3) drop-shadow(0 0 10px rgba(255, 255, 255, 0.8)); }
+        @keyframes streak-pulse {
+            0%, 100% { filter: var(--glow-a); }
+            50% { filter: var(--glow-b); }
         }
 
         .topbar h1 .ico {
@@ -2318,19 +2287,51 @@ permalink: /personal-trainer/
             renderPreview();
         });
 
-        // Mirrors the s3/s7/s14/s30/s60/s100 streak achievement milestones.
-        const STREAK_TIER_MINS = [0, 3, 7, 14, 30, 60, 100];
-        function streakTierClass(streak) {
-            let tier = 0;
-            STREAK_TIER_MINS.forEach((min, i) => { if (streak >= min) tier = i; });
-            return `streak-t${tier}`;
+        // How "maxed out" the streak glow is, 0..1. Climbs at a constant rate (one even
+        // step per day) through day 10, then the climb eases off — later streaks keep
+        // getting shinier, just more gradually each day.
+        function streakGlowProgress(streak) {
+            if (streak <= 0) return 0;
+            if (streak <= 10) return (streak / 10) * 0.5;
+            return 0.5 + 0.5 * (1 - Math.exp(-(streak - 10) / 25));
+        }
+
+        // Maps a 0..1 progress value to a CSS filter: brighter/more saturated with a
+        // bigger glow as p grows, sweeping hue from the flame's native orange through
+        // red and into a cool purple-blue at the very top of the range.
+        function streakGlowFilter(p) {
+            const saturate = (1 + p * 1.2).toFixed(2);
+            const brightness = (1 + p * 0.5).toFixed(2);
+            const blur = Math.round(3 + p * 13);
+            const opacity = (0.4 + p * 0.55).toFixed(2);
+            const hue = p < 0.6 ? -15 * (p / 0.6) : -15 + ((p - 0.6) / 0.4) * 165;
+            return `hue-rotate(${hue.toFixed(1)}deg) saturate(${saturate}) brightness(${brightness}) drop-shadow(0 0 ${blur}px rgba(251, 146, 60, ${opacity}))`;
+        }
+
+        function applyStreakGlow(streak) {
+            const ico = document.getElementById('stat-streak-ico');
+            if (streak <= 0) {
+                ico.classList.remove('streak-pulse');
+                ico.style.filter = 'saturate(0.45) brightness(0.8) grayscale(0.25)';
+                return;
+            }
+            const p = streakGlowProgress(streak);
+            if (streak >= 20) {
+                ico.style.setProperty('--glow-a', streakGlowFilter(p));
+                ico.style.setProperty('--glow-b', streakGlowFilter(Math.min(1, p + 0.12)));
+                ico.style.filter = '';
+                ico.classList.add('streak-pulse');
+            } else {
+                ico.classList.remove('streak-pulse');
+                ico.style.filter = streakGlowFilter(p);
+            }
         }
 
         function renderHome() {
             document.getElementById('stat-level').textContent = levelLabel();
             document.getElementById('stat-workouts').textContent = state.history.length;
             document.getElementById('stat-streak').textContent = state.streak;
-            document.getElementById('stat-streak-ico').className = `stat-ico ${streakTierClass(state.streak)}`;
+            applyStreakGlow(state.streak);
             ['core', 'pilates'].forEach((disc) => {
                 const score = state.prog[disc];
                 const cap = tierCap(score);

--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1012,6 +1012,53 @@ permalink: /personal-trainer/
             object-fit: contain;
             display: block;
             margin: 0 auto 6px;
+            transition: filter 0.4s ease;
+        }
+
+        /* Streak flame — grows more vibrant and shiny as the streak climbs, mirroring the
+           s3/s7/s14/s30/s60/s100 achievement milestones (🔥🧨🚀🌋☄️🌌). */
+        .streak-t0 {
+            filter: saturate(0.45) brightness(0.8) grayscale(0.25);
+        }
+
+        .streak-t1 {
+            filter: saturate(1) brightness(1) drop-shadow(0 0 3px rgba(239, 138, 95, 0.45));
+        }
+
+        .streak-t2 {
+            filter: saturate(1.3) brightness(1.08) drop-shadow(0 0 5px rgba(239, 138, 95, 0.6));
+        }
+
+        .streak-t3 {
+            filter: hue-rotate(-8deg) saturate(1.5) brightness(1.12) drop-shadow(0 0 7px rgba(248, 113, 90, 0.7));
+        }
+
+        .streak-t4 {
+            animation: streak-pulse-warm 2.2s ease-in-out infinite;
+        }
+
+        .streak-t5 {
+            animation: streak-pulse-cool 1.8s ease-in-out infinite;
+        }
+
+        .streak-t6 {
+            animation: streak-pulse-cosmic 2.4s linear infinite;
+        }
+
+        @keyframes streak-pulse-warm {
+            0%, 100% { filter: hue-rotate(-12deg) saturate(1.6) brightness(1.1) drop-shadow(0 0 6px rgba(251, 146, 60, 0.65)); }
+            50% { filter: hue-rotate(-12deg) saturate(1.8) brightness(1.3) drop-shadow(0 0 11px rgba(251, 146, 60, 0.9)); }
+        }
+
+        @keyframes streak-pulse-cool {
+            0%, 100% { filter: hue-rotate(150deg) saturate(1.8) brightness(1.2) drop-shadow(0 0 8px rgba(167, 139, 250, 0.7)); }
+            50% { filter: hue-rotate(150deg) saturate(2) brightness(1.4) drop-shadow(0 0 14px rgba(167, 139, 250, 0.95)); }
+        }
+
+        @keyframes streak-pulse-cosmic {
+            0% { filter: hue-rotate(0deg) saturate(2) brightness(1.3) drop-shadow(0 0 10px rgba(255, 255, 255, 0.8)); }
+            50% { filter: hue-rotate(180deg) saturate(2.2) brightness(1.5) drop-shadow(0 0 16px rgba(255, 215, 130, 0.95)); }
+            100% { filter: hue-rotate(360deg) saturate(2) brightness(1.3) drop-shadow(0 0 10px rgba(255, 255, 255, 0.8)); }
         }
 
         .topbar h1 .ico {
@@ -1336,7 +1383,7 @@ permalink: /personal-trainer/
             <div class="stats-row">
                 <div class="stat accent-green"><img class="stat-ico" src="/img/pt/level.png" alt=""><div class="value" id="stat-level">–</div><div class="label">Level</div></div>
                 <div class="stat accent-blue"><img class="stat-ico" src="/img/pt/workout.png" alt=""><div class="value" id="stat-workouts">0</div><div class="label">Workouts</div></div>
-                <div class="stat accent-orange"><img class="stat-ico" src="/img/pt/streak.png" alt=""><div class="value" id="stat-streak">0</div><div class="label">Streak</div></div>
+                <div class="stat accent-orange"><img class="stat-ico" id="stat-streak-ico" src="/img/pt/streak.png" alt=""><div class="value" id="stat-streak">0</div><div class="label">Streak</div></div>
             </div>
             <div class="card" id="weekly-card">
                 <div class="level-row"><strong>This week</strong><span class="tier" id="week-label"></span></div>
@@ -2271,10 +2318,19 @@ permalink: /personal-trainer/
             renderPreview();
         });
 
+        // Mirrors the s3/s7/s14/s30/s60/s100 streak achievement milestones.
+        const STREAK_TIER_MINS = [0, 3, 7, 14, 30, 60, 100];
+        function streakTierClass(streak) {
+            let tier = 0;
+            STREAK_TIER_MINS.forEach((min, i) => { if (streak >= min) tier = i; });
+            return `streak-t${tier}`;
+        }
+
         function renderHome() {
             document.getElementById('stat-level').textContent = levelLabel();
             document.getElementById('stat-workouts').textContent = state.history.length;
             document.getElementById('stat-streak').textContent = state.streak;
+            document.getElementById('stat-streak-ico').className = `stat-ico ${streakTierClass(state.streak)}`;
             ['core', 'pilates'].forEach((disc) => {
                 const score = state.prog[disc];
                 const cap = tierCap(score);

--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -2298,13 +2298,15 @@ permalink: /personal-trainer/
 
         // Maps a 0..1 progress value to a CSS filter: brighter/more saturated with a
         // bigger glow as p grows, sweeping hue from the flame's native orange through
-        // red and into a cool purple-blue at the very top of the range.
+        // red and into a cool purple-blue at the very top of the range. Ranges are wide
+        // on purpose — at a 24px icon size, subtle percentage changes don't read at all,
+        // so even the first few days need a visibly bigger glow halo and color shift.
         function streakGlowFilter(p) {
-            const saturate = (1 + p * 1.2).toFixed(2);
-            const brightness = (1 + p * 0.5).toFixed(2);
-            const blur = Math.round(3 + p * 13);
-            const opacity = (0.4 + p * 0.55).toFixed(2);
-            const hue = p < 0.6 ? -15 * (p / 0.6) : -15 + ((p - 0.6) / 0.4) * 165;
+            const saturate = (1 + p * 2).toFixed(2);
+            const brightness = (1 + p * 0.8).toFixed(2);
+            const blur = Math.round(3 + p * 25);
+            const opacity = (0.4 + p * 0.6).toFixed(2);
+            const hue = p < 0.6 ? -20 * (p / 0.6) : -20 + ((p - 0.6) / 0.4) * 170;
             return `hue-rotate(${hue.toFixed(1)}deg) saturate(${saturate}) brightness(${brightness}) drop-shadow(0 0 ${blur}px rgba(251, 146, 60, ${opacity}))`;
         }
 

--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1015,19 +1015,56 @@ permalink: /personal-trainer/
             transition: filter 0.4s ease;
         }
 
-        /* Streak flame — the glow strengthens roughly a day at a time through day 10,
-           then keeps growing but more gradually the longer the streak runs. The actual
-           filter values are computed per-render in streakGlowFilter() and applied as
-           inline style (continuous, not steppy); .streak-pulse just adds a gentle shine
-           animation once the streak is well established, animating between the two
-           filter strings the JS stores in --glow-a/--glow-b. */
-        .streak-pulse {
-            animation: streak-pulse 2.2s ease-in-out infinite;
+        /* Streak flame — a circular badge around the icon whose ring color, glow and
+           inner tint strengthen roughly a day at a time through day 10, then keep
+           growing but more gradually the longer the streak runs. Ring and flame values
+           are computed per-render in streakRingStyle()/streakGlowFilter() and applied as
+           inline style (continuous, not steppy). .streak-pulse adds a gentle shine
+           animation once the streak is well established (the JS stores the two glow
+           extremes in --ring-glow-a/--ring-glow-b), and .streak-shine adds a small
+           twinkling sparkle once the streak is very long. */
+        .streak-badge {
+            position: relative;
+            width: 32px;
+            height: 32px;
+            margin: 0 auto 6px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border: 2px solid var(--border);
+            background: transparent;
+            transition: border-color 0.4s ease, box-shadow 0.4s ease, background 0.4s ease;
         }
 
-        @keyframes streak-pulse {
-            0%, 100% { filter: var(--glow-a); }
-            50% { filter: var(--glow-b); }
+        .streak-badge .stat-ico {
+            width: 18px;
+            height: 18px;
+            margin: 0;
+        }
+
+        .streak-badge.streak-pulse {
+            animation: streak-ring-pulse 2.2s ease-in-out infinite;
+        }
+
+        @keyframes streak-ring-pulse {
+            0%, 100% { box-shadow: var(--ring-glow-a); }
+            50% { box-shadow: var(--ring-glow-b); }
+        }
+
+        .streak-badge.streak-shine::after {
+            content: '✨';
+            position: absolute;
+            top: -7px;
+            right: -7px;
+            font-size: 12px;
+            line-height: 1;
+            animation: streak-sparkle 1.6s ease-in-out infinite;
+        }
+
+        @keyframes streak-sparkle {
+            0%, 100% { opacity: 0.5; transform: scale(0.85); }
+            50% { opacity: 1; transform: scale(1.1); }
         }
 
         .topbar h1 .ico {
@@ -1352,7 +1389,7 @@ permalink: /personal-trainer/
             <div class="stats-row">
                 <div class="stat accent-green"><img class="stat-ico" src="/img/pt/level.png" alt=""><div class="value" id="stat-level">–</div><div class="label">Level</div></div>
                 <div class="stat accent-blue"><img class="stat-ico" src="/img/pt/workout.png" alt=""><div class="value" id="stat-workouts">0</div><div class="label">Workouts</div></div>
-                <div class="stat accent-orange"><img class="stat-ico" id="stat-streak-ico" src="/img/pt/streak.png" alt=""><div class="value" id="stat-streak">0</div><div class="label">Streak</div></div>
+                <div class="stat accent-orange"><div class="streak-badge" id="stat-streak-badge"><img class="stat-ico" id="stat-streak-ico" src="/img/pt/streak.png" alt=""></div><div class="value" id="stat-streak">0</div><div class="label">Streak</div></div>
             </div>
             <div class="card" id="weekly-card">
                 <div class="level-row"><strong>This week</strong><span class="tier" id="week-label"></span></div>
@@ -2296,36 +2333,74 @@ permalink: /personal-trainer/
             return 0.5 + 0.5 * (1 - Math.exp(-(streak - 10) / 25));
         }
 
-        // Maps a 0..1 progress value to a CSS filter: brighter/more saturated with a
-        // bigger glow as p grows, sweeping hue from the flame's native orange through
-        // red and into a cool purple-blue at the very top of the range. Ranges are wide
-        // on purpose — at a 24px icon size, subtle percentage changes don't read at all,
-        // so even the first few days need a visibly bigger glow halo and color shift.
+        // Shared hue journey for both the flame and its ring: starts at the flame's
+        // native orange, sweeps toward red by mid-progress, then on through magenta and
+        // into a cool blue at the very top of the range. Rotation only ever goes
+        // negative so it takes the short way round the color wheel (orange → red →
+        // magenta → purple → blue) instead of drifting through yellow-green.
+        function streakHueShift(p) {
+            return p < 0.6 ? -20 * (p / 0.6) : -20 - ((p - 0.6) / 0.4) * 165;
+        }
+
+        // Maps a 0..1 progress value to a CSS filter for the flame icon itself: brighter
+        // and more saturated as p grows. Ranges are wide on purpose — at an 18px icon
+        // size, subtle percentage changes don't read at all, so even the first few days
+        // need a visibly bigger color shift.
         function streakGlowFilter(p) {
             const saturate = (1 + p * 2).toFixed(2);
             const brightness = (1 + p * 0.8).toFixed(2);
-            const blur = Math.round(3 + p * 25);
-            const opacity = (0.4 + p * 0.6).toFixed(2);
-            const hue = p < 0.6 ? -20 * (p / 0.6) : -20 + ((p - 0.6) / 0.4) * 170;
-            return `hue-rotate(${hue.toFixed(1)}deg) saturate(${saturate}) brightness(${brightness}) drop-shadow(0 0 ${blur}px rgba(251, 146, 60, ${opacity}))`;
+            const hue = streakHueShift(p);
+            return `hue-rotate(${hue.toFixed(1)}deg) saturate(${saturate}) brightness(${brightness})`;
+        }
+
+        // A color along the same hue journey, base orange at p=0. Saturation/lightness
+        // also climb with p so the ring reads as "more vivid", not just recolored.
+        function streakRingColor(p, alpha) {
+            const hue = ((25 + streakHueShift(p)) % 360 + 360) % 360;
+            const sat = 55 + p * 35;
+            const light = 50 + p * 8;
+            return `hsla(${hue.toFixed(0)}, ${sat.toFixed(0)}%, ${light.toFixed(0)}%, ${alpha.toFixed(2)})`;
+        }
+
+        // The ring's border/background/glow at progress p. Border alpha itself scales
+        // with p so days 0-2 read as a barely-tinted, near-neutral ring rather than
+        // jumping straight to a saturated color.
+        function streakRingStyle(p) {
+            const borderAlpha = 0.12 + p * 0.83;
+            const blur = Math.round(2 + p * 22);
+            const glowAlpha = 0.2 + p * 0.55;
+            return {
+                border: streakRingColor(p, borderAlpha),
+                bg: `radial-gradient(circle, ${streakRingColor(p, 0.1 + p * 0.15)}, transparent 70%)`,
+                glowA: `0 0 ${blur}px ${streakRingColor(p, glowAlpha)}`,
+                glowB: `0 0 ${Math.round(blur * 1.5)}px ${streakRingColor(p, Math.min(1, glowAlpha + 0.3))}`,
+            };
         }
 
         function applyStreakGlow(streak) {
+            const badge = document.getElementById('stat-streak-badge');
             const ico = document.getElementById('stat-streak-ico');
+            badge.classList.remove('streak-pulse', 'streak-shine');
             if (streak <= 0) {
-                ico.classList.remove('streak-pulse');
+                badge.style.borderColor = '';
+                badge.style.background = '';
+                badge.style.boxShadow = '';
                 ico.style.filter = 'saturate(0.45) brightness(0.8) grayscale(0.25)';
                 return;
             }
             const p = streakGlowProgress(streak);
+            ico.style.filter = streakGlowFilter(p);
+            const ring = streakRingStyle(p);
+            badge.style.borderColor = ring.border;
+            badge.style.background = ring.bg;
+            if (streak >= 60) badge.classList.add('streak-shine');
             if (streak >= 20) {
-                ico.style.setProperty('--glow-a', streakGlowFilter(p));
-                ico.style.setProperty('--glow-b', streakGlowFilter(Math.min(1, p + 0.12)));
-                ico.style.filter = '';
-                ico.classList.add('streak-pulse');
+                badge.style.setProperty('--ring-glow-a', ring.glowA);
+                badge.style.setProperty('--ring-glow-b', ring.glowB);
+                badge.style.boxShadow = '';
+                badge.classList.add('streak-pulse');
             } else {
-                ico.classList.remove('streak-pulse');
-                ico.style.filter = streakGlowFilter(p);
+                badge.style.boxShadow = ring.glowA;
             }
         }
 


### PR DESCRIPTION
## What

The flame icon in the home screen's Streak stat now sits inside a circular ring badge — similar to a Duolingo-style streak ring — that fills in with color and glow as the streak grows, instead of always looking the same regardless of whether you're on day 1 or day 150.

## Pacing

- **Days 0-10**: a constant, even step every single day — the ring visibly brightens and gains glow at a steady, predictable rate as a new streak gets going.
- **Day 10+**: growth decelerates — the ring keeps getting shinier and its hue keeps sweeping from orange toward red, then magenta/purple, then blue, but each additional day matters progressively less, so very long streaks look correspondingly more "maxed out" rather than escalating forever.
- **Day 20+**: a gentle pulsing glow animation kicks in on the ring.
- **Day 60+**: a small twinkling sparkle appears on the badge.
- **Streak 0**: plain gray outline ring, dim/desaturated flame, no glow.

## Color story

Uses a different palette than typical orange/gold streak UIs: the hue rotates the "short way" round the color wheel — orange → red → magenta/purple → blue — deliberately avoiding the yellow-green band so the flame never looks off-theme mid-progression.

## Implementation

- The streak icon is a flat single-color PNG (solid `--orange` silhouette with alpha-only edges), so CSS `filter` (`hue-rotate`/`saturate`/`brightness`) recolors it directly — no new image assets needed.
- Wrapped the icon in a `.streak-badge` circle with a border/background/box-shadow driven by `streakRingStyle(p)`, computed continuously (not steppy) from the same 0..1 progress value used for the flame's own filter.
- `streakHueShift(p)` is shared between the flame filter and the ring color so both move through the same color journey together.
- `.streak-pulse` (glow breathing, ≥ day 20) and `.streak-shine` (sparkle, ≥ day 60) are small CSS animations layered on top of the continuous base look.

## Testing

Verified via Playwright that: the day-over-day progress delta is exactly constant for streak 1-10 and decelerates after; the ring's border alpha and glow blur radius climb with streak; the pulse/sparkle class thresholds trigger at exactly the right streak values; the badge and icon are structured correctly in the DOM; and there are no uncaught page errors. Visually reviewed screenshots across the whole curve (0, 1, 2, 5, 10, 20, 30, 60, 100) and confirmed the hue fix removes an earlier yellow-green artifact around streak 30. Re-ran all 9 other existing regression suites — no failures. `bundle exec jekyll build` passes (only the known benign `feed` layout warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_