### PR TITLE
Pin the Personal Trainer header while scrolling

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -51,6 +51,8 @@ permalink: /personal-trainer/
             --blue-rgb: 107 184 239;
             --warn-rgb: 251 191 36;
             --danger-rgb: 248 113 113;
+            /* Page background, as channels — used for the frosted sticky header. */
+            --bg-rgb: 15 21 33;
 
             /* ---- Type --------------------------------------------------------- */
             /* An 8-step ramp plus one off-ramp display size. Tight steps (~1.09) at
@@ -196,7 +198,22 @@ permalink: /personal-trainer/
             display: flex;
             align-items: center;
             justify-content: space-between;
-            padding: var(--sp-1) 0 var(--sp-4);
+            /* Pin the header so the back button and title stay reachable while a
+               screen scrolls. Negative margins cancel #app's top-safe-area and
+               16px side padding so the stuck bar reaches every edge and tucks
+               under the notch; the same amounts are re-added as padding so the
+               title and buttons stay exactly where they were. A frosted fill +
+               hairline keeps scrolling content legible behind it. The player has
+               no .topbar, so it stays full-bleed and unaffected. */
+            position: sticky;
+            top: 0;
+            z-index: 20;
+            margin: calc(-1 * (12px + env(safe-area-inset-top, 4px))) calc(-1 * var(--sp-4)) 0;
+            padding: calc(12px + env(safe-area-inset-top, 4px) + var(--sp-1)) var(--sp-4) var(--sp-3);
+            background: rgb(var(--bg-rgb) / 82%);
+            -webkit-backdrop-filter: blur(12px);
+            backdrop-filter: blur(12px);
+            border-bottom: 1px solid var(--border);
         }
 
         header.topbar h1 {

--- a/personal-trainer/sw.js
+++ b/personal-trainer/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607260459';
+const CACHE_VERSION = '2607261213';
 const CACHE_NAME = `personal-trainer-${CACHE_VERSION}`;
 const OFFLINE_URL = '/personal-trainer/';
 const PRECACHE_URLS = [


### PR DESCRIPTION
## What & why

On the Personal Trainer's longer screens (How it works, Achievements, Records, History, Library) the header scrolled away with the content, so the back button was only reachable after scrolling all the way back to the top. This pins the header so the back button and title stay visible at all times.

## Changes

- **`header.topbar` → `position: sticky; top: 0`** with a frosted fill (blurred `--bg` tint) and a hairline bottom border, so scrolling content stays legible behind the pinned bar.
- **Full-bleed** — negative margins cancel `#app`'s top-safe-area and 16px side padding so the stuck bar reaches every edge and tucks under the notch, with the same amounts re-added as padding so the title and buttons don't shift.
- Added a **`--bg-rgb`** channel token (matching the file's existing `*-rgb` convention) for the frosted fill.

The player screen has no `.topbar` (it uses its own full-screen workout controls), so it's unaffected. All changes stay on the design tokens.

Files: `personal-trainer/index.html` and a `personal-trainer/sw.js` PWA cache-version bump.

## Verification

- **e2e:** all 21 Personal Trainer specs pass via `tools/personal-trainer-e2e/run.sh`, including `e2e-setup-back.js` (back-button behavior) and `e2e-design-system.js` (token gate).
- **Scroll test:** at the 390×844 viewport, the header stays at `top: 0` after scrolling (verified on Home at 581px and How-it-works at 900px scroll offsets), with the back button fully within the viewport and content frosted behind the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GVYnKdJcUSs3NVaQkYxCB

---
_Generated by [Claude Code](https://claude.ai/code/session_012GVYnKdJcUSs3NVaQkYxCB)_