### PR TITLE
feat(personal-trainer): sensory & coaching layer — haptics, voice, and the wake-lock fix

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1564,6 +1564,21 @@ permalink: /personal-trainer/
             grid-template-columns: repeat(4, 1fr);
         }
 
+        .choice-row.cols-2 {
+            grid-template-columns: repeat(2, 1fr);
+        }
+
+        /* Label for an individual toggle inside a multi-setting card. */
+        .setting-label {
+            font-size: var(--fs-sm);
+            color: var(--muted);
+            margin-top: var(--sp-4);
+        }
+
+        .setting-label:first-of-type {
+            margin-top: var(--sp-2);
+        }
+
         /* The preview list is the only scroll region inside a screen. */
         .scroll-fill {
             flex: 1;
@@ -1618,6 +1633,25 @@ permalink: /personal-trainer/
                     <div class="choice" data-v="4">4×<small>a week</small></div>
                     <div class="choice" data-v="5">5×<small>a week</small></div>
                 </div>
+            </div>
+            <div class="card">
+                <div class="section-title">Coaching</div>
+                <div class="setting-label">Sound</div>
+                <div class="choice-row cols-2" id="setup-sound">
+                    <div class="choice selected" data-v="on">On<small>Interval chimes</small></div>
+                    <div class="choice" data-v="off">Off<small>Silent</small></div>
+                </div>
+                <div class="setting-label">Voice</div>
+                <div class="choice-row cols-2" id="setup-voice">
+                    <div class="choice selected" data-v="on">On<small>Calls each move</small></div>
+                    <div class="choice" data-v="off">Off<small>No speech</small></div>
+                </div>
+                <div class="setting-label">Vibration</div>
+                <div class="choice-row cols-2" id="setup-haptics">
+                    <div class="choice selected" data-v="on">On<small>Buzz on change</small></div>
+                    <div class="choice" data-v="off">Off<small>No buzz</small></div>
+                </div>
+                <p class="muted-note mt-3">Voice calls the next move out loud so you can keep your eyes off the screen — useful face-down on a mat.</p>
             </div>
             <p class="muted-note mb-4">All workouts mix core fitness and mat pilates — just a mat, no equipment. The plan adapts every session based on your feedback.</p>
             <button class="btn" id="setup-go">Let's go</button>
@@ -1881,7 +1915,7 @@ permalink: /personal-trainer/
     </div>
 
     <script>
-        const SW_VERSION = '2607260032';
+        const SW_VERSION = '2607260138';
 
         if ('serviceWorker' in navigator) {
             let hasRefreshedForUpdate = false;
@@ -2131,7 +2165,10 @@ permalink: /personal-trainer/
                 achievements: {},
                 lastTwist: null,
                 records: {},
-                frozenDates: []
+                frozenDates: [],
+                sound: true,
+                voice: true,
+                haptics: true
             };
         }
 
@@ -2150,6 +2187,7 @@ permalink: /personal-trainer/
                 if (typeof currentWorkout === 'object' && currentWorkout) {
                     currentWorkout.newRecords = (currentWorkout.newRecords || 0) + 1;
                 }
+                haptic('record');
                 saveState();
             }
         }
@@ -2491,6 +2529,7 @@ permalink: /personal-trainer/
                 if (cur === 'player' && window.confirm('Quit this workout? Progress won’t be saved.')) {
                     stopTimer();
                     clearVideo();
+                    stopSpeaking();
                     releaseWakeLock();
                     goHome();
                 }
@@ -2553,6 +2592,15 @@ permalink: /personal-trainer/
         bindChoiceRow('setup-level', () => {});
         bindChoiceRow('setup-duration', () => {});
         bindChoiceRow('setup-goal', () => {});
+        // Applied immediately rather than on "Let's go", so the toggle you just tapped is
+        // already in effect — and so they still stick if you leave via the back button.
+        bindChoiceRow('setup-sound', (v) => { state.sound = v === 'on'; saveState(); });
+        bindChoiceRow('setup-voice', (v) => {
+            state.voice = v === 'on';
+            if (!state.voice) stopSpeaking();
+            saveState();
+        });
+        bindChoiceRow('setup-haptics', (v) => { state.haptics = v === 'on'; saveState(); });
         document.getElementById('setup-go').addEventListener('click', () => {
             const level = selectedValue('setup-level') || 'intermediate';
             state.duration = parseInt(selectedValue('setup-duration') || '25', 10);
@@ -2576,6 +2624,9 @@ permalink: /personal-trainer/
         document.getElementById('nav-settings').addEventListener('click', () => {
             markSelected('setup-duration', state.duration);
             markSelected('setup-goal', state.weeklyGoal || 3);
+            markSelected('setup-sound', state.sound ? 'on' : 'off');
+            markSelected('setup-voice', state.voice ? 'on' : 'off');
+            markSelected('setup-haptics', state.haptics ? 'on' : 'off');
             if (state.level) markSelected('setup-level', state.level);
             document.getElementById('setup-back').style.display = '';
             navigate('setup');
@@ -2908,6 +2959,7 @@ permalink: /personal-trainer/
             if (window.confirm('Quit this workout? Progress won’t be saved.')) {
                 stopTimer();
                 clearVideo();
+                stopSpeaking();
                 releaseWakeLock();
                 goHome();
             }
@@ -2930,12 +2982,30 @@ permalink: /personal-trainer/
             player.idx = 0;
             player.paused = false;
             player.startedAt = Date.now();
-            try {
-                if ('wakeLock' in navigator) player.wakeLock = await navigator.wakeLock.request('screen');
-            } catch (e) { /* wake lock is best-effort */ }
+            await requestWakeLock();
             navigate('player');
             loadItem();
         }
+
+        async function requestWakeLock() {
+            if (!('wakeLock' in navigator) || player.wakeLock) return;
+            try {
+                player.wakeLock = await navigator.wakeLock.request('screen');
+                // The browser drops the sentinel on its own when the tab is hidden; clear
+                // our handle so the visibilitychange listener knows to ask again.
+                player.wakeLock.addEventListener('release', () => { player.wakeLock = null; });
+            } catch (e) { /* wake lock is best-effort */ }
+        }
+
+        // Browsers release the screen lock whenever the page is backgrounded and never
+        // restore it, so before this the screen began sleeping mid-workout after any app
+        // switch. Re-acquire on return, but only while a workout is actually running.
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState !== 'visible') return;
+            if (!document.getElementById('player').classList.contains('active')) return;
+            if (player.paused) return;
+            requestWakeLock();
+        });
 
         function releaseWakeLock() {
             if (player.wakeLock) {
@@ -2961,7 +3031,46 @@ permalink: /personal-trainer/
             return `${m}:${String(s).padStart(2, '0')}`;
         }
 
+        // ---- Sensory layer -------------------------------------------------------
+        // A mat workout has you face-down or eyes-closed mid-exertion, so the screen is
+        // the worst channel available. Sound, speech and vibration carry the interval
+        // boundaries instead; each is independently switchable from Settings, and each
+        // helper no-ops when its API is missing so unsupported browsers degrade quietly.
+
+        // Distinct enough to tell apart through a mat without looking.
+        const HAPTICS = {
+            work: [60],             // a new exercise starts — the one you must not miss
+            rest: [25],             // ease off
+            countdown: [15],        // final three seconds, one tick each
+            complete: [80, 60, 80], // workout finished
+            record: [40, 40, 120]   // personal best
+        };
+
+        function haptic(name) {
+            if (!state.haptics || !('vibrate' in navigator)) return;
+            try { navigator.vibrate(HAPTICS[name] || name); } catch (e) { /* haptics are optional */ }
+        }
+
+        // `interrupt` drops anything still queued — at an interval boundary the previous
+        // announcement is stale, and letting utterances pile up puts the voice further
+        // and further behind the timer.
+        function speak(text, interrupt) {
+            if (!state.voice || !('speechSynthesis' in window) || !text) return;
+            try {
+                if (interrupt) window.speechSynthesis.cancel();
+                const u = new SpeechSynthesisUtterance(text);
+                u.rate = 1.05;
+                window.speechSynthesis.speak(u);
+            } catch (e) { /* speech is optional */ }
+        }
+
+        function stopSpeaking() {
+            if (!('speechSynthesis' in window)) return;
+            try { window.speechSynthesis.cancel(); } catch (e) { /* no-op */ }
+        }
+
         function beep(freq) {
+            if (!state.sound) return;
             try {
                 const ctx = beep.ctx || (beep.ctx = new (window.AudioContext || window.webkitAudioContext)());
                 const osc = ctx.createOscillator();
@@ -3114,6 +3223,10 @@ permalink: /personal-trainer/
 
                 startCountdown(item.secs);
                 beep(440);
+                haptic('rest');
+                // Naming what's coming is the whole point of the rest beat — it lets you
+                // set up for the next move without reading the screen.
+                speak(next ? `${item.prep ? 'Get into position' : 'Rest'}. Next up, ${next.ex.name}${next.side ? ', ' + next.side : ''}` : 'Rest', true);
                 return;
             }
 
@@ -3133,6 +3246,8 @@ permalink: /personal-trainer/
             startCueRotation(ex.cues);
             renderExerciseMedia(ex);
             beep(880);
+            haptic('work');
+            speak(`${ex.name}${item.side ? ', ' + item.side : ''}`, true);
 
             if (ex.type === 'secs') {
                 actionBtn.textContent = 'Pause';
@@ -3199,7 +3314,16 @@ permalink: /personal-trainer/
                 }
                 displayEl.textContent = fmtTime(player.remaining);
                 setTimerRing(player.remaining / secs, true);
-                if (player.remaining <= 3) beep(660);
+                // Only worth calling on intervals long enough for it to mean something —
+                // on a 10s hold "halfway" would land almost on top of the 3-2-1.
+                if (secs >= 20 && player.remaining === Math.round(secs / 2)) speak('Halfway');
+                if (player.remaining <= 3) {
+                    beep(660);
+                    haptic('countdown');
+                    // Not interrupting: these are one word each and must not cut each
+                    // other off, or the count audibly skips numbers.
+                    speak(String(player.remaining));
+                }
             }, 1000);
         }
 
@@ -3239,6 +3363,8 @@ permalink: /personal-trainer/
             // handler), so the big payoff marks the thing that counts.
             beep(880);
             setTimeout(() => beep(1100), 200);
+            haptic('complete');
+            speak('Workout complete. Nice work.', true);
         }
 
         const FEEDBACK_DELTA = { easy: 8, right: 4, hard: -5 };

--- a/personal-trainer/sw.js
+++ b/personal-trainer/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607260032';
+const CACHE_VERSION = '2607260138';
 const CACHE_NAME = `personal-trainer-${CACHE_VERSION}`;
 const OFFLINE_URL = '/personal-trainer/';
 const PRECACHE_URLS = [

--- a/tools/personal-trainer-e2e/specs/e2e-sensory.js
+++ b/tools/personal-trainer-e2e/specs/e2e-sensory.js
@@ -1,0 +1,192 @@
+const { chromium } = require('playwright');
+const SHOTS = process.env.SHOTS_DIR;
+
+// Phase 3 — sensory & coaching layer.
+//
+// Headless Chromium has no real vibration motor, no speech engine and (usually) no
+// Screen Wake Lock, so every one of these APIs is installed as a recording stub via
+// addInitScript before any page script runs. That means this spec verifies *our*
+// call sites — that the right thing fires at the right interval boundary, and that
+// the settings toggles actually gate it — not the browser's implementation.
+const INSTALL_STUBS = () => {
+    window.__sensory = { vibrations: [], spoken: [], wakeRequests: 0 };
+
+    // speechSynthesis and wakeLock are read-only accessors on the prototype in Chromium,
+    // so plain assignment fails silently (non-strict) and you get a stub that never
+    // records anything. defineProperty is required; do the same for vibrate for symmetry.
+    const define = (obj, prop, value) =>
+        Object.defineProperty(obj, prop, { configurable: true, get: () => value });
+
+    define(navigator, 'vibrate', (pattern) => {
+        window.__sensory.vibrations.push(Array.isArray(pattern) ? pattern.join(',') : String(pattern));
+        return true;
+    });
+
+    // Minimal SpeechSynthesis surface: the app only uses speak() and cancel().
+    define(window, 'SpeechSynthesisUtterance', function (text) { this.text = text; this.rate = 1; });
+    define(window, 'speechSynthesis', {
+        speak: (u) => window.__sensory.spoken.push(u.text),
+        cancel: () => window.__sensory.spoken.push('<cancel>')
+    });
+
+    // A sentinel that reports release, so re-acquisition is observable.
+    let sentinel = null;
+    define(navigator, 'wakeLock', {
+        request: async () => {
+            window.__sensory.wakeRequests += 1;
+            const listeners = [];
+            sentinel = {
+                released: false,
+                addEventListener: (_, fn) => listeners.push(fn),
+                release: async () => { sentinel.released = true; listeners.forEach((f) => f()); },
+                __fireRelease: () => { sentinel.released = true; listeners.forEach((f) => f()); }
+            };
+            window.__sensory.sentinel = sentinel;
+            return sentinel;
+        }
+    });
+};
+
+(async () => {
+    const browser = await chromium.launch();
+    const assert = (c, m) => { if (!c) throw new Error('ASSERT FAILED: ' + m); };
+
+    const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+    await page.addInitScript(INSTALL_STUBS);
+
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(String(e)));
+    const active = () => page.evaluate(() => document.querySelector('.screen.active').id);
+    const sensory = () => page.evaluate(() => window.__sensory);
+    const reset = () => page.evaluate(() => {
+        window.__sensory.vibrations = [];
+        window.__sensory.spoken = [];
+    });
+
+    await page.goto('http://localhost:4001/personal-trainer/', { waitUntil: 'load' });
+    await page.waitForLoadState('networkidle');
+    if (await active() === 'setup') {
+        await page.click('#setup-level .choice[data-v="intermediate"]').catch(() => {});
+        await page.click('#setup-go');
+    }
+    assert(await active() === 'home', 'reached home, got ' + await active());
+    if (errors.length) assert(false, 'clean load: ' + errors.join(' | '));
+
+    // 1. Defaults are on, so an upgrading user is never silently muted.
+    const defaults = await page.evaluate(() => ({ sound: state.sound, voice: state.voice, haptics: state.haptics }));
+    console.log('defaults:', JSON.stringify(defaults));
+    assert(defaults.sound === true && defaults.voice === true && defaults.haptics === true,
+        'sound/voice/haptics all default to on, got ' + JSON.stringify(defaults));
+
+    // 2. Starting a workout takes the wake lock and announces the first exercise.
+    await page.click('#btn-generate');
+    await reset();
+    await page.click('#btn-start');
+    await page.waitForSelector('#player.active', { timeout: 5000 });
+    await page.waitForTimeout(600);
+
+    const start = await sensory();
+    console.log('at work start — vibrations:', start.vibrations, 'spoken:', start.spoken);
+    assert(start.wakeRequests === 1, 'wake lock requested once on start, got ' + start.wakeRequests);
+    assert(start.vibrations.includes('60'), 'work-start haptic fired, got ' + JSON.stringify(start.vibrations));
+    const firstName = await page.textContent('#player-exname');
+    assert(start.spoken.some((s) => s.includes(firstName.trim())),
+        `announced the exercise name "${firstName.trim()}", got ` + JSON.stringify(start.spoken));
+    await page.screenshot({ path: `${SHOTS}/1-sensory-work.png` });
+
+    // 3. The final three seconds tick individually, and the count is not interrupted
+    //    (interrupting is what makes a spoken countdown audibly skip numbers).
+    await reset();
+    await page.evaluate(() => { player.remaining = 4; });
+    await page.waitForTimeout(3400);
+    const countdown = await sensory();
+    console.log('countdown — vibrations:', countdown.vibrations, 'spoken:', countdown.spoken);
+    assert(countdown.vibrations.filter((v) => v === '15').length >= 3,
+        'a countdown haptic per second for the final three, got ' + JSON.stringify(countdown.vibrations));
+    ['3', '2', '1'].forEach((n) => {
+        assert(countdown.spoken.includes(n), `spoke "${n}" in the countdown, got ` + JSON.stringify(countdown.spoken));
+    });
+    const countIdx = countdown.spoken.indexOf('3');
+    assert(!countdown.spoken.slice(countIdx, countdown.spoken.indexOf('1')).includes('<cancel>'),
+        'the 3-2-1 count is not interrupted mid-sequence, got ' + JSON.stringify(countdown.spoken));
+
+    // 4. Crossing into rest names what is coming next, which is the point of the beat.
+    //    The countdown above already advanced us into a rest, so step off it first —
+    //    otherwise the loop below exits immediately and reset() has wiped the evidence.
+    const kind = () => page.evaluate(() => currentWorkout.items[player.idx].kind);
+    for (let i = 0; i < 20 && (await kind()) === 'rest'; i++) {
+        await page.click('#btn-skip');
+        await page.waitForTimeout(120);
+    }
+    await reset();
+    for (let i = 0; i < 20 && (await kind()) !== 'rest'; i++) {
+        await page.click('#btn-skip');
+        await page.waitForTimeout(120);
+    }
+    assert(await kind() === 'rest', 'reached a rest interval');
+    await page.waitForTimeout(300);
+    const rest = await sensory();
+    console.log('rest — vibrations:', rest.vibrations, 'spoken:', rest.spoken);
+    assert(rest.vibrations.includes('25'), 'rest haptic is distinct from work, got ' + JSON.stringify(rest.vibrations));
+    const upNext = await page.textContent('#player-exname');
+    assert(rest.spoken.some((s) => s.includes(upNext.trim())),
+        `rest announces the upcoming exercise "${upNext.trim()}", got ` + JSON.stringify(rest.spoken));
+
+    // 5. Wake lock is re-acquired after the page is backgrounded. This is the bug the
+    //    phase fixes: the browser drops the lock on hide and nothing ever asked again,
+    //    so the screen began sleeping mid-workout after an app switch.
+    const before = (await sensory()).wakeRequests;
+    await page.evaluate(() => {
+        window.__sensory.sentinel.__fireRelease();          // what the browser does on hide
+        Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'hidden' });
+        document.dispatchEvent(new Event('visibilitychange'));
+        Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'visible' });
+        document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.waitForTimeout(300);
+    const after = (await sensory()).wakeRequests;
+    console.log(`wake lock requests: ${before} -> ${after}`);
+    assert(after === before + 1, `wake lock re-acquired on return to foreground, got ${before} -> ${after}`);
+
+    // 6. Each toggle actually gates its channel. Quit out to settings first.
+    page.once('dialog', (d) => d.accept());
+    await page.click('#btn-quit');
+    await page.waitForTimeout(300);
+    assert(await active() === 'home', 'back home after quitting, got ' + await active());
+
+    await page.click('#nav-settings');
+    await page.click('#setup-voice .choice[data-v="off"]');
+    await page.click('#setup-haptics .choice[data-v="off"]');
+    const off = await page.evaluate(() => ({ voice: state.voice, haptics: state.haptics, sound: state.sound }));
+    assert(off.voice === false && off.haptics === false, 'toggles flipped in state, got ' + JSON.stringify(off));
+    assert(off.sound === true, 'sound is independent of the other two, got ' + JSON.stringify(off));
+    await page.screenshot({ path: `${SHOTS}/2-sensory-settings.png` });
+
+    // 7. They persist across a reload — the settings are in saved state, not just memory.
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    const persisted = await page.evaluate(() => ({ voice: state.voice, haptics: state.haptics, sound: state.sound }));
+    console.log('after reload:', JSON.stringify(persisted));
+    assert(persisted.voice === false && persisted.haptics === false && persisted.sound === true,
+        'toggles persisted across reload, got ' + JSON.stringify(persisted));
+
+    // 8. And with them off, a workout fires neither channel — while sound still works.
+    await reset();
+    await page.click('#btn-generate');
+    await page.click('#btn-start');
+    await page.waitForSelector('#player.active', { timeout: 5000 });
+    await page.waitForTimeout(600);
+    const silenced = await sensory();
+    console.log('with voice+haptics off:', JSON.stringify(silenced.vibrations), JSON.stringify(silenced.spoken));
+    assert(silenced.vibrations.length === 0, 'no haptics when disabled, got ' + JSON.stringify(silenced.vibrations));
+    assert(silenced.spoken.filter((s) => s !== '<cancel>').length === 0,
+        'no speech when disabled, got ' + JSON.stringify(silenced.spoken));
+
+    if (errors.length) {
+        console.log('PAGE ERRORS:', errors);
+        assert(false, 'no uncaught page errors: ' + errors.join(' | '));
+    }
+
+    console.log('ALL SENSORY CHECKS PASSED');
+    await browser.close();
+})().catch((e) => { console.error(e.message || e); process.exit(1); });


### PR DESCRIPTION
Phase 3 of the UX elevation plan. Based on `master` (Phases 1 and 2 are both merged), so this diff shows only the sensory layer.

## Why

The audit's third finding: the app had **zero** `navigator.vibrate` and **zero** `speechSynthesis` usage. A mat workout has you face-down or eyes-closed mid-exertion, so the screen is the worst channel available — yet it was the only one. Phase 1 fixed *what* the screen says and when; this phase stops requiring you to look at it.

## Haptics

Five patterns, distinct enough to tell apart through a mat without looking:

| Event | Pattern |
|---|---|
| Work interval starts | `[60]` — the one you must not miss |
| Rest / prep starts | `[25]` |
| Each of the final 3 seconds | `[15]` |
| Workout complete | `[80, 60, 80]` |
| New personal record | `[40, 40, 120]` |

## Voice

- **Work start** announces the exercise name and side.
- **Rest** names the upcoming move — "Get into position. Next up, Standing Side Bend" — which is what makes the rest beat usable without reading it.
- **"Halfway"**, gated to intervals ≥20s. On a 10s hold it would land almost on top of the 3-2-1.
- **3-2-1**, spoken per second alongside the existing chime.

One subtlety: boundary announcements interrupt (a stale one is worse than silence), but the countdown deliberately does **not** — interrupting makes a spoken count audibly skip numbers.

## Sound / Voice / Vibration toggles

There was previously no mute at all for the existing `beep()` chimes. New "Coaching" card in Settings, built on the existing `.choice-row` pattern (new `cols-2` modifier). Each toggle applies immediately rather than on "Let's go", so it takes effect as you tap it and still sticks if you leave via Back.

All three default to on, and `loadState()` does `Object.assign(defaultState(), parsed)` — so **existing users inherit the defaults rather than being silently muted**.

## Wake-lock re-acquisition — a real bug

The lock was requested once in `startWorkout()` and never again. Browsers release it whenever the page is backgrounded, so the screen began sleeping mid-workout after any app switch. Now the sentinel's `release` event clears our handle, and a `visibilitychange` listener re-acquires on return — but only while the player is actually active and unpaused.

## Verification

New `e2e-sensory.js` covers all four areas: defaults are on; the wake lock is taken at start and **re-acquired** after a simulated background/foreground cycle; work/rest/countdown haptics fire with the right patterns; the exercise name is announced; the 3-2-1 is not interrupted; both toggles gate their channel, stay independent of `sound`, and persist across reload.

**20/20 specs pass.** `jekyll build` clean, `node --check` clean on both `sw.js` and the extracted inline script, `SW_VERSION`/`CACHE_VERSION` bumped in lockstep.

Settings card was visually reviewed at 390×844 — it sits on the Phase 2 tokens and no `.choice small` sub-label wraps (the regression Phase 2 hit).

> Worth recording for future specs: `speechSynthesis` and `wakeLock` are read-only prototype accessors in Chromium, so stubbing them requires `Object.defineProperty`. Plain assignment fails silently and you get a stub that records nothing — which is exactly how this spec failed first time round.

## Not included

The plan's **explicitly deferred** accessibility/data-safety track is untouched — the `.choice` tiles are still keyboard-inoperable, there's still no `aria-live`, and Export still backs up only video links. Those remain the hard blockers to an actual design award, and are still yours to schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_