### PR TITLE
fix(personal-trainer): syntax error in sw.js breaking the service worker

### DIFF
--- a/personal-trainer/sw.js
+++ b/personal-trainer/sw.js
@@ -28,7 +28,7 @@ const PRECACHE_URLS = [
     '/img/pt/feedback-right.png',
     '/img/pt/feedback-hard.png',
     '/img/pt/celebration.png',
-    '/img/pt/barnaby-victory.png'
+    '/img/pt/barnaby-victory.png',
     '/img/pt/barnaby-easy.png',
     '/img/pt/barnaby-right.png',
     '/img/pt/barnaby-hard.png'


### PR DESCRIPTION
## What

Fixes a live bug on master: `sw.js`'s `PRECACHE_URLS` array is missing a comma between `'/img/pt/barnaby-victory.png'` and `'/img/pt/barnaby-easy.png'`, making the file invalid JavaScript. This breaks service worker registration for the whole Personal Trainer PWA — no offline support, no precaching, until it's fixed.

## How this happened

PR #287 and PR #288 each independently appended entries to the same array, merged back to back. Somewhere in that sequence the two additions landed adjacent to each other without a separating comma — I noticed it by chance while reading the file for an unrelated task, not because either PR's own CI caught it (there's no JS syntax check in this repo's pipeline).

## Fix

Added the missing comma. Verified with `node --check personal-trainer/sw.js` (fails before this change, passes after), and confirmed via Playwright that the service worker now registers and reaches `activated` state with no console errors.

## Testing

`node --check` passes. Playwright: service worker registers, activates, no page errors. Re-ran all 14 existing regression suites — no failures. `bundle exec jekyll build` passes (only the known benign `feed` layout warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_