### PR TITLE
feat(personal-trainer): move This Week / progression cards to bottom of Home

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1400,19 +1400,6 @@ permalink: /personal-trainer/
                 <div class="stat accent-blue"><img class="stat-ico" src="/img/pt/workout.png" alt=""><div class="value" id="stat-workouts">0</div><div class="label">Workouts</div></div>
                 <div class="stat accent-orange"><div class="streak-badge" id="stat-streak-badge"><img class="stat-ico" id="stat-streak-ico" src="/img/pt/streak.png" alt=""></div><div class="value" id="stat-streak">0</div><div class="label">Streak</div></div>
             </div>
-            <div class="card" id="weekly-card">
-                <div class="level-row"><strong>This week</strong><span class="tier" id="week-label"></span></div>
-                <div class="week-segs" id="week-segs"></div>
-                <button class="info-link" id="btn-freeze">❄️ Freeze today's streak</button>
-                <button class="btn secondary" id="btn-commit" style="margin-top:12px;">Commit &amp; share ↗</button>
-            </div>
-            <div class="card disc-card">
-                <div class="level-row row-core"><strong><img class="ico" src="/img/pt/core-fitness.png" alt="">Core Fitness</strong><span class="tier" id="core-tier">Tier 1 of 5</span></div>
-                <div class="level-bar"><div id="core-bar" style="width:0%"></div></div>
-                <div class="level-row row-pilates" style="margin-top:14px;"><strong><img class="ico" src="/img/pt/mat-pilates.png" alt="">Mat Pilates</strong><span class="tier" id="pilates-tier">Tier 1 of 5</span></div>
-                <div class="level-bar"><div id="pilates-bar" style="width:0%"></div></div>
-                <button class="info-link" id="nav-info">ⓘ How progression works</button>
-            </div>
             <div class="card">
                 <div class="section-title">Session length</div>
                 <div class="choice-row" id="home-duration">
@@ -1433,6 +1420,19 @@ permalink: /personal-trainer/
             <div class="card clickable-card" id="rec-card" role="button" tabindex="0">
                 <div class="level-row"><strong><img class="ico" src="/img/pt/records.png" alt="">Records</strong><span class="see-all">All ›</span></div>
                 <div id="rec-preview"></div>
+            </div>
+            <div class="card" id="weekly-card">
+                <div class="level-row"><strong>This week</strong><span class="tier" id="week-label"></span></div>
+                <div class="week-segs" id="week-segs"></div>
+                <button class="info-link" id="btn-freeze">❄️ Freeze today's streak</button>
+                <button class="btn secondary" id="btn-commit" style="margin-top:12px;">Commit &amp; share ↗</button>
+            </div>
+            <div class="card disc-card">
+                <div class="level-row row-core"><strong><img class="ico" src="/img/pt/core-fitness.png" alt="">Core Fitness</strong><span class="tier" id="core-tier">Tier 1 of 5</span></div>
+                <div class="level-bar"><div id="core-bar" style="width:0%"></div></div>
+                <div class="level-row row-pilates" style="margin-top:14px;"><strong><img class="ico" src="/img/pt/mat-pilates.png" alt="">Mat Pilates</strong><span class="tier" id="pilates-tier">Tier 1 of 5</span></div>
+                <div class="level-bar"><div id="pilates-bar" style="width:0%"></div></div>
+                <button class="info-link" id="nav-info">ⓘ How progression works</button>
             </div>
             <div class="home-nav">
                 <button class="btn secondary" id="nav-history"><img class="ico" src="/img/pt/history.png" alt="">History</button>


### PR DESCRIPTION
## What

Reorders the Home screen so the immediate action comes first and the secondary/status cards follow, ending with the two cards that matter least in the moment.

**New order**: stats row → Session length → Generate today's workout → Consistency → Achievements → Records → This Week (commit/freeze) → Core Fitness/Mat Pilates progression → History.

Previously This Week and the Core Fitness/Mat Pilates progression cards sat right at the top, above the actual "start a workout" flow, pushing the primary action further down the screen.

## Why

Requested UX improvement — the action someone opens the app to take (generate + start today's workout) should be reachable without scrolling past status cards first. This Week's commitment/freeze actions and the tier progress bars are useful to check, but they're not what most visits are for, so they move to the bottom.

## Changes

Pure markup reorder in `personal-trainer/index.html` — moved the `#weekly-card` and `.disc-card` blocks to just above the History button. No `id`s, event bindings, or render functions changed, since everything is wired via `document.getElementById` regardless of DOM position.

## Testing

Visually confirmed the new order via a full-page screenshot. Re-ran all 11 existing regression suites (streak freeze, streak icon, home heatmap, heatmap goal tile, share card, commitment card, achievements, workout items, generator modal, common mistakes, library video) — no failures, since none of the reordered elements' ids or behavior changed. `bundle exec jekyll build` passes (only the known benign `feed` layout warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_