### PR TITLE
feat(personal-trainer): share-a-goal picker (this week's goal vs. long-term streak)

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1424,6 +1424,7 @@ permalink: /personal-trainer/
             <div class="card" id="streak-card">
                 <div class="section-title">Consistency</div>
                 <div id="home-heatmap"></div>
+                <button class="btn secondary" id="btn-share-streak" style="margin-top:4px;">Share my streak ↗</button>
             </div>
             <div class="card clickable-card" id="ach-card" role="button" tabindex="0">
                 <div class="level-row"><strong><img class="ico" src="/img/pt/achievements.png" alt="">Achievements</strong><span class="see-all">All <span id="ach-badge-count" class="ach-count"></span> ›</span></div>
@@ -1960,6 +1961,37 @@ permalink: /personal-trainer/
                 byWeek[w] = (byWeek[w] || 0) + 1;
             });
             return Object.values(byWeek).filter((c) => c >= state.weeklyGoal).length;
+        }
+
+        // Consecutive weeks (not just total) the weekly goal was met — the long-term
+        // counterpart to the daily state.streak. `current` stays alive through an
+        // in-progress week that hasn't hit goal yet (same grace-period idea as the daily
+        // streak): it only breaks once a full week goes by with the goal unmet.
+        function weeklyStreakStats() {
+            const byWeek = {};
+            state.history.forEach((h) => {
+                const w = weekStartTs(h.ts);
+                byWeek[w] = (byWeek[w] || 0) + 1;
+            });
+            const goal = state.weeklyGoal || 3;
+            const metWeeks = Object.keys(byWeek).map(Number).filter((w) => byWeek[w] >= goal).sort((a, b) => a - b);
+            if (!metWeeks.length) return { current: 0, best: 0 };
+
+            const weekMs = 7 * 86400000;
+            let best = 1, run = 1;
+            for (let i = 1; i < metWeeks.length; i++) {
+                run = metWeeks[i] - metWeeks[i - 1] === weekMs ? run + 1 : 1;
+                best = Math.max(best, run);
+            }
+
+            const thisWeek = weekStartTs();
+            const lastMet = metWeeks[metWeeks.length - 1];
+            let current = 0;
+            if (lastMet === thisWeek || lastMet === thisWeek - weekMs) {
+                current = 1;
+                for (let w = lastMet - weekMs; metWeeks.includes(w); w -= weekMs) current++;
+            }
+            return { current, best };
         }
 
         // ---- Streak freezes ----
@@ -3172,6 +3204,106 @@ permalink: /personal-trainer/
             return new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
         }
 
+        // A long-term-consistency card: the current and best consecutive-week streaks of
+        // hitting the weekly goal, plus how many weeks it's been met in total. Distinct
+        // from the daily progress/commitment cards — this one is about the sustained
+        // habit, not a single session.
+        async function buildStreakShareCardBlob() {
+            const SIZE = 1080;
+            const PAD = 72;
+            const canvas = document.createElement('canvas');
+            canvas.width = SIZE;
+            canvas.height = SIZE;
+            const ctx = canvas.getContext('2d');
+
+            const bg = ctx.createLinearGradient(0, 0, SIZE, SIZE);
+            bg.addColorStop(0, '#131a27');
+            bg.addColorStop(0.55, '#0e131e');
+            bg.addColorStop(1, '#0b0f18');
+            ctx.fillStyle = bg;
+            ctx.fillRect(0, 0, SIZE, SIZE);
+
+            const glow = ctx.createRadialGradient(SIZE * 0.82, SIZE * 0.12, 0, SIZE * 0.82, SIZE * 0.12, SIZE * 0.55);
+            glow.addColorStop(0, 'rgba(107, 184, 239, 0.18)');
+            glow.addColorStop(1, 'rgba(107, 184, 239, 0)');
+            ctx.fillStyle = glow;
+            ctx.fillRect(0, 0, SIZE, SIZE);
+
+            const logo = await loadImg('/img/pt/app-logo.png');
+
+            let y = PAD;
+
+            if (logo) ctx.drawImage(logo, PAD, y, 64, 64);
+            ctx.fillStyle = '#8a97a8';
+            ctx.font = '600 28px -apple-system, "Segoe UI", sans-serif';
+            ctx.textBaseline = 'middle';
+            ctx.fillText('PERSONAL TRAINER', PAD + (logo ? 80 : 0), y + 32);
+            y += 64 + 56;
+
+            ctx.fillStyle = '#6bb8ef';
+            ctx.font = '700 30px -apple-system, "Segoe UI", sans-serif';
+            ctx.textBaseline = 'alphabetic';
+            ctx.fillText('LONG-TERM COMMITMENT', PAD, y);
+            y += 48;
+
+            const { current, best } = weeklyStreakStats();
+            const goal = state.weeklyGoal || 3;
+            const totalWeeks = goalMetWeeks();
+
+            ctx.fillStyle = '#e9eef5';
+            ctx.font = '800 74px -apple-system, "Segoe UI", sans-serif';
+            ctx.fillText(current > 0 ? `${current} week${current === 1 ? '' : 's'} strong` : 'Building the habit', PAD, y + 74);
+            y += 74 + 20;
+
+            ctx.fillStyle = '#8a97a8';
+            ctx.font = '500 32px -apple-system, "Segoe UI", sans-serif';
+            ctx.fillText(
+                current > 0
+                    ? `Hit my ${goal}×/week goal ${current} week${current === 1 ? '' : 's'} in a row`
+                    : `Working toward ${goal}×/week, every week`,
+                PAD, y + 32
+            );
+            y += 32 + 56;
+
+            ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.moveTo(PAD, y);
+            ctx.lineTo(SIZE - PAD, y);
+            ctx.stroke();
+            y += 56;
+
+            const tileW = (SIZE - PAD * 2 - 32) / 2;
+            const tiles = [
+                { label: 'BEST STREAK', value: `${best} wk${best === 1 ? '' : 's'}` },
+                { label: 'WEEKS ON TARGET', value: `${totalWeeks}` }
+            ];
+            tiles.forEach((t, i) => {
+                const tx = PAD + i * (tileW + 32);
+                ctx.fillStyle = 'rgba(255, 255, 255, 0.04)';
+                roundRect(ctx, tx, y, tileW, 128, 16);
+                ctx.fill();
+                ctx.fillStyle = '#8a97a8';
+                ctx.font = '700 22px -apple-system, "Segoe UI", sans-serif';
+                ctx.textBaseline = 'alphabetic';
+                ctx.fillText(t.label, tx + 24, y + 40);
+                ctx.fillStyle = '#e9eef5';
+                ctx.font = '800 44px -apple-system, "Segoe UI", sans-serif';
+                ctx.fillText(t.value, tx + 24, y + 92);
+            });
+            y += 128 + 72;
+
+            ctx.fillStyle = '#e9eef5';
+            ctx.font = '600 34px -apple-system, "Segoe UI", sans-serif';
+            wrapText(ctx, 'Consistency beats intensity — see you next week. 💪', PAD, y, SIZE - PAD * 2, 44);
+
+            ctx.fillStyle = '#8a97a8';
+            ctx.font = '500 24px -apple-system, "Segoe UI", sans-serif';
+            ctx.fillText('jorgecensi.com/personal-trainer', PAD, SIZE - PAD);
+
+            return new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
+        }
+
         // Try the native share sheet with the image file; fall back to a plain download.
         async function shareImageBlob(blob, filename, title, text) {
             const file = new File([blob], filename, { type: 'image/png' });
@@ -3206,6 +3338,7 @@ permalink: /personal-trainer/
 
         bindShareButton('btn-share', buildShareCardBlob, 'personal-trainer-progress.png', 'Personal Trainer', 'My workout progress');
         bindShareButton('btn-commit', buildCommitmentCardBlob, 'personal-trainer-commitment.png', 'Personal Trainer', 'My weekly workout commitment');
+        bindShareButton('btn-share-streak', buildStreakShareCardBlob, 'personal-trainer-streak.png', 'Personal Trainer', 'My long-term consistency streak');
 
         // =====================================================
         // Library (with editable YouTube links)

--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1424,7 +1424,6 @@ permalink: /personal-trainer/
             <div class="card" id="streak-card">
                 <div class="section-title">Consistency</div>
                 <div id="home-heatmap"></div>
-                <button class="btn secondary" id="btn-share-streak" style="margin-top:4px;">Share my streak ↗</button>
             </div>
             <div class="card clickable-card" id="ach-card" role="button" tabindex="0">
                 <div class="level-row"><strong><img class="ico" src="/img/pt/achievements.png" alt="">Achievements</strong><span class="see-all">All <span id="ach-badge-count" class="ach-count"></span> ›</span></div>
@@ -1438,7 +1437,7 @@ permalink: /personal-trainer/
                 <div class="level-row"><strong>This week</strong><span class="tier" id="week-label"></span></div>
                 <div class="week-segs" id="week-segs"></div>
                 <button class="info-link" id="btn-freeze">❄️ Freeze today's streak</button>
-                <button class="btn secondary" id="btn-commit" style="margin-top:12px;">Commit &amp; share ↗</button>
+                <button class="btn secondary" id="btn-commit" style="margin-top:12px;">Share a goal ↗</button>
             </div>
             <div class="card disc-card">
                 <div class="level-row row-core"><strong><img class="ico" src="/img/pt/core-fitness.png" alt="">Core Fitness</strong><span class="tier" id="core-tier">Tier 1 of 5</span></div>
@@ -1643,6 +1642,26 @@ permalink: /personal-trainer/
                 <div class="card">
                     <div class="section-title">Not feeling this mix?</div>
                     <p class="muted-note">Tap 🔀 on the preview screen to reshuffle before you start — as many times as you like, no penalty. Once you're training, your post-workout feedback (too easy / just right / too hard) is what actually moves the difficulty needle — see <strong style="color:var(--text);">How Progression Works</strong> for that part.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============ SHARE A GOAL (modal) ============ -->
+    <div class="modal-overlay" id="share-goal-modal">
+        <div class="modal-card">
+            <div class="modal-head">
+                <h2>Share a <span>Goal</span></h2>
+                <button class="modal-close" id="close-share-goal" aria-label="Close">✕</button>
+            </div>
+            <div class="modal-body">
+                <div class="card clickable-card" id="share-goal-week" role="button" tabindex="0">
+                    <div class="level-row"><strong>📅 This week's goal</strong></div>
+                    <p class="muted-note" style="margin-top:6px;">Commit to hitting it, and invite whoever you send it to to line up a reward if you do.</p>
+                </div>
+                <div class="card clickable-card" id="share-goal-streak" role="button" tabindex="0">
+                    <div class="level-row"><strong>🔥 My long-term streak</strong></div>
+                    <p class="muted-note" style="margin-top:6px;">Show off your consecutive weeks of hitting the goal — the long game, not just this week.</p>
                 </div>
             </div>
         </div>
@@ -2402,6 +2421,37 @@ permalink: /personal-trainer/
         window.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && generatorInfoModal.classList.contains('open')) closeGeneratorInfo();
         });
+
+        // ---- Share-a-goal modal: pick between this week's goal and the long-term streak ----
+        const shareGoalModal = document.getElementById('share-goal-modal');
+        function openShareGoalModal() {
+            shareGoalModal.classList.add('open');
+        }
+        function closeShareGoalModal() {
+            shareGoalModal.classList.remove('open');
+        }
+        document.getElementById('btn-commit').addEventListener('click', openShareGoalModal);
+        document.getElementById('close-share-goal').addEventListener('click', closeShareGoalModal);
+        shareGoalModal.addEventListener('click', (e) => {
+            if (e.target === shareGoalModal) closeShareGoalModal();
+        });
+        window.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && shareGoalModal.classList.contains('open')) closeShareGoalModal();
+        });
+
+        async function shareGoalCard(buildBlob, filename, text) {
+            closeShareGoalModal();
+            try {
+                await shareImageBlob(await buildBlob(), filename, 'Personal Trainer', text);
+            } catch (e) {
+                if (e.name !== 'AbortError') alert('Could not create the share image — try again.');
+            }
+        }
+        bindClickableCard('share-goal-week', () =>
+            shareGoalCard(buildCommitmentCardBlob, 'personal-trainer-commitment.png', 'My weekly workout commitment'));
+        bindClickableCard('share-goal-streak', () =>
+            shareGoalCard(buildStreakShareCardBlob, 'personal-trainer-streak.png', 'My long-term consistency streak'));
+
         function bindClickableCard(id, handler) {
             const el = document.getElementById(id);
             el.addEventListener('click', handler);
@@ -3337,8 +3387,6 @@ permalink: /personal-trainer/
         }
 
         bindShareButton('btn-share', buildShareCardBlob, 'personal-trainer-progress.png', 'Personal Trainer', 'My workout progress');
-        bindShareButton('btn-commit', buildCommitmentCardBlob, 'personal-trainer-commitment.png', 'Personal Trainer', 'My weekly workout commitment');
-        bindShareButton('btn-share-streak', buildStreakShareCardBlob, 'personal-trainer-streak.png', 'Personal Trainer', 'My long-term consistency streak');
 
         // =====================================================
         // Library (with editable YouTube links)


### PR DESCRIPTION
## What

Adds a long-term, "sustained habit" option to the existing goal-sharing flow: the "Share a goal" button (previously "Commit & share") now opens a small picker with two options — **This week's goal** (the existing commitment card) or **My long-term streak** (new: the CONSECUTIVE-week streak of hitting the weekly goal) — instead of always sharing the same weekly-commitment card.

## Why

The existing cards covered "today's workout" (progress) and "this week's goal" (commitment). Neither captured the more impressive long-term story — e.g. "12 weeks in a row hitting my goal" — which is exactly the kind of milestone worth sharing for social accountability. Rather than bolt on a separate button for it, it belongs as an option on the share flow that already exists.

## How it works

- Tapping "Share a goal" opens a `share-goal-modal` with two tappable cards, styled like the app's existing `.clickable-card` pattern and reusing the same modal shell as the "How the Generator Works" info modal.
- **This week's goal** → `buildCommitmentCardBlob()` (unchanged, existing card).
- **My long-term streak** → `buildStreakShareCardBlob()` (new), built around `weeklyStreakStats()`, which computes `{ current, best }` consecutive weeks the weekly goal was met — using the same grace-period idea as the existing daily `state.streak` (a week that hasn't happened yet doesn't break the streak, but a full week going by without hitting goal does). Distinct from the existing `goalMetWeeks()`, which just counts total weeks met regardless of consecutiveness. The card shows the current streak (or an encouraging "Building the habit" for new accounts), a best-streak tile, and a weeks-on-target tile, in the same visual language as the other cards but with a blue accent to set it apart.
- Picking either option closes the modal and shares immediately (native share sheet, download fallback) via the same `shareImageBlob()` plumbing as the other cards.

## Files

`personal-trainer/index.html` only — `weeklyStreakStats()`, `buildStreakShareCardBlob()`, the `#share-goal-modal` markup + open/close wiring, `shareGoalCard()` helper, and `bindClickableCard()` calls for the two options. The `#btn-commit` button's own `bindShareButton()` call was replaced with a click handler that opens the modal instead of sharing directly.

## Testing

Verified via Playwright: the modal opens on "Share a goal" and closes via the ✕ button, backdrop click, and Escape key; both options are labeled correctly; picking either one closes the modal and triggers the correct card's download with the correct filename, without navigating away from Home; `weeklyStreakStats()` correctly computes a 4-week current/best streak from synthetic history with an isolated older 2-week run (proving it isn't confused by non-adjacent met weeks) and correctly stays at 0/0 for a fresh account; `goalMetWeeks()` still counts all 6 total weeks met including non-consecutive ones. Re-ran all 12 other existing regression suites (updated the one that directly clicked the old `#btn-commit` share behavior to go through the new modal) — no failures. `bundle exec jekyll build` passes (only the known benign `feed` layout warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_