### PR TITLE
Harden PWA precaching, tighten error handling and a11y across apps

### DIFF
--- a/auto-runner/index.html
+++ b/auto-runner/index.html
@@ -35,7 +35,7 @@ permalink: /auto-runner/
   <canvas id="canvas" role="img" aria-label="Auto Runner game screen"></canvas>
 
   <script>
-    const SW_VERSION = '2607260416';
+    const SW_VERSION = '2607290423';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function askUpdate(reg) {

--- a/auto-runner/sw.js
+++ b/auto-runner/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607260416';
+const CACHE_VERSION = '2607290423';
 const CACHE_NAME = `auto-runner-${CACHE_VERSION}`;
 const OFFLINE_URL = '/auto-runner/';
 const PRECACHE_URLS = [
@@ -11,7 +11,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache.add(url).catch((err) => console.warn(`Precache failed for ${url}`, err))
+        )
+      )
+    )
   );
 });
 

--- a/binary/binary.js
+++ b/binary/binary.js
@@ -1,4 +1,4 @@
-const APP_VERSION = '2607181249';
+const APP_VERSION = '2607290423';
 
 document.addEventListener("DOMContentLoaded", () => {
     const gridSize = 8;

--- a/binary/sw.js
+++ b/binary/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607181249';
+const CACHE_VERSION = '2607290423';
 const CACHE_NAME = `binary-puzzle-en-${CACHE_VERSION}`;
 const OFFLINE_URL = "/binary/";
 const PRECACHE_URLS = [
@@ -13,7 +13,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache.add(url).catch((err) => console.warn(`Precache failed for ${url}`, err))
+        )
+      )
+    )
   );
 });
 

--- a/curator/index.html
+++ b/curator/index.html
@@ -500,7 +500,7 @@
 <div id="key-screen" style="display:none">
   <span class="logo">Curator</span>
   <p class="key-hint">Your personal YouTube feed, no algorithm.<br>Your API key is stored only in your browser — never sent anywhere.</p>
-  <input id="key-input" class="input-field" type="password" placeholder="YouTube Data API v3 key (AIza…)" autocomplete="off" />
+  <input id="key-input" class="input-field" type="password" placeholder="YouTube Data API v3 key (AIza…)" autocomplete="off" aria-label="YouTube Data API v3 key" />
   <button class="btn-primary" id="key-save-btn">Get started →</button>
   <a class="key-link" href="https://console.cloud.google.com/apis/library/youtube.googleapis.com" target="_blank" rel="noopener">How to get a free API key ↗</a>
   <p class="key-hint" style="font-size:10px; color:#333;">
@@ -538,7 +538,7 @@
     </div>
     <p class="modal-hint">Add a channel URL, @handle, playlist URL/ID, or search keyword.</p>
     <div class="modal-input-row">
-      <input class="input-field" id="source-input" placeholder="@mkbhd · youtube.com/... · PLxxx · formula 1" />
+      <input class="input-field" id="source-input" placeholder="@mkbhd · youtube.com/... · PLxxx · formula 1" aria-label="Channel URL, handle, playlist, or search keyword" />
       <button class="btn-primary" id="source-add-btn" style="padding:11px 18px">Add</button>
     </div>
     <div class="sources-list" id="sources-list"></div>
@@ -555,7 +555,7 @@
 
 <script>
 // ── Constants ────────────────────────────────────────────────────────────────
-const APP_VERSION = '2607281411';
+const APP_VERSION = '2607290423';
 const KEY_API   = 'curator_api_key';
 const KEY_SRCS  = 'curator_sources';
 const KEY_IDX   = 'curator_idx';
@@ -774,7 +774,7 @@ function renderMain(errors = []) {
     <div class="video-card">
       <div class="video-frame" id="video-frame">
         ${playerActive
-          ? `<iframe class="video-iframe" src="https://www.youtube.com/embed/${cur.id}?autoplay=1" allow="autoplay; encrypted-media; fullscreen" allowfullscreen></iframe>`
+          ? `<iframe class="video-iframe" src="https://www.youtube.com/embed/${escHtml(cur.id)}?autoplay=1" allow="autoplay; encrypted-media; fullscreen" allowfullscreen></iframe>`
           : `
             <img class="video-thumb" src="${cur.thumb || ''}" alt="${escHtml(cur.title)}" onerror="this.style.display='none'" />
             <div class="thumb-overlay"></div>
@@ -794,7 +794,7 @@ function renderMain(errors = []) {
       </div>
       <div class="video-nav">
         <button class="nav-btn" onclick="navigate(-1)" ${idx === 0 ? 'disabled' : ''} aria-label="Previous">←</button>
-        <a class="yt-link" href="https://www.youtube.com/watch?v=${cur.id}" target="_blank" rel="noopener">Open on YouTube ↗</a>
+        <a class="yt-link" href="https://www.youtube.com/watch?v=${escHtml(cur.id)}" target="_blank" rel="noopener">Open on YouTube ↗</a>
         <button class="nav-btn" onclick="navigate(1)" ${idx >= videos.length - 1 ? 'disabled' : ''} aria-label="Next">→</button>
       </div>
     </div>`;

--- a/curator/sw.js
+++ b/curator/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607281411';
+const CACHE_VERSION = '2607290423';
 const CACHE = `curator-${CACHE_VERSION}`;
 const SHELL = [
   './',
@@ -12,7 +12,13 @@ const SHELL = [
 // Install: cache app shell
 self.addEventListener('install', e => {
   e.waitUntil(
-    caches.open(CACHE).then(cache => cache.addAll(SHELL))
+    caches.open(CACHE).then(cache =>
+      Promise.all(
+        SHELL.map(url =>
+          cache.add(url).catch(err => console.warn(`Precache failed for ${url}`, err))
+        )
+      )
+    )
   );
 });
 

--- a/drum-machine/index.html
+++ b/drum-machine/index.html
@@ -2214,7 +2214,7 @@ document.getElementById('sync-beat-btn').addEventListener('click', () => {
 
 // ─── Service Worker ───────────────────────────────────────────────────────────
 if ('serviceWorker' in navigator) {
-    const SW_VERSION = '2607260416';
+    const SW_VERSION = '2607290423';
     navigator.serviceWorker.register(
         `/drum-machine/sw.js?v=${encodeURIComponent(SW_VERSION)}`,
         { scope: '/drum-machine/' }

--- a/drum-machine/sw.js
+++ b/drum-machine/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607260416';
+const CACHE_VERSION = '2607290423';
 const CACHE_NAME = `drum-machine-${CACHE_VERSION}`;
 const OFFLINE_URL = '/drum-machine/';
 const PRECACHE_URLS = [
@@ -8,7 +8,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener('install', event => {
     event.waitUntil(
-        caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
+        caches.open(CACHE_NAME).then(cache =>
+            Promise.all(
+                PRECACHE_URLS.map(url =>
+                    cache.add(url).catch(err => console.warn(`Precache failed for ${url}`, err))
+                )
+            )
+        )
     );
 });
 

--- a/elastomania/index.html
+++ b/elastomania/index.html
@@ -122,7 +122,7 @@ permalink: /elastomania/
   </div>
 
   <script>
-    const SW_VERSION = '2607260416';
+    const SW_VERSION = '2607290423';
     if ('serviceWorker' in navigator) {
       let refreshed = false;
       function showBanner(reg) {

--- a/elastomania/sw.js
+++ b/elastomania/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607260416';
+const CACHE_VERSION = '2607290423';
 const CACHE_NAME = `elastomania-${CACHE_VERSION}`;
 const OFFLINE_URL = '/elastomania/';
 const PRECACHE_URLS = [
@@ -12,7 +12,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache.add(url).catch((err) => console.warn(`Precache failed for ${url}`, err))
+        )
+      )
+    )
   );
 });
 

--- a/flappy/flappyBird.js
+++ b/flappy/flappyBird.js
@@ -135,9 +135,9 @@ class FlappyBird {
     playSound(key) {
         try {
             this.sounds[key].currentTime = 0;
-            this.sounds[key].play().catch(e => console.log('Audio play failed:', e));
+            this.sounds[key].play().catch(e => console.error('Audio play failed:', e));
         } catch (e) {
-            console.log('Audio error:', e);
+            console.error('Audio error:', e);
         }
     }
     

--- a/flappy/index.html
+++ b/flappy/index.html
@@ -90,7 +90,7 @@ permalink: /flappy/
     </style>
     
     <script>
-        const SW_VERSION = '2607270858';
+        const SW_VERSION = '2607290423';
         document.getElementById('flappy-version').textContent = 'v' + SW_VERSION;
 
         // Register service worker with opt-in update flow

--- a/flappy/sw.js
+++ b/flappy/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607270858';
+const CACHE_VERSION = '2607290423';
 const CACHE_NAME = `flappy-bird-${CACHE_VERSION}`;
 const OFFLINE_URL = '/flappy/';
 const PRECACHE_URLS = [
@@ -10,7 +10,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache.add(url).catch((err) => console.warn(`Precache failed for ${url}`, err))
+        )
+      )
+    )
   );
 });
 

--- a/music-theory/index.html
+++ b/music-theory/index.html
@@ -1610,7 +1610,7 @@ title: Music Theory
 
       // Service Worker
       if ('serviceWorker' in navigator) {
-        const SW_VERSION = '2607270858';
+        const SW_VERSION = '2607290423';
         navigator.serviceWorker.register(
           `/music-theory/sw.js?v=${encodeURIComponent(SW_VERSION)}`,
           { scope: '/music-theory/' }

--- a/music-theory/sw.js
+++ b/music-theory/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607270858';
+const CACHE_VERSION = '2607290423';
 const CACHE_NAME = `music-theory-${CACHE_VERSION}`;
 const OFFLINE_URL = '/music-theory/';
 const PRECACHE_URLS = [
@@ -10,7 +10,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache.add(url).catch((err) => console.warn(`Precache failed for ${url}`, err))
+        )
+      )
+    )
   );
 });
 

--- a/pt-BR/binary/sw.js
+++ b/pt-BR/binary/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607181249';
+const CACHE_VERSION = '2607290423';
 const CACHE_NAME = `binary-puzzle-ptbr-${CACHE_VERSION}`;
 const OFFLINE_URL = "/pt-BR/binary/";
 const PRECACHE_URLS = [
@@ -13,7 +13,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache.add(url).catch((err) => console.warn(`Precache failed for ${url}`, err))
+        )
+      )
+    )
   );
 });
 

--- a/synth/index.html
+++ b/synth/index.html
@@ -1291,7 +1291,11 @@ const KeyDetector = (() => {
       rafId = setInterval(collect, 50);
       detectionInterval = setInterval(detectKey, 2500);
       renderBtn();
-    } catch(e) {}
+    } catch(e) {
+      console.error('Key detection mic access failed:', e);
+      const label = document.getElementById('key-label');
+      if (label) label.textContent = 'mic blocked';
+    }
   }
 
   function stop() {
@@ -1417,7 +1421,7 @@ document.getElementById('install-btn').addEventListener('click', async () => {
 });
 
 if ('serviceWorker' in navigator) {
-  const SW_VERSION = '2607281411';
+  const SW_VERSION = '2607290423';
   let hasRefreshedForUpdate = false;
 
   function showUpdateBanner(registration) {

--- a/synth/sw.js
+++ b/synth/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607281411';
+const CACHE_VERSION = '2607290423';
 const CACHE_NAME = `synth-${CACHE_VERSION}`;
 const OFFLINE_URL = "/synth/";
 const PRECACHE_URLS = [
@@ -10,7 +10,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+    caches.open(CACHE_NAME).then((cache) =>
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache.add(url).catch((err) => console.warn(`Precache failed for ${url}`, err))
+        )
+      )
+    )
   );
 });
 

--- a/tennis-planner-sw.js
+++ b/tennis-planner-sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607281411';
+const CACHE_VERSION = '2607290423';
 const CACHE_NAME = `tennis-planner-${CACHE_VERSION}`;
 const OFFLINE_URL = "/tennis-planner/";
 const PRECACHE_URLS = [

--- a/tennis-planner.html
+++ b/tennis-planner.html
@@ -124,7 +124,7 @@ permalink: /tennis-planner/
                         <p class="text-gray-500">Loading players...</p>
                     </div>
                     <div class="flex space-x-2">
-                        <input type="text" id="new-player-name" placeholder="Enter player name" class="flex-grow p-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:outline-none transition">
+                        <input type="text" id="new-player-name" placeholder="Enter player name" aria-label="New player name" class="flex-grow p-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:outline-none transition">
                         <button id="add-player-btn" class="bg-teal-500 text-white font-semibold px-4 py-2 rounded-lg hover:bg-teal-600 transition-transform transform hover:scale-105">Add</button>
                     </div>
                 </div>
@@ -425,7 +425,7 @@ permalink: /tennis-planner/
 
     <!-- PWA: Service Worker Registration & Install Prompt -->
     <script>
-        const SW_VERSION = '2607281411';
+        const SW_VERSION = '2607290423';
         // Service worker registration
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/tuner/index.html
+++ b/tuner/index.html
@@ -812,7 +812,7 @@ permalink: /tuner/
         document.getElementById('btn-ukulele').addEventListener('click', () => switchInstrument('ukulele'));
 
         // ─── Service worker ───────────────────────────────────────────────────────
-        const SW_VERSION = '2607281411';
+        const SW_VERSION = '2607290423';
 
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register(

--- a/tuner/sw.js
+++ b/tuner/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2607281411';
+const CACHE_VERSION = '2607290423';
 const CACHE_NAME = `tuner-${CACHE_VERSION}`;
 const OFFLINE_URL = '/tuner/';
 const PRECACHE_URLS = [
@@ -11,7 +11,13 @@ const PRECACHE_URLS = [
 
 self.addEventListener('install', (event) => {
     event.waitUntil(
-        caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+        caches.open(CACHE_NAME).then((cache) =>
+            Promise.all(
+                PRECACHE_URLS.map((url) =>
+                    cache.add(url).catch((err) => console.warn(`Precache failed for ${url}`, err))
+                )
+            )
+        )
     );
 });
 


### PR DESCRIPTION
## Summary

Scheduled codebase review across the ~15 client-side PWA apps in this repo. This PR implements the safe, mechanically-verifiable fixes found; a few larger architectural items are called out below as recommendations rather than automated changes, since they'd benefit from manual visual QA.

### Implemented in this PR

- **Service worker precache resilience (10 apps: flappy, auto-runner, elastomania, synth, tuner, music-theory, binary, pt-BR/binary, drum-machine, curator).** Their `install` handlers used a bare `cache.addAll(PRECACHE_URLS)`, which fails the *entire* SW install if even one precached asset 404s (e.g. a renamed icon) — silently disabling offline support/installability with no console signal. Changed each to precache assets individually with its own `.catch()`, matching the pattern already used correctly in `squeak-the-geek-sw.js`, `tennis-planner-sw.js`, and `worldcup-2026/sw.js`. Bumped each touched app's cache/SW version constant so already-installed PWAs actually pick up the fix.
- **`synth`: silent mic-permission failure.** `KeyDetector.start()` had an empty `catch(e) {}` around `getUserMedia` — denying mic access (or having none) left the "detect key" button permanently non-functional with zero feedback. `drum-machine` already handles the identical situation correctly (`showToast('Mic access denied...')`); synth now logs the error and updates the key-label UI instead of failing silently.
- **`flappy`: `console.log` → `console.error` for audio error paths**, matching the logging convention used everywhere else in the repo (every other app's catch blocks use `console.error`/`console.warn`).
- **`curator`: unescaped YouTube video ID.** `cur.id` was interpolated directly into the embed `<iframe src>` and the "Open on YouTube" `href` without going through the `escHtml()` helper that every other dynamic field in the same render function uses (title, channel, source label). Low real-world exploitability today (the YouTube Data API only returns clean IDs), but it was a latent injection point and an inconsistency with the rest of the file's escaping discipline.
- **`curator`: missing accessible names.** `#key-input` (the YouTube API key field) and `#source-input` relied solely on `placeholder` text, which disappears once the user types and isn't a valid accessible-name substitute (WCAG 1.3.1/3.3.2). Added `aria-label` to both.
- **`tennis-planner`: missing accessible name.** `#new-player-name` had no label, unlike the `#court-cost` field two lines above it which correctly uses a `<label for>`. Added `aria-label` for consistency without touching layout.

Verified with `jekyll build` (exit 0, only the known-benign `feed` layout warning) and `node -c` syntax checks on every touched JS/SW file.

### Recommended but not automated here (would want visual/manual QA first)

- **`worldcup-2026`**: ships raw JSX transpiled at runtime via Babel Standalone, and embeds two large base64 images (~48KB of text) directly in the JS instead of as separate cacheable files. Both are real perf wins but need a build step / asset extraction and a visual smoke test — out of scope for an unattended pass.
- **Missing SRI** on a few CDN `<script>` tags (`worldcup-2026`'s React/ReactDOM/Babel, `music-theory`'s Tone.js, `tennis-planner`'s Tailwind CDN) — every other CDN include in the repo already uses `integrity`/`crossorigin`. Needs the exact hash of each pinned CDN asset version.
- **`tennis-planner`** loads Tailwind via the `cdn.tailwindcss.com` "Play CDN" (explicitly not recommended for production by Tailwind's own docs) and that script isn't in `tennis-planner-sw.js`'s `PRECACHE_URLS`, so the app's styling silently breaks offline. Fixing this well means either precaching the CDN script or migrating off the Play CDN.
- A handful of single-file apps exceed ~1500-2500 lines mixing markup/CSS/JS (`worldcup-2026` 6.8k, `personal-trainer` 4.8k, `f1-championship` 2.6k, `crossfit-timer` 2.4k, `drum-machine` 2.3k) — worth splitting into separate CSS/JS files per app if/when they get touched again, given there's no build step to enforce module boundaries.

## Test plan

- [x] `jekyll build` exits 0 (only the pre-existing, documented-benign `feed` layout warning)
- [x] `node -c` syntax check on every modified `.js`/`sw.js` file
- [ ] Manual smoke test of each touched app in a browser (not done in this unattended pass — changes are additive error-handling/a11y/precaching hardening, no behavioral logic changed on the happy path)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WTWQ13fgEnqStrhKeQGG1w)_