### PR TITLE
feat(personal-trainer): full backup/restore and stop losing data silently

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1653,6 +1653,13 @@ permalink: /personal-trainer/
                 </div>
                 <p class="muted-note mt-3">Voice calls the next move out loud so you can keep your eyes off the screen — useful face-down on a mat.</p>
             </div>
+            <div class="card">
+                <div class="section-title">Your data</div>
+                <p class="muted-note" id="backup-status">Everything is stored on this device only.</p>
+                <button class="btn secondary mt-3" id="btn-backup">Back up my data ↗</button>
+                <button class="btn secondary mt-3" id="btn-restore">Restore from a backup</button>
+                <input type="file" id="restore-file" accept=".json,application/json" style="display:none;">
+            </div>
             <p class="muted-note mb-4">All workouts mix core fitness and mat pilates — just a mat, no equipment. The plan adapts every session based on your feedback.</p>
             <button class="btn" id="setup-go">Let's go</button>
             <button class="btn secondary mt-3" id="nav-library"><img class="ico" src="/img/pt/exercise-library.png" alt="">Exercise library</button>
@@ -1915,7 +1922,7 @@ permalink: /personal-trainer/
     </div>
 
     <script>
-        const SW_VERSION = '2607260138';
+        const SW_VERSION = '2607260323';
 
         if ('serviceWorker' in navigator) {
             let hasRefreshedForUpdate = false;
@@ -2142,6 +2149,15 @@ permalink: /personal-trainer/
         // State
         // =====================================================
         const STORAGE_KEY = 'pt-state-v1';
+        // The previous blob that parsed cleanly. Without it a single corrupt write is
+        // terminal: load falls back to defaults, and the next save overwrites the damaged
+        // (but possibly salvageable) original with an empty one.
+        // Declared here, not beside loadState(), because `state = loadState()` runs further
+        // up this file — a const declared below it would still be in the temporal dead zone.
+        const BACKUP_KEY = 'pt-state-v1-prev';
+        // Set during load, surfaced after boot: loadState() runs long before there is a
+        // rendered screen to show a message on.
+        let storageNotice = null;
         const LEVEL_START = { beginner: 0, intermediate: 36, advanced: 54 };
         const SCORE_PER_TIER = 18;
         const MAX_SCORE = SCORE_PER_TIER * 5; // tier 5 fully progressed
@@ -2168,7 +2184,8 @@ permalink: /personal-trainer/
                 frozenDates: [],
                 sound: true,
                 voice: true,
-                haptics: true
+                haptics: true,
+                lastBackup: null
             };
         }
 
@@ -2276,17 +2293,97 @@ permalink: /personal-trainer/
         }
 
         function loadState() {
+            let raw = null;
             try {
-                const raw = localStorage.getItem(STORAGE_KEY);
-                if (raw) return Object.assign(defaultState(), JSON.parse(raw));
-            } catch (e) { /* corrupted state falls back to defaults */ }
-            return defaultState();
+                raw = localStorage.getItem(STORAGE_KEY);
+            } catch (e) {
+                storageNotice = 'Saved data could not be read — progress won’t persist this session.';
+                return defaultState();
+            }
+            if (!raw) return defaultState();
+
+            try {
+                const parsed = Object.assign(defaultState(), JSON.parse(raw));
+                try { localStorage.setItem(BACKUP_KEY, raw); } catch (e) { /* best-effort */ }
+                return parsed;
+            } catch (e) {
+                try {
+                    const prev = localStorage.getItem(BACKUP_KEY);
+                    if (prev) {
+                        const recovered = Object.assign(defaultState(), JSON.parse(prev));
+                        storageNotice = 'Saved data was damaged — restored your previous session. Back up from Settings.';
+                        return recovered;
+                    }
+                } catch (e2) { /* the backup is gone too — nothing left to recover */ }
+                storageNotice = 'Saved data was damaged and could not be recovered. Starting fresh.';
+                return defaultState();
+            }
         }
+
+        let saveFailed = false;
 
         function saveState() {
             try {
                 localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-            } catch (e) { /* storage full or unavailable (e.g. private browsing) */ }
+                saveFailed = false;
+            } catch (e) {
+                // The worst failure mode in the app: without this you keep training for
+                // weeks while nothing is written and nothing says so. Warn once, then stay
+                // quiet so it can't nag mid-workout.
+                if (!saveFailed) {
+                    saveFailed = true;
+                    showToast('<div><strong>⚠️ Progress isn’t being saved</strong><br>Storage is full or unavailable. Back up from Settings.</div>', 5000);
+                }
+            }
+        }
+
+        // ---- Backup / restore ----------------------------------------------------
+        // Everything lives in one localStorage key on one device, so a full export is the
+        // only thing standing between a cleared cache and losing every workout ever done.
+        // It goes through the share sheet because this is used as an installed phone PWA,
+        // where "save to Files/Drive" is a real destination and a download barely is.
+        const BACKUP_FORMAT = 1;
+
+        function buildBackupBlob() {
+            const payload = {
+                app: 'personal-trainer',
+                format: BACKUP_FORMAT,
+                exportedAt: new Date().toISOString(),
+                state
+            };
+            return new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+        }
+
+        // Accepts either a wrapped backup or a bare state object, so a hand-edited file
+        // or an older shape still restores.
+        function parseBackup(text) {
+            const data = JSON.parse(text);
+            const incoming = data && data.state ? data.state : data;
+            if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) {
+                throw new Error('not an object');
+            }
+            // Enough of a shape check to reject an unrelated JSON file without being so
+            // strict that a backup from a future version stops restoring.
+            if (!('prog' in incoming) && !('history' in incoming) && !('records' in incoming)) {
+                throw new Error('missing recognisable fields');
+            }
+            return Object.assign(defaultState(), incoming);
+        }
+
+        function backupSummary(s) {
+            const workouts = (s.history || []).length;
+            const records = Object.keys(s.records || {}).length;
+            const badges = Object.keys(s.achievements || {}).length;
+            return `${workouts} workout${workouts === 1 ? '' : 's'}, ${records} record${records === 1 ? '' : 's'}, ${badges} badge${badges === 1 ? '' : 's'}`;
+        }
+
+        // Ask the browser not to evict this origin under storage pressure. Installed PWAs
+        // are usually granted it without prompting; it is a no-op where unsupported.
+        function requestPersistentStorage() {
+            if (!navigator.storage || !navigator.storage.persist) return;
+            navigator.storage.persisted()
+                .then((already) => (already ? null : navigator.storage.persist()))
+                .catch(() => { /* best-effort */ });
         }
 
         function tierCap(score) {
@@ -2601,6 +2698,68 @@ permalink: /personal-trainer/
             saveState();
         });
         bindChoiceRow('setup-haptics', (v) => { state.haptics = v === 'on'; saveState(); });
+
+        document.getElementById('btn-backup').addEventListener('click', async () => {
+            const btn = document.getElementById('btn-backup');
+            const original = btn.textContent;
+            btn.disabled = true;
+            btn.textContent = 'Preparing…';
+            try {
+                const name = `personal-trainer-backup-${new Date().toISOString().slice(0, 10)}.json`;
+                await shareImageBlob(buildBackupBlob(), name, 'Personal Trainer backup', backupSummary(state));
+                state.lastBackup = Date.now();
+                saveState();
+                renderBackupStatus();
+            } catch (e) {
+                // A cancelled share sheet lands here too, which is not worth reporting.
+                if (e && e.name !== 'AbortError') window.alert('Could not create the backup.');
+            } finally {
+                btn.disabled = false;
+                btn.textContent = original;
+            }
+        });
+
+        document.getElementById('btn-restore').addEventListener('click', () => {
+            document.getElementById('restore-file').click();
+        });
+
+        document.getElementById('restore-file').addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            if (!file) return;
+            file.text().then((text) => {
+                let incoming;
+                try {
+                    incoming = parseBackup(text);
+                } catch (err) {
+                    window.alert('That doesn’t look like a Personal Trainer backup.');
+                    return;
+                }
+                // Restoring replaces everything, so name what is being traded away.
+                const ok = window.confirm(
+                    `Restore ${backupSummary(incoming)}?\n\nThis replaces what's on this device now (${backupSummary(state)}).`
+                );
+                if (!ok) return;
+                state = incoming;
+                saveState();
+                renderHome();
+                renderBackupStatus();
+                showToast(`<div><strong>✅ Restored</strong><br>${backupSummary(state)}</div>`, 3200);
+            }).catch(() => window.alert('Could not read that file.'));
+            e.target.value = '';
+        });
+
+        function renderBackupStatus() {
+            const el = document.getElementById('backup-status');
+            if (!el) return;
+            const summary = backupSummary(state);
+            if (!state.lastBackup) {
+                el.textContent = `${summary} on this device — never backed up.`;
+                return;
+            }
+            const days = Math.floor((Date.now() - state.lastBackup) / 86400000);
+            const when = days === 0 ? 'today' : days === 1 ? 'yesterday' : `${days} days ago`;
+            el.textContent = `${summary} on this device — last backed up ${when}.`;
+        }
         document.getElementById('setup-go').addEventListener('click', () => {
             const level = selectedValue('setup-level') || 'intermediate';
             state.duration = parseInt(selectedValue('setup-duration') || '25', 10);
@@ -2627,6 +2786,7 @@ permalink: /personal-trainer/
             markSelected('setup-sound', state.sound ? 'on' : 'off');
             markSelected('setup-voice', state.voice ? 'on' : 'off');
             markSelected('setup-haptics', state.haptics ? 'on' : 'off');
+            renderBackupStatus();
             if (state.level) markSelected('setup-level', state.level);
             document.getElementById('setup-back').style.display = '';
             navigate('setup');
@@ -3778,8 +3938,10 @@ permalink: /personal-trainer/
         }
 
         // Try the native share sheet with the image file; fall back to a plain download.
+        // Also used for the JSON backup, hence the blob's own type rather than a hardcoded
+        // image/png — every existing caller passes a PNG blob, so their behaviour is unchanged.
         async function shareImageBlob(blob, filename, title, text) {
-            const file = new File([blob], filename, { type: 'image/png' });
+            const file = new File([blob], filename, { type: blob.type || 'image/png' });
             if (navigator.canShare && navigator.canShare({ files: [file] })) {
                 await navigator.share({ files: [file], title, text });
             } else {
@@ -4028,20 +4190,28 @@ permalink: /personal-trainer/
             }).join('');
         }
 
+        function showToast(innerHtml, ms, onDone) {
+            const el = document.createElement('div');
+            el.className = 'toast';
+            el.innerHTML = innerHtml;
+            document.body.appendChild(el);
+            requestAnimationFrame(() => el.classList.add('show'));
+            setTimeout(() => {
+                el.classList.remove('show');
+                setTimeout(() => { el.remove(); if (onDone) onDone(); }, 350);
+            }, ms);
+        }
+
         function showAchievementToasts(list) {
             let i = 0;
             const next = () => {
                 if (i >= list.length) return;
                 const a = list[i++];
-                const el = document.createElement('div');
-                el.className = 'toast';
-                el.innerHTML = `<img class="toast-mascot" src="/img/pt/barnaby-victory.png" alt=""><div><strong>${a.emoji} Achievement unlocked!</strong><br>${a.name}</div>`;
-                document.body.appendChild(el);
-                requestAnimationFrame(() => el.classList.add('show'));
-                setTimeout(() => {
-                    el.classList.remove('show');
-                    setTimeout(() => { el.remove(); next(); }, 350);
-                }, 2600);
+                showToast(
+                    `<img class="toast-mascot" src="/img/pt/barnaby-victory.png" alt=""><div><strong>${a.emoji} Achievement unlocked!</strong><br>${a.name}</div>`,
+                    2600,
+                    next
+                );
             };
             next();
         }
@@ -4156,6 +4326,10 @@ permalink: /personal-trainer/
         } else {
             show('setup');
         }
+        requestPersistentStorage();
+        // Reported after boot so the message lands on a rendered screen rather than a
+        // blank one. loadState() runs long before there is anything to show it on.
+        if (storageNotice) showToast(`<div><strong>⚠️ ${storageNotice}</strong></div>`, 6000);
     </script>
 </body>
 

--- a/personal-trainer/sw.js
+++ b/personal-trainer/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607260138';
+const CACHE_VERSION = '2607260323';
 const CACHE_NAME = `personal-trainer-${CACHE_VERSION}`;
 const OFFLINE_URL = '/personal-trainer/';
 const PRECACHE_URLS = [

--- a/tools/personal-trainer-e2e/specs/e2e-data-safety.js
+++ b/tools/personal-trainer-e2e/specs/e2e-data-safety.js
@@ -1,0 +1,165 @@
+const { chromium } = require('playwright');
+const SHOTS = process.env.SHOTS_DIR;
+
+const URL = 'http://localhost:4001/personal-trainer/';
+const KEY = 'pt-state-v1';
+const PREV = 'pt-state-v1-prev';
+
+(async () => {
+    const browser = await chromium.launch();
+    const assert = (c, m) => { if (!c) throw new Error('ASSERT FAILED: ' + m); };
+
+    // Each case needs its own storage, so use a fresh context rather than one page.
+    const fresh = async () => {
+        const ctx = await browser.newContext({ viewport: { width: 390, height: 844 } });
+        const page = await ctx.newPage();
+        const errs = [];
+        page.on('pageerror', (e) => errs.push(String(e)));
+        return { ctx, page, errs };
+    };
+    const active = (page) => page.evaluate(() => document.querySelector('.screen.active').id);
+
+    // Drive a real workout so there is genuine history to lose.
+    const seed = async (page) => {
+        await page.goto(URL, { waitUntil: 'load' });
+        await page.waitForLoadState('networkidle');
+        if (await active(page) === 'setup') {
+            await page.click('#setup-level .choice[data-v="intermediate"]').catch(() => {});
+            await page.click('#setup-go');
+        }
+        await page.click('#btn-generate');
+        await page.click('#btn-start');
+        await page.waitForSelector('#player.active', { timeout: 5000 });
+        for (let i = 0; i < 140 && (await active(page)) === 'player'; i++) {
+            await page.click('#btn-skip');
+            await page.waitForTimeout(40);
+        }
+        await page.click('[data-fb="right"]');
+        assert(await active(page) === 'home', 'committed a workout, got ' + await active(page));
+        return page.evaluate(() => state.history.length);
+    };
+
+    // --- 1. A corrupt primary key recovers from the rolling backup ----------------
+    {
+        const { ctx, page, errs } = await fresh();
+        const workouts = await seed(page);
+        assert(workouts >= 1, 'seeded at least one workout, got ' + workouts);
+
+        // Reload once so the good blob is mirrored into the backup key, then corrupt
+        // the primary exactly the way a truncated/interrupted write would.
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        const mirrored = await page.evaluate((k) => !!localStorage.getItem(k), PREV);
+        assert(mirrored, 'a clean load mirrors the blob into the backup key');
+
+        await page.evaluate((k) => localStorage.setItem(k, '{"history":[{"ts":1,'), KEY);
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+
+        const after = await page.evaluate(() => state.history.length);
+        console.log(`corrupt primary: history ${workouts} -> ${after}`);
+        assert(after === workouts, `history recovered from the backup key, got ${after} of ${workouts}`);
+        const toast = await page.textContent('.toast').catch(() => '');
+        assert(/damaged/i.test(toast), 'the recovery is reported, not silent — got: ' + JSON.stringify(toast));
+        await page.screenshot({ path: `${SHOTS}/1-recovery-toast.png` });
+        if (errs.length) assert(false, 'no page errors during recovery: ' + errs.join(' | '));
+        await ctx.close();
+    }
+
+    // --- 2. Corrupt primary AND no backup fails loudly rather than silently -------
+    {
+        const { ctx, page } = await fresh();
+        await seed(page);
+        await page.evaluate(([k, p]) => {
+            localStorage.setItem(k, 'not json at all');
+            localStorage.removeItem(p);
+        }, [KEY, PREV]);
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        const toast = await page.textContent('.toast').catch(() => '');
+        assert(/could not be recovered/i.test(toast), 'unrecoverable loss is announced, got: ' + JSON.stringify(toast));
+        await ctx.close();
+    }
+
+    // --- 3. A failing write warns instead of silently dropping progress ----------
+    {
+        const { ctx, page } = await fresh();
+        await page.goto(URL, { waitUntil: 'load' });
+        await page.waitForLoadState('networkidle');
+        if (await active(page) === 'setup') {
+            await page.click('#setup-level .choice[data-v="intermediate"]').catch(() => {});
+            await page.click('#setup-go');
+        }
+        // Simulate a full quota the way Safari private mode behaves.
+        await page.evaluate(() => {
+            localStorage.setItem = () => { const e = new Error('quota'); e.name = 'QuotaExceededError'; throw e; };
+        });
+        await page.click('#nav-settings');
+        await page.click('#setup-haptics .choice[data-v="off"]');
+        await page.waitForTimeout(300);
+        const toast = await page.textContent('.toast').catch(() => '');
+        console.log('save-failure toast:', JSON.stringify(toast));
+        assert(/isn.t being saved/i.test(toast), 'a failed write is surfaced, got: ' + JSON.stringify(toast));
+        await ctx.close();
+    }
+
+    // --- 4. Backup captures everything, and restore round-trips it ---------------
+    {
+        const { ctx, page } = await fresh();
+        const workouts = await seed(page);
+
+        const payload = await page.evaluate(async () => {
+            const blob = buildBackupBlob();
+            return { text: await blob.text(), type: blob.type };
+        });
+        assert(payload.type === 'application/json', 'backup blob is JSON, got ' + payload.type);
+        const parsed = JSON.parse(payload.text);
+        console.log('backup:', parsed.app, 'format', parsed.format, '|', Object.keys(parsed.state).length, 'state keys');
+        assert(parsed.app === 'personal-trainer' && parsed.format === 1, 'backup is tagged and versioned');
+
+        // The whole point: this is what the old links-only export threw away.
+        ['history', 'prog', 'records', 'achievements', 'streak', 'bestStreak', 'links'].forEach((k) => {
+            assert(k in parsed.state, `backup includes "${k}"`);
+        });
+        assert(parsed.state.history.length === workouts, 'backup carries the full history');
+
+        // Wipe, then restore from that exact payload.
+        await page.evaluate(() => { state = defaultState(); saveState(); renderHome(); });
+        assert(await page.evaluate(() => state.history.length) === 0, 'wiped before restoring');
+
+        const restored = await page.evaluate((text) => {
+            state = parseBackup(text);
+            saveState();
+            return state.history.length;
+        }, payload.text);
+        console.log(`restore: 0 -> ${restored}`);
+        assert(restored === workouts, `restore round-trips the history, got ${restored} of ${workouts}`);
+
+        // And it survives a reload, i.e. it was actually written.
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        assert(await page.evaluate(() => state.history.length) === workouts, 'restored data persisted');
+        await ctx.close();
+    }
+
+    // --- 5. Restore rejects a file that isn't ours -------------------------------
+    {
+        const { ctx, page } = await fresh();
+        await page.goto(URL, { waitUntil: 'load' });
+        await page.waitForLoadState('networkidle');
+        const rejects = await page.evaluate(() => {
+            const bad = ['{}', '[]', 'null', '{"foo":1}', '{"state":{"foo":1}}', 'not json'];
+            return bad.map((t) => { try { parseBackup(t); return `ACCEPTED ${t}`; } catch (e) { return null; } })
+                      .filter(Boolean);
+        });
+        assert(rejects.length === 0, 'unrelated JSON is rejected, but got: ' + JSON.stringify(rejects));
+
+        // A bare state object (no wrapper) still restores — hand-edited files matter.
+        const bare = await page.evaluate(() => parseBackup(JSON.stringify({ history: [{ ts: 1, mins: 5 }], prog: { core: 9, pilates: 3 } })).prog.core);
+        assert(bare === 9, 'a bare state object restores, got ' + bare);
+        await ctx.close();
+    }
+
+    console.log('ALL DATA-SAFETY CHECKS PASSED');
+    await browser.close();
+})().catch((e) => { console.error(e.message || e); process.exit(1); });


### PR DESCRIPTION
The data-safety half of the deferred track. Keyboard/screen-reader accessibility stays out of scope — this is a single-user phone PWA.

Everything lives in one `localStorage` key on one device, and three separate paths could destroy it with no warning.

## 1. Backup and restore, in Settings

The old `#btn-export` wrote `JSON.stringify(state.links)` — your YouTube links, and none of your history, streak, records or achievements. It stays as-is (sharing a curated link set is a fair separate feature); the new card backs up **everything**.

It goes through the **share sheet**, reusing the `canShare({files})` path already proven by the share cards, so "save to Files / Drive / send to self" is two taps. A download barely exists as a destination in an installed iOS PWA.

Restore accepts either a wrapped backup or a bare state object (hand-edited files still work), rejects unrelated JSON, and names the trade before making it:

> Restore 42 workouts, 18 records, 9 badges?
> This replaces what's on this device now (2 workouts, 3 records, 2 badges).

The status line reads `2 workouts, 3 records, 2 badges on this device — never backed up.`

## 2. Two silent failures, fixed

| | Before | After |
|---|---|---|
| `saveState()` | Swallowed quota/private-mode errors — **train for weeks, nothing written, nothing said** | Warns once per session, then stays quiet so it can't nag mid-workout |
| `loadState()` | Parse error → defaults, then the next save **overwrote the damaged blob with an empty one** | Each clean load mirrors to `pt-state-v1-prev`; a corrupt write costs one session, and the recovery is announced |

The `saveState` one is the worse of the two and wasn't in the original audit note — it's the path that quietly eats months.

## 3. `navigator.storage.persist()`

One call at boot, previously unused. Asks the browser not to evict the origin under storage pressure; installed PWAs are generally granted it without a prompt.

## Verification

New `e2e-data-safety.js` drives a **real workout** (so there's genuine history to lose), then:

- corrupts the primary key → asserts history is recovered intact and the toast says so
- corrupts it with the backup also gone → asserts the unrecoverable case is announced, not silent
- simulates a failing write the way Safari private mode behaves → asserts the warning appears
- round-trips a backup through restore and confirms it survives a reload
- checks `parseBackup` rejects `{}`, `[]`, `null`, `{"foo":1}` and non-JSON while still accepting a bare state object

**21/21 specs pass.** Build and `node --check` clean, versions bumped in lockstep, settings card visually reviewed at 390×844.

> Found while writing the spec: `const BACKUP_KEY` was initially declared next to `loadState()`, which sits *below* `let state = loadState()` in the file — so every mirror write threw a temporal-dead-zone `ReferenceError` that my own inner try/catch swallowed. The backup key was silently never written. Same failure class this PR exists to remove; the declaration now sits beside `STORAGE_KEY` with a comment saying why.

## Deliberately not included

Automatic off-device sync. GitHub Pages has no backend, so that needs a third party — a Cloudflare Worker + KV would be the honest ~30-line version. Worth seeing whether manual share-to-iCloud is enough in practice first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyxAHMoJWC1d2xw43y88fF)_