### PR TITLE
feat(personal-trainer): back button on Settings + button-styled back actions

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -125,6 +125,16 @@ permalink: /personal-trainer/
             padding: 6px 0;
         }
 
+        /* Actual "go back" actions get a visible pill so they read as tappable buttons,
+           not plain text — unlike the plain icon-only topbar actions (settings, info,
+           regenerate) which keep the minimal look above. */
+        .topbar .back-btn[data-back] {
+            background: var(--surface2);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 6px 14px;
+        }
+
         .card {
             background: var(--surface);
             border: 1px solid var(--border);
@@ -1357,7 +1367,9 @@ permalink: /personal-trainer/
         <!-- ============ SETUP ============ -->
         <section class="screen" id="setup">
             <header class="topbar">
+                <button class="back-btn" id="setup-back" data-back="home" style="display:none;">‹ Back</button>
                 <h1><img class="ico" src="/img/pt/app-logo.png" alt="">Personal <span>Trainer</span></h1>
+                <span></span>
             </header>
             <div class="card">
                 <div class="section-title">Your fitness level</div>
@@ -2335,6 +2347,7 @@ permalink: /personal-trainer/
             markSelected('setup-duration', state.duration);
             markSelected('setup-goal', state.weeklyGoal || 3);
             if (state.level) markSelected('setup-level', state.level);
+            document.getElementById('setup-back').style.display = '';
             navigate('setup');
         });
         document.getElementById('nav-library').addEventListener('click', () => { renderLibrary(); navigate('library'); });


### PR DESCRIPTION
## What

Two related UX fixes to navigation:

1. **Settings had no way back.** The `#setup` screen doubles as first-run onboarding (level/duration/goal picker, no valid "back" destination since Home doesn't exist yet) and the Settings page reached via Home's gear icon ("Change level / duration"). Only the second case had anywhere to go back to, but the screen never had a back button at all — you had to rely on the browser/OS back gesture.
2. **Back buttons didn't look like buttons.** The "‹ Back" links across the app (Preview, Library, History, How it Works, Achievements, Records) were plain text with no visible background or border — easy to miss as tappable.

## Changes

- Added `#setup-back` (a `data-back="home"` button) to the setup screen's topbar, `display:none` by default so first-run onboarding is unaffected. The `nav-settings` click handler (the only way to reach setup with a valid back target) reveals it right before navigating in.
- Added a `.topbar .back-btn[data-back]` style — visible background + border — so every literal back button (the 6 existing ones plus the new Settings one) reads as a real button. Scoped specifically to `data-back` elements, so the icon-only topbar actions that reuse the `.back-btn` class for sizing (settings gear, generator info, regenerate) keep their existing minimal look since they aren't "back" actions.

## Testing

Verified via Playwright: first-run onboarding still shows no back button; reaching Settings via the gear icon shows a back button styled with a visible background/border, and clicking it returns to Home; it still works correctly on a second visit (not a one-shot fluke); all 7 `data-back` buttons in the app now have a visible background and border; the non-back icon buttons (`btn-generator-info`, `btn-regenerate`) remain unstyled/transparent as before. Visually reviewed screenshots of onboarding, Settings, and History. Re-ran all 11 other existing regression suites — no failures. `bundle exec jekyll build` passes (only the known benign `feed` layout warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_