### PR TITLE
feat(personal-trainer): share any achievement badge, unlocked or in progress

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1168,6 +1168,12 @@ permalink: /personal-trainer/
             display: flex;
             gap: 10px;
             align-items: flex-start;
+            cursor: pointer;
+            transition: transform 0.1s, border-color 0.15s;
+        }
+
+        .ach:active {
+            transform: scale(0.96);
         }
 
         .ach.unlocked {
@@ -2382,6 +2388,34 @@ permalink: /personal-trainer/
         }
         bindClickableCard('ach-card', () => { renderAchievements(); navigate('achievements'); });
         bindClickableCard('rec-card', () => { renderRecords(); navigate('records'); });
+
+        // Tapping any badge on the Achievements screen shares that specific badge —
+        // works whether it's unlocked or still in progress. Delegated on the stable
+        // #ach-grid container since its children are re-rendered on every visit.
+        const achGrid = document.getElementById('ach-grid');
+        async function shareAchievementCard(achId) {
+            try {
+                await shareImageBlob(
+                    await buildAchievementCardBlob(achId),
+                    'personal-trainer-badge.png',
+                    'Personal Trainer',
+                    'My Personal Trainer badge'
+                );
+            } catch (e) {
+                if (e.name !== 'AbortError') alert('Could not create the share image — try again.');
+            }
+        }
+        achGrid.addEventListener('click', (e) => {
+            const el = e.target.closest('.ach');
+            if (el) shareAchievementCard(el.dataset.achId);
+        });
+        achGrid.addEventListener('keydown', (e) => {
+            if (e.key !== 'Enter' && e.key !== ' ') return;
+            const el = e.target.closest('.ach');
+            if (!el) return;
+            e.preventDefault();
+            shareAchievementCard(el.dataset.achId);
+        });
         document.querySelectorAll('[data-back]').forEach((b) =>
             b.addEventListener('click', () => { clearPreviewVideos(); clearLibraryVideos(); closeGeneratorInfo(); goBack(); }));
 
@@ -3172,6 +3206,91 @@ permalink: /personal-trainer/
             return new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
         }
 
+        // A single-badge card, tapped directly from any card on the Achievements screen —
+        // works for an unlocked badge ("look what I earned") just as well as one still in
+        // progress ("here's how close I am"). Green for unlocked, blue for in-progress,
+        // matching the celebratory/progress-tracking split used elsewhere in the app.
+        async function buildAchievementCardBlob(achId) {
+            const a = ACHIEVEMENTS.find((x) => x.id === achId);
+            const isUnlocked = !!state.achievements[achId];
+            const cur = Math.floor(Math.min(a.value(), a.target));
+            const ratio = isUnlocked ? 1 : Math.min(1, a.value() / a.target);
+
+            const SIZE = 1080;
+            const PAD = 72;
+            const canvas = document.createElement('canvas');
+            canvas.width = SIZE;
+            canvas.height = SIZE;
+            const ctx = canvas.getContext('2d');
+
+            const accent = isUnlocked ? '#10b981' : '#6bb8ef';
+            const accentGlow = isUnlocked ? 'rgba(16, 185, 129, 0.18)' : 'rgba(107, 184, 239, 0.18)';
+
+            const bg = ctx.createLinearGradient(0, 0, SIZE, SIZE);
+            bg.addColorStop(0, '#131a27');
+            bg.addColorStop(0.55, '#0e131e');
+            bg.addColorStop(1, '#0b0f18');
+            ctx.fillStyle = bg;
+            ctx.fillRect(0, 0, SIZE, SIZE);
+
+            const glow = ctx.createRadialGradient(SIZE * 0.82, SIZE * 0.12, 0, SIZE * 0.82, SIZE * 0.12, SIZE * 0.55);
+            glow.addColorStop(0, accentGlow);
+            glow.addColorStop(1, 'rgba(0, 0, 0, 0)');
+            ctx.fillStyle = glow;
+            ctx.fillRect(0, 0, SIZE, SIZE);
+
+            const logo = await loadImg('/img/pt/app-logo.png');
+
+            let y = PAD;
+
+            if (logo) ctx.drawImage(logo, PAD, y, 64, 64);
+            ctx.fillStyle = '#8a97a8';
+            ctx.font = '600 28px -apple-system, "Segoe UI", sans-serif';
+            ctx.textBaseline = 'middle';
+            ctx.fillText('PERSONAL TRAINER', PAD + (logo ? 80 : 0), y + 32);
+            y += 64 + 64;
+
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'alphabetic';
+            ctx.font = '160px -apple-system, "Segoe UI", sans-serif';
+            ctx.fillText(a.emoji, SIZE / 2, y + 140);
+            y += 140 + 48;
+
+            ctx.fillStyle = accent;
+            ctx.font = '700 30px -apple-system, "Segoe UI", sans-serif';
+            ctx.fillText(isUnlocked ? 'BADGE UNLOCKED' : 'IN PROGRESS', SIZE / 2, y);
+            y += 56;
+
+            ctx.fillStyle = '#e9eef5';
+            ctx.font = '800 64px -apple-system, "Segoe UI", sans-serif';
+            ctx.fillText(a.name, SIZE / 2, y + 56);
+            y += 56 + 32;
+
+            ctx.textAlign = 'left';
+            ctx.fillStyle = '#8a97a8';
+            ctx.font = '500 32px -apple-system, "Segoe UI", sans-serif';
+            y = wrapText(ctx, a.desc, PAD, y, SIZE - PAD * 2, 42) + 48;
+
+            const barW = SIZE - PAD * 2, barH = 20;
+            ctx.fillStyle = 'rgba(255, 255, 255, 0.08)';
+            roundRect(ctx, PAD, y, barW, barH, 10);
+            ctx.fill();
+            ctx.fillStyle = accent;
+            roundRect(ctx, PAD, y, Math.max(barH, barW * ratio), barH, 10);
+            ctx.fill();
+            y += barH + 32;
+
+            ctx.fillStyle = '#8a97a8';
+            ctx.font = '700 30px -apple-system, "Segoe UI", sans-serif';
+            ctx.fillText(`${cur}/${a.target}`, PAD, y);
+
+            ctx.fillStyle = '#8a97a8';
+            ctx.font = '500 24px -apple-system, "Segoe UI", sans-serif';
+            ctx.fillText('jorgecensi.com/personal-trainer', PAD, SIZE - PAD);
+
+            return new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
+        }
+
         // Try the native share sheet with the image file; fall back to a plain download.
         async function shareImageBlob(blob, filename, title, text) {
             const file = new File([blob], filename, { type: 'image/png' });
@@ -3372,7 +3491,7 @@ permalink: /personal-trainer/
                 const cur = Math.floor(Math.min(a.value(), a.target));
                 const ratio = isUnlocked ? 1 : Math.min(1, a.value() / a.target);
                 return `
-                <div class="ach ${isUnlocked ? 'unlocked' : 'locked'}">
+                <div class="ach ${isUnlocked ? 'unlocked' : 'locked'}" data-ach-id="${a.id}" role="button" tabindex="0" title="Share this badge">
                     <span class="em">${a.emoji}</span>
                     <div class="ach-main">
                         <div class="nm">${a.name}</div>

--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -3210,11 +3210,41 @@ permalink: /personal-trainer/
         // works for an unlocked badge ("look what I earned") just as well as one still in
         // progress ("here's how close I am"). Green for unlocked, blue for in-progress,
         // matching the celebratory/progress-tracking split used elsewhere in the app.
+        // When a still-locked badge might reasonably be "on a schedule", estimate the date
+        // it'll unlock — otherwise null (one-off/binary badges like "First workout" or
+        // "Early bird" aren't on any schedule, and there's nothing to project from before
+        // a single workout is logged). Streak badges project from the CURRENT active
+        // streak continuing uninterrupted; "One-year club" has an exact date already
+        // (a year from the first workout); everything else projects forward at whatever
+        // pace has been maintained since the first workout.
+        function projectedAchievementDate(a, achId) {
+            if (a.target <= 1 || a.value() >= a.target) return null;
+            const first = state.history[0];
+            if (!first) return null;
+
+            if (/^s\d+$/.test(achId)) {
+                const remaining = a.target - (state.streak || 0);
+                return remaining > 0 ? new Date(Date.now() + remaining * 86400000) : null;
+            }
+            if (achId === 'year1') {
+                return new Date(first.ts + 365 * 86400000);
+            }
+
+            const daysActive = Math.max(1, (Date.now() - first.ts) / 86400000);
+            const cur = a.value();
+            const rate = cur / daysActive;
+            const remaining = a.target - cur;
+            if (rate <= 0 || remaining <= 0) return null;
+            const daysNeeded = remaining / rate;
+            return isFinite(daysNeeded) && daysNeeded <= 3650 ? new Date(Date.now() + daysNeeded * 86400000) : null;
+        }
+
         async function buildAchievementCardBlob(achId) {
             const a = ACHIEVEMENTS.find((x) => x.id === achId);
             const isUnlocked = !!state.achievements[achId];
             const cur = Math.floor(Math.min(a.value(), a.target));
             const ratio = isUnlocked ? 1 : Math.min(1, a.value() / a.target);
+            const targetDate = isUnlocked ? null : projectedAchievementDate(a, achId);
 
             const SIZE = 1080;
             const PAD = 72;
@@ -3283,6 +3313,26 @@ permalink: /personal-trainer/
             ctx.fillStyle = '#8a97a8';
             ctx.font = '700 30px -apple-system, "Segoe UI", sans-serif';
             ctx.fillText(`${cur}/${a.target}`, PAD, y);
+            y += 30 + 48;
+
+            if (targetDate) {
+                ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+                ctx.lineWidth = 2;
+                ctx.beginPath();
+                ctx.moveTo(PAD, y);
+                ctx.lineTo(SIZE - PAD, y);
+                ctx.stroke();
+                y += 48;
+
+                ctx.fillStyle = '#e9eef5';
+                ctx.font = '600 34px -apple-system, "Segoe UI", sans-serif';
+                y = wrapText(ctx, "I'm committing to reach this goal — cheer me on! 🙌", PAD, y, SIZE - PAD * 2, 44) + 16;
+
+                const dateLabel = targetDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+                ctx.fillStyle = accent;
+                ctx.font = '700 30px -apple-system, "Segoe UI", sans-serif';
+                ctx.fillText(`Aiming for ${dateLabel}`, PAD, y);
+            }
 
             ctx.fillStyle = '#8a97a8';
             ctx.font = '500 24px -apple-system, "Segoe UI", sans-serif';

--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -3254,7 +3254,7 @@ permalink: /personal-trainer/
             ctx.textBaseline = 'alphabetic';
             ctx.font = '160px -apple-system, "Segoe UI", sans-serif';
             ctx.fillText(a.emoji, SIZE / 2, y + 140);
-            y += 140 + 48;
+            y += 140 + 90;
 
             ctx.fillStyle = accent;
             ctx.font = '700 30px -apple-system, "Segoe UI", sans-serif';
@@ -3264,7 +3264,7 @@ permalink: /personal-trainer/
             ctx.fillStyle = '#e9eef5';
             ctx.font = '800 64px -apple-system, "Segoe UI", sans-serif';
             ctx.fillText(a.name, SIZE / 2, y + 56);
-            y += 56 + 32;
+            y += 56 + 64;
 
             ctx.textAlign = 'left';
             ctx.fillStyle = '#8a97a8';
@@ -3278,7 +3278,7 @@ permalink: /personal-trainer/
             ctx.fillStyle = accent;
             roundRect(ctx, PAD, y, Math.max(barH, barW * ratio), barH, 10);
             ctx.fill();
-            y += barH + 32;
+            y += barH + 56;
 
             ctx.fillStyle = '#8a97a8';
             ctx.font = '700 30px -apple-system, "Segoe UI", sans-serif';


### PR DESCRIPTION
## What

Every badge card on the Achievements screen is tappable and shares that specific badge as an image — a trophy-style card for something already earned, or a progress-and-commitment card for one still in the works.

## In-progress badges now include a commitment + projected date

For a locked/in-progress badge, the card tells whoever it's shared with **"I'm committing to reach this goal — cheer me on! 🙌"**, plus an estimated unlock date (**"Aiming for {date}"**). Unlocked badges are unaffected — there's no future date to commit to for something already earned.

`projectedAchievementDate(a, achId)` estimates the date three different ways depending on the badge:
- **Streak badges** (On a roll, Week of fire, Unstoppable, …): target minus the *current active* streak, assuming it continues uninterrupted starting today.
- **"One-year club"**: deterministic — exactly 365 days after the first logged workout.
- **Everything else** (workout counts, minutes trained, weekly-goal weeks, tier progress, records): projected forward at whatever pace has been maintained since the first workout.

One-off/binary badges (target ≤ 1 — "First workout", "Early bird", "Night owl", "Goal getter") get no date or commitment block, since there's no meaningful schedule to project for something that isn't a countable climb toward a target.

## How it works (unchanged from before)

- Tapping (or Enter/Space on) any `.ach` card calls `buildAchievementCardBlob(achId)`, rendering a 1080×1080 card: badge emoji, "BADGE UNLOCKED"/"IN PROGRESS" eyebrow, name, description, progress bar and fraction — now followed by the commitment/date block when applicable.
- Green accent for unlocked, blue for in-progress.
- `renderAchievements()` tags each card with `data-ach-id` + `role="button"`/`tabindex="0"`; one delegated listener on `#ach-grid` handles all cards.
- Reuses the existing `shareImageBlob()` plumbing (native share sheet, download fallback).

## Files

`personal-trainer/index.html` only — `projectedAchievementDate()`, the commitment/date block in `buildAchievementCardBlob()`, plus the earlier spacing fix for the card's existing elements.

## Testing

Verified via Playwright: `projectedAchievementDate()` returns `null` for every one-off/binary badge and for already-unlocked badges; a workout-count badge with a real pace behind it gets a valid `Date`; a streak badge with an active streak of 5 and target 14 projects exactly 9 days out; the card renders successfully both with and without the commitment block. Visually reviewed full-resolution renders of a workout-count projection, a streak projection, and the single longest achievement description in the whole list (to stress-test wrapping) — none overlap the footer. Re-ran all other relevant regression suites (achievement card structure/accessibility, download flow, keyboard activation, setup back button, streak freeze, streak icon, home heatmap, heatmap goal tile, progress share card, achievements/records, workout items, generator modal, common mistakes, library video) — no failures. `bundle exec jekyll build` passes (only the known benign `feed` layout warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_