### PR TITLE
Fix PWA install reliability, accessibility gaps, and error handling

### DIFF
--- a/crossfit-timer/index.html
+++ b/crossfit-timer/index.html
@@ -215,7 +215,7 @@ permalink: /crossfit-timer/
                     </div>
 
                     <!-- Circular Timer Display -->
-                    <div class="cf-circular-timer" style="display: none;" id="progress-container">
+                    <div class="cf-circular-timer" style="display: none;" id="progress-container" role="button" tabindex="0" aria-label="Pause or resume timer">
                         <svg class="cf-circular-progress" viewBox="0 0 200 200">
                             <circle cx="100" cy="100" r="90" class="cf-progress-background"></circle>
                             <circle cx="100" cy="100" r="90" class="cf-progress-circle" id="progress-bar"></circle>
@@ -227,7 +227,7 @@ permalink: /crossfit-timer/
                             <i class="fas fa-pause"></i>
                         </div>
                     </div>
-                    <div class="cf-crossfit-clock" id="crossfit-clock-display" style="display: none;" aria-live="polite">
+                    <div class="cf-crossfit-clock" id="crossfit-clock-display" style="display: none;" aria-live="polite" role="button" tabindex="0" aria-label="Pause or resume clock">
                         <div class="cf-class-clock-six" id="class-clock-six">
                             <span class="cf-class-clock-digit">U</span>
                             <span class="cf-class-clock-digit">P</span>
@@ -1714,8 +1714,16 @@ class CrossFitTimer {
                 }
             }
         };
+        const handleTimerSurfaceKeydown = (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleTimerSurfaceClick();
+            }
+        };
         this.progressContainer.addEventListener('click', handleTimerSurfaceClick);
+        this.progressContainer.addEventListener('keydown', handleTimerSurfaceKeydown);
         this.crossfitClockDisplay.addEventListener('click', handleTimerSurfaceClick);
+        this.crossfitClockDisplay.addEventListener('keydown', handleTimerSurfaceKeydown);
 
         window.addEventListener('resize', () => this.updateClockLandscapeGate());
         window.addEventListener('orientationchange', () => this.updateClockLandscapeGate());
@@ -1732,6 +1740,7 @@ class CrossFitTimer {
     }
     
     async initializeAudio() {
+        if (this.audioContext) return;
         try {
             this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
         } catch (e) {

--- a/curator/index.html
+++ b/curator/index.html
@@ -718,7 +718,12 @@ async function loadFeed() {
     else errors.push(`${sources[i].raw}: ${r.reason?.message || 'unknown error'}`);
   });
 
-  const noShorts = await filterShorts(all);
+  let noShorts = all;
+  try {
+    noShorts = await filterShorts(all);
+  } catch (e) {
+    errors.push(`Could not filter Shorts: ${e?.message || 'unknown error'}`);
+  }
   noShorts.sort((a, b) => new Date(b.published) - new Date(a.published));
   videos = noShorts;
   status = 'done';

--- a/f1-championship/index.html
+++ b/f1-championship/index.html
@@ -8,6 +8,7 @@ permalink: /f1-championship/
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <meta name="description" content="Track your lap time championship across the full 2026 F1 season.">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="F1 Champ">

--- a/flappy/flappyBird.js
+++ b/flappy/flappyBird.js
@@ -70,18 +70,18 @@ class FlappyBird {
             { key: 'score', src: '/sounds/score.mp3' }
         ];
         
-        // Load images
-        for (const file of imageFiles) {
+        // Load images in parallel
+        await Promise.all(imageFiles.map(file => {
             this.images[file.key] = new Image();
             this.images[file.key].src = file.src;
-            await new Promise(resolve => {
+            return new Promise(resolve => {
                 this.images[file.key].onload = resolve;
                 this.images[file.key].onerror = () => {
                     console.error(`Failed to load image: ${file.src}`);
                     resolve();
                 };
             });
-        }
+        }));
         
         // Load sounds
         for (const file of soundFiles) {

--- a/music-theory/index.html
+++ b/music-theory/index.html
@@ -906,6 +906,12 @@ title: Music Theory
         samplerReady = true;
         document.getElementById('keyboard-loading').classList.add('hidden');
       },
+      onerror: (err) => {
+        console.error('Failed to load piano samples', err);
+        const loading = document.getElementById('keyboard-loading');
+        const label = loading && loading.querySelector('span');
+        if (label) label.textContent = 'Could not load piano sounds. Check your connection and reload.';
+      },
     }).toDestination();
 
     function midiToNoteName(midi) {

--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -1707,7 +1707,7 @@ permalink: /personal-trainer/
         <span>Install Personal Trainer for quick access</span>
         <div class="banner-actions">
             <button id="install-btn">Install</button>
-            <button id="install-dismiss">&times;</button>
+            <button id="install-dismiss" aria-label="Dismiss install prompt">&times;</button>
         </div>
     </div>
 
@@ -1862,7 +1862,7 @@ permalink: /personal-trainer/
             </div>
             <div>
                 <div class="player-controls">
-                    <button class="btn ghost" id="btn-quit">✕</button>
+                    <button class="btn ghost" id="btn-quit" aria-label="Quit workout">✕</button>
                     <button class="btn" id="btn-main-action">Pause</button>
                     <button class="btn ghost" id="btn-skip">Skip ›</button>
                 </div>

--- a/squeak-the-geek-sw.js
+++ b/squeak-the-geek-sw.js
@@ -11,7 +11,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache.add(url).catch((err) => console.warn(`Precache failed for ${url}`, err))
+        )
+      )
+    )
   );
 });
 

--- a/squeak-the-geek.html
+++ b/squeak-the-geek.html
@@ -309,10 +309,10 @@ permalink: /squeak-the-geek/
     </div>
 
     <div id="dpad">
-        <div class="dbtn" id="dUp">▲</div>
-        <div class="dbtn" id="dDown">▼</div>
-        <div class="dbtn" id="dLeft">◀</div>
-        <div class="dbtn" id="dRight">▶</div>
+        <div class="dbtn" id="dUp" role="button" aria-label="Move up">▲</div>
+        <div class="dbtn" id="dDown" role="button" aria-label="Move down">▼</div>
+        <div class="dbtn" id="dLeft" role="button" aria-label="Move left">◀</div>
+        <div class="dbtn" id="dRight" role="button" aria-label="Move right">▶</div>
     </div>
 
     <div id="toast"></div>

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ self.addEventListener("activate", (event) => {
       const cacheNames = await caches.keys();
       await Promise.all(
         cacheNames.map((cacheName) => {
-          if (cacheName === "site-pwa-v2") {
+          if (cacheName.startsWith("site-pwa-")) {
             return caches.delete(cacheName);
           }
           return Promise.resolve();

--- a/tennis-planner-sw.js
+++ b/tennis-planner-sw.js
@@ -10,7 +10,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache.add(url).catch((err) => console.warn(`Precache failed for ${url}`, err))
+        )
+      )
+    )
   );
 });
 

--- a/tennis-planner.html
+++ b/tennis-planner.html
@@ -98,7 +98,7 @@ permalink: /tennis-planner/
         <span class="text-sm font-medium">Install Tennis Planner for quick access</span>
         <div class="flex gap-2">
             <button id="install-btn" class="bg-white text-teal-600 text-sm font-semibold px-3 py-1 rounded-lg hover:bg-teal-50 transition">Install</button>
-            <button id="install-dismiss" class="text-white text-lg leading-none px-1 hover:text-teal-200 transition">&times;</button>
+            <button id="install-dismiss" class="text-white text-lg leading-none px-1 hover:text-teal-200 transition" aria-label="Dismiss install prompt">&times;</button>
         </div>
     </div>
 

--- a/worldcup-2026/sw.js
+++ b/worldcup-2026/sw.js
@@ -14,7 +14,9 @@ const PRECACHE_URLS = [
 ];
 
 self.addEventListener('install', (event) => {
-  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS.map((url) => new Request(url, { cache: 'reload' })))));
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => Promise.all(
+    PRECACHE_URLS.map((url) => cache.add(new Request(url, { cache: 'reload' })).catch((err) => console.warn(`Precache failed for ${url}`, err)))
+  )));
 });
 self.addEventListener('activate', (event) => {
   event.waitUntil(caches.keys().then((cacheNames) => Promise.all(cacheNames.map((cacheName) => {


### PR DESCRIPTION
## Summary

Automated code review of the mini-app collection in this repo (crossfit-timer, personal-trainer, tennis-planner, squeak-the-geek, worldcup-2026, curator, f1-championship, flappy, music-theory, and others). Three parallel review passes covered the small single-file PWAs, the larger PWAs with service workers, and the site shell/multi-file apps.

Overall the codebase is well-hardened — most apps already guard `localStorage`/`JSON.parse`, clean up timers/mic streams, and guard `AudioContext` creation. The fixes below are the real gaps found against that baseline: a handful of concrete bugs, PWA-reliability issues, and cheap accessibility fixes. Verified with `jekyll build` (clean) and `node --check` on every edited JS file.

## Fixed in this PR

- **Service worker install reliability** (`tennis-planner-sw.js`, `squeak-the-geek-sw.js`, `worldcup-2026/sw.js`): install used `cache.addAll(...)`, which is all-or-nothing — one failed precache request (flaky network, blocked CDN) aborts the entire SW install and silently kills offline support for that app. Replaced with per-URL `cache.add().catch()`, matching the pattern `personal-trainer/sw.js` already used correctly.
- **`crossfit-timer`: AudioContext leak** — `initializeAudio()` created a brand new `AudioContext` on every "Start Workout" click with no guard, unlike `synth/index.html` and `drum-machine/index.html` which both guard with `if (ctx) return`. Safari caps concurrent live contexts (~4-6), so a user starting several workouts in one session would eventually lose all timer sound with no error shown. Added the missing guard.
- **`crossfit-timer`: keyboard accessibility** — the "tap the timer circle to pause/resume" surfaces were click-only `<div>`s with no way for keyboard-only users to pause mid-workout. Added `role="button"`, `tabindex`, and Enter/Space handling.
- **Icon-only buttons missing `aria-label`** — the install-banner "×" dismiss button (`personal-trainer`, `tennis-planner`) and the workout player's "✕" quit button (`personal-trainer`) had no accessible name; screen readers announced them as unlabeled buttons. Added labels.
- **`squeak-the-geek`: on-screen d-pad labeling** — the touch d-pad buttons had no `role`/`aria-label`, so assistive tech announced nothing for the game's primary on-screen control. Added labels (physical arrow keys were already keyboard-operable via a separate global listener).
- **`music-theory`: stuck loading state** — `Tone.Sampler` had an `onload` callback but no `onerror`. If the external CDN sample fetch fails (offline, blocked CDN), the "Loading piano samples…" spinner spun forever with zero feedback and every control silently no-op'd. Added an `onerror` handler that updates the message instead of leaving the UI stuck.
- **`curator`: unhandled rejection stalls the feed** — `filterShorts()` inside `loadFeed()` was called outside the `Promise.allSettled` error boundary, so a YouTube API error there (quota, bad key) threw unhandled and left the UI stuck on "Fetching your feed…" forever. Wrapped in try/catch so partial results still render with an error message.
- **`f1-championship`: missing meta description** — unlike sibling apps (`worldcup-2026`, `curator`), this app had no `<meta name="description">`, so link previews/search snippets fell back to empty/generic text. Added one (reused from the app's manifest).
- **`flappy`: sequential asset loading** — `loadAssets()` awaited each of 5 game images one at a time instead of loading them concurrently, needlessly multiplying load time on slow connections. Switched to `Promise.all`.
- **Root `sw.js`: incomplete cache cleanup** — the kill-switch service worker only deleted the exact cache name `"site-pwa-v2"`, so an older leftover cache from a prior migration (e.g. `site-pwa-v1`) would never get swept. Now matches any `"site-pwa-"`-prefixed cache.

## Recommended follow-ups (not implemented — larger/riskier or out of scope for a mechanical fix)

- `worldcup-2026`: ships ~6,600 lines of raw JSX transpiled in-browser via `babel-standalone` on every page load — precompiling would remove a real perf cost, especially on low-end mobile, but is a bigger build-tooling change.
- `index.html` / `pt-BR/index.html`: some app cards use `{{ t.apps_page.* }}` i18n keys while others have hardcoded, hand-duplicated copy across the two language files — a maintenance/drift risk worth a dedicated i18n cleanup pass.
- `personal-trainer/sw.js`, `tennis-planner-sw.js`, `squeak-the-geek-sw.js` duplicate ~90% of their install/activate/fetch boilerplate with no shared module — worth factoring out once there's a build step, so a fix like this PR's doesn't have to be applied N times by hand.
- `crossfit-timer`: the workout `tick()` timer re-arms with `setTimeout(..., 1000)` with no wall-clock anchor, so it can drift over a long AMRAP/EMOM or when the tab is briefly backgrounded.
- `tennis-planner.html`: the per-day availability checkbox grid has no `aria-label`/`aria-describedby` per cell, so a screen reader just announces "checkbox" repeated across the grid with no player/date context.
- `_layouts/default.html`: Bootstrap, Google Fonts, and Font Awesome are all loaded render-blocking from three separate CDNs on every page for a handful of icons — a candidate for self-hosting/subsetting.
- `Gemfile.lock`: `github-pages (232)` pins Jekyll 3.10/Liquid 4.0, both several majors behind current — this is dictated by GitHub Pages' supported gem set and isn't independently fixable without leaving GH Pages builds.

## Test plan

- [x] `jekyll build` completes cleanly (only the known benign `feed` layout warning)
- [x] `node --check` passes on every edited `.js`/inline-script file
- [ ] Manual smoke test of each touched app in a browser (not done in this environment — no live browser verification was performed for this PR; recommend a quick pass before merging)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gww3e4DsQYvuQjJHUoiDzK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gww3e4DsQYvuQjJHUoiDzK)_