### PR TITLE
Codebase review: fix small cross-app bugs + prioritized improvement list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,3 +22,4 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - README.md
+  - tools

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,14 +21,6 @@
     <link rel="apple-touch-icon" href="/img/binary-icon-192.png">
     <link rel="manifest" href="{% if lang == 'pt-BR' %}/binary/manifest-pt-BR.json{% else %}/binary/manifest.json{% endif %}">
     {% endif %}
-    {% if page.ref == "synth" %}
-    <meta name="theme-color" content="#0f0f1a">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <meta name="apple-mobile-web-app-title" content="Synth">
-    <link rel="apple-touch-icon" href="/img/synth-icon-192.png">
-    <link rel="manifest" href="/synth/manifest.json">
-    {% endif %}
     {% seo title=false %}
 </head>
 

--- a/auto-runner/sw.js
+++ b/auto-runner/sw.js
@@ -47,7 +47,7 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(
       fetch(event.request)
         .then((res) => {
-          if (res.ok) caches.open(CACHE_NAME).then((c) => c.put(event.request, res.clone()));
+          if (res.ok) caches.open(CACHE_NAME).then((c) => c.put(event.request, res.clone())).catch(() => {});
           return res;
         })
         .catch(() =>
@@ -62,7 +62,7 @@ self.addEventListener('fetch', (event) => {
       caches.match(event.request).then((cached) => {
         const network = fetch(event.request)
           .then((res) => {
-            if (res.ok) caches.open(CACHE_NAME).then((c) => c.put(event.request, res.clone()));
+            if (res.ok) caches.open(CACHE_NAME).then((c) => c.put(event.request, res.clone())).catch(() => {});
             return res;
           })
           .catch(() => cached);

--- a/crossfit-timer/index.html
+++ b/crossfit-timer/index.html
@@ -341,7 +341,7 @@ permalink: /crossfit-timer/
                  <button class="cf-back-btn" onclick="timer.goToPage('workout-selection')">
                     <i class="fas fa-arrow-left"></i> Back
                 </button>
-                <button class="cf-btn cf-btn-primary" onclick="timer.saveSettings()">
+                <button id="cf-save-settings-btn" class="cf-btn cf-btn-primary" onclick="timer.saveSettings()">
                     <i class="fas fa-save me-2"></i> Save Settings
                 </button>
             </div>
@@ -1780,7 +1780,7 @@ class CrossFitTimer {
         this.displayMode = settings.displayMode;
         
         // Show confirmation
-        const saveBtn = document.querySelector('.cf-btn-primary[onclick="timer.saveSettings()"]');
+        const saveBtn = document.getElementById('cf-save-settings-btn');
         const originalText = saveBtn.innerHTML;
         saveBtn.innerHTML = '<i class="fas fa-check me-2"></i> Saved!';
         saveBtn.classList.add('cf-btn-success');

--- a/curator/sw.js
+++ b/curator/sw.js
@@ -56,6 +56,16 @@ self.addEventListener('fetch', e => {
     return;
   }
 
+  // Navigations — cache first, fallback to network, fallback to cached shell when offline
+  if (e.request.mode === 'navigate') {
+    e.respondWith(
+      caches.match(e.request)
+        .then(cached => cached || fetch(e.request))
+        .catch(() => caches.match('./index.html'))
+    );
+    return;
+  }
+
   // App shell — cache first, fallback to network
   e.respondWith(
     caches.match(e.request).then(cached => cached || fetch(e.request))

--- a/drum-machine/index.html
+++ b/drum-machine/index.html
@@ -1922,6 +1922,7 @@ async function startRecording() {
     } catch (e) {
         isRecording = false;
         updateClapRecordUI();
+        showToast('Mic access denied — can\'t record clap');
     }
 }
 

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -48,7 +48,7 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(
       fetch(event.request)
         .then((res) => {
-          if (res.ok) caches.open(CACHE_NAME).then((c) => c.put(event.request, res.clone()));
+          if (res.ok) caches.open(CACHE_NAME).then((c) => c.put(event.request, res.clone())).catch(() => {});
           return res;
         })
         .catch(() =>
@@ -63,7 +63,7 @@ self.addEventListener('fetch', (event) => {
       caches.match(event.request).then((cached) => {
         const network = fetch(event.request)
           .then((res) => {
-            if (res.ok) caches.open(CACHE_NAME).then((c) => c.put(event.request, res.clone()));
+            if (res.ok) caches.open(CACHE_NAME).then((c) => c.put(event.request, res.clone())).catch(() => {});
             return res;
           })
           .catch(() => cached);

--- a/f1-championship/sw.js
+++ b/f1-championship/sw.js
@@ -56,7 +56,7 @@ self.addEventListener('fetch', (event) => {
         .then((networkResponse) => {
           if (networkResponse.ok) {
             const responseClone = networkResponse.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone)).catch(() => {});
           }
           return networkResponse;
         })
@@ -72,7 +72,7 @@ self.addEventListener('fetch', (event) => {
           .then((networkResponse) => {
             if (networkResponse.ok) {
               const responseClone = networkResponse.clone();
-              caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+              caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone)).catch(() => {});
             }
             return networkResponse;
           })

--- a/flappy/sw.js
+++ b/flappy/sw.js
@@ -50,7 +50,7 @@ self.addEventListener('fetch', (event) => {
         .then((networkResponse) => {
           if (networkResponse.ok) {
             const responseClone = networkResponse.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone)).catch(() => {});
           }
           return networkResponse;
         })
@@ -66,7 +66,7 @@ self.addEventListener('fetch', (event) => {
           .then((networkResponse) => {
             if (networkResponse.ok) {
               const responseClone = networkResponse.clone();
-              caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+              caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone)).catch(() => {});
             }
             return networkResponse;
           })

--- a/pt-BR/index.html
+++ b/pt-BR/index.html
@@ -120,7 +120,7 @@ ref: home
     {% for post in site.posts %}
     <article class="postitem">
         <ul class="meta">
-            <li class="category">{% for tag in post.tags %}<a href="/pt-BR/search.html">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}</li>
+            <li class="category">{% for tag in post.tags %}<a href="/pt-BR/search.html#{{ tag | slugify }}">{{ tag }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}</li>
             <li class="date"><a href="{{ post.url }}"><time datetime="{{post.date}}">{{ post.date | date: "%d/%m/%Y" }}</time></a></li>
         </ul>
         <h2 class="title">

--- a/pt-BR/search.html
+++ b/pt-BR/search.html
@@ -10,7 +10,7 @@ ref: search
 
 <div class="tag-section">
 {% for tag in site.tags %}
-<h3>{{ tag[0] }}</h3>
+<h3 id="{{ tag[0] | slugify }}">{{ tag[0] }}</h3>
 <ul>
     {% for post in tag[1] %}
     <li><a href="{{ post.url }}">{{ post.title }}</a></li>

--- a/squeak-the-geek-sw.js
+++ b/squeak-the-geek-sw.js
@@ -51,7 +51,7 @@ self.addEventListener('fetch', (event) => {
         .then((networkResponse) => {
           if (networkResponse.ok) {
             const responseClone = networkResponse.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone)).catch(() => {});
           }
           return networkResponse;
         })
@@ -67,7 +67,7 @@ self.addEventListener('fetch', (event) => {
           .then((networkResponse) => {
             if (networkResponse.ok) {
               const responseClone = networkResponse.clone();
-              caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+              caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone)).catch(() => {});
             }
             return networkResponse;
           })

--- a/synth/index.html
+++ b/synth/index.html
@@ -1137,6 +1137,9 @@ function buildPiano() {
     key.dataset.note = k.id;
     key.dataset.midi = k.midi;
     key.textContent = k.label;
+    key.setAttribute('role', 'button');
+    key.setAttribute('tabindex', '0');
+    key.setAttribute('aria-label', `Play ${k.label}`);
 
     const playKey = () => {
       let midi = k.midi;
@@ -1169,6 +1172,13 @@ function buildPiano() {
     key.addEventListener('pointerdown', (e) => {
       e.preventDefault();
       playKey();
+    });
+
+    key.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        playKey();
+      }
     });
 
     piano.appendChild(key);

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -44,8 +44,8 @@ self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
   const isNav = event.request.mode === 'navigate';
   if (isNav) {
-    event.respondWith(fetch(event.request).then((r) => { if (r.ok) { const c = r.clone(); caches.open(CACHE_NAME).then((cache) => cache.put(event.request, c)); } return r; }).catch(() => caches.match(event.request).then((c) => c || caches.match(OFFLINE_URL))));
+    event.respondWith(fetch(event.request).then((r) => { if (r.ok) { const c = r.clone(); caches.open(CACHE_NAME).then((cache) => cache.put(event.request, c)).catch(() => {}); } return r; }).catch(() => caches.match(event.request).then((c) => c || caches.match(OFFLINE_URL))));
     return;
   }
-  event.respondWith(caches.match(event.request).then((cached) => { const nf = fetch(event.request).then((r) => { if (r.ok) { const c = r.clone(); caches.open(CACHE_NAME).then((cache) => cache.put(event.request, c)); } return r; }).catch(() => cached); return cached || nf; }));
+  event.respondWith(caches.match(event.request).then((cached) => { const nf = fetch(event.request).then((r) => { if (r.ok) { const c = r.clone(); caches.open(CACHE_NAME).then((cache) => cache.put(event.request, c)).catch(() => {}); } return r; }).catch(() => cached); return cached || nf; }));
 });


### PR DESCRIPTION
## Summary

Scheduled codebase review across all apps in this repo. I fixed the small, low-risk, verifiable issues directly in this PR, and I'm listing the rest here prioritized by impact/effort for you to triage.

## Fixed in this PR

- **`tools/` was being published to the live site** — `_config.yml`'s `exclude:` only listed `Gemfile`/`Gemfile.lock`/`README.md`, so Jekyll copied dev tooling (Playwright specs, scripts, `package-lock.json`) into `_site/tools/`. Added `tools` to `exclude`.
- **Dead code in `_layouts/default.html`** — a `{% if page.ref == "synth" %}` block (theme-color/manifest tags) could never render because `synth/index.html` sets `layout: null` and already hardcodes those tags itself. Removed the unreachable block.
- **`curator/sw.js` had no offline fallback** — unlike every other app's service worker, a failed navigation fetch simply rejected instead of falling back to the cached shell. Brought it in line with the pattern used elsewhere.
- **Brittle DOM coupling in `crossfit-timer`** — the "Saved!" confirmation looked up its own button via `document.querySelector('[onclick="timer.saveSettings()"]')`, which silently breaks on any markup refactor. Gave the button a real `id`.
- **Synth's on-screen piano keys were keyboard-inaccessible** — only `pointerdown` was wired; added `role="button"`, `tabindex`, `aria-label`, and an Enter/Space `keydown` handler.
- **Silent failure on mic-denied clap recording in `drum-machine`** — the button just reset with no explanation; added a toast message, matching how the BPM detector already handles the same case.
- **pt-BR tag links were dead** — `pt-BR/search.html`'s `<h3>` tags had no `id`, and `pt-BR/index.html` linked to `/pt-BR/search.html` with no `#anchor` at all, so PT readers could never jump to a tag section (the EN site does this correctly).
- **Unhandled promise rejections in 6 game PWAs' service workers** (`worldcup-2026`, `f1-championship`, `flappy`, `squeak-the-geek`, `elastomania`, `auto-runner`) — `cache.put()` calls had no `.catch()`, so a failed cache write during a fetch could surface as console noise. Added `.catch(() => {})` to each.

Verified with `jekyll build` (clean) and `node --check` on every edited service worker; confirmed each fix in the built `_site/` output.

## Remaining findings, prioritized

**High impact**
- `crossfit-timer` and `personal-trainer` countdown timers use naive `setInterval`/recursive `setTimeout` decrementing, with no wall-clock (`Date.now()`) drift correction — timers silently diverge from real elapsed time when a tab is backgrounded/throttled. This is the core value prop of a timer app.
- `crossfit-timer`/`tuner` service workers skip caching cross-origin requests, and Font Awesome/Google Fonts aren't in `PRECACHE_URLS` — offline mode renders blank icon squares for the primary controls, contradicting the "works offline" PWA promise.
- `auto-runner`'s game loop applies gravity/velocity per `requestAnimationFrame` tick with no delta-time scaling — physics run ~2x faster on 120Hz displays than 60Hz (other games like `flappy`/`elastomania` already do this correctly).
- `synth`'s piano and `drum-machine`'s pads hand-roll near-identical `AudioContext` bootstrap/resume logic in 4+ places with no shared utility — any future audio-unlock fix has to be applied everywhere by hand.

**Medium impact**
- `tennis-planner.html` loads Tailwind from the unpinned Play CDN (`cdn.tailwindcss.com`), which Tailwind's own docs warn against for production — no version pin, ships the whole in-browser compiler, single point of failure (every other app uses precompiled CSS + a service worker).
- `pt-BR/index.html` has only 4 of 15 app cards pulling from `_data/translations/pt-BR.yml`; the rest are hand-translated inline HTML, so any English copy edit requires manually re-syncing 11 duplicated blocks.
- `worldcup-2026/index.html` inlines a ~65KB base64 image directly in its 6700-line source instead of as an external asset, bloating parse/download and defeating HTTP caching.
- Root-level manifest/service-worker files are inconsistent: 13 apps keep them in their own folder, but `squeak-the-geek`/`tennis-planner` dump theirs at the repo root — this pattern is also baked into the cache-bump GitHub workflow, so renaming an app means touching several unrelated places.
- `js/jorge-cli.js` easter-egg terminal (`PROJECTS_TEXT`/`LS_TEXT`/`BLOG_TEXT`) is stale — lists only 3 of 15 apps, references a non-existent `/portfolio` route, and hardcodes blog post titles instead of pulling from `site.posts`.
- `curator/index.html` stores its YouTube Data API key in `localStorage` and appends it as a `?key=` query param on every request — visible in history/devtools/any XSS; largely inherent to a backend-less static site, but worth flagging if the key's scope ever broadens.

**Low impact / larger effort**
- Near-identical service-worker install/activate/fetch boilerplate is duplicated across 6+ apps; a shared generator/import would let one bugfix propagate everywhere.
- `crossfit-timer` and `tuner` have almost no `aria-label`/`role` attributes on primary controls — a real screen-reader gap, but requires a fuller accessibility audit to do well.
- `worldcup-2026` is 6700 lines of React/JSX transpiled client-side via Babel-standalone with no build step — real parse/JIT cost on every load, and hard to review/maintain as one file. Introducing a real bundler (esbuild/Vite) would be a larger, separate effort.
- Gemfile.lock is pinned to GitHub Pages' native Jekyll 3.10 toolchain (vs. mainline Jekyll 4.x) — a forced constraint of using GH Pages' native build; only fixable by switching to an Actions-based deploy.

## What's *not* an issue (checked and ruled out)
- `blog/atom.xml` does have front matter (`---\n---\n` at the top) and is processed by Liquid correctly — an earlier pass suspected it was broken/static, but reading the raw file confirms it isn't.
- GitHub Actions versions are current (`checkout@v4`, `setup-node@v4`, `codeql-action@v3`).
- `README.md`'s app list is accurate against all 15 top-level app directories.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVYynTZvSzWTbgng29CLDP)_