### PR TITLE
Embed the body map on the Progress page

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -631,9 +631,10 @@ permalink: /personal-trainer/
         .bal-pct.low { color: var(--orange); }
 
         #body-map-container {
-            background: var(--surface);
+            background: var(--surface2);
             border-radius: var(--r-md);
             padding: var(--sp-3);
+            margin-top: var(--sp-3);
             min-height: 300px;
             display: flex;
             align-items: center;
@@ -2263,7 +2264,23 @@ permalink: /personal-trainer/
                 <div id="balance-bars"></div>
                 <p class="muted-note mt-3" id="balance-note"></p>
                 <button class="info-link" id="nav-info-balance">ⓘ Why balance matters</button>
-                <button class="info-link" id="nav-bodymap">🗺 View body map ›</button>
+            </div>
+            <div class="card" id="bodymap-card">
+                <div class="level-row"><strong><img class="ico" src="/img/pt/level.png" alt="">Body map</strong></div>
+                <div class="choice-row cols-2" id="bodymap-view">
+                    <button class="choice selected" data-v="front">Front</button>
+                    <button class="choice" data-v="back">Back</button>
+                </div>
+                <div id="body-map-container"></div>
+                <div class="bm-face-row">
+                    <button class="info-link" id="btn-face-upload">📷 Add your face</button>
+                    <button class="info-link" id="btn-face-adjust" style="display:none">✎ Adjust</button>
+                    <button class="info-link bm-face-remove" id="btn-face-remove" style="display:none">✕ Remove</button>
+                </div>
+                <input type="file" id="face-file" accept="image/*" hidden>
+                <div id="body-map-region"></div>
+                <div class="body-map-legend"><span>None</span><div class="body-map-gradient"></div><span>Heavy</span></div>
+                <p class="body-map-caption">Colour reflects recent training volume. Older sessions fade over about two weeks. Only the trunk lights up — this is a core &amp; mat programme.</p>
             </div>
             <div class="card disc-card">
                 <div class="level-row row-core"><strong><img class="ico" src="/img/pt/core-fitness.png" alt="">Core Fitness</strong><span class="tier" id="core-tier">Tier 1 of 5</span></div>
@@ -2451,29 +2468,6 @@ permalink: /personal-trainer/
             <p class="muted-note mb-3" id="rec-note"></p>
             <div id="records-list"></div>
         </section>
-
-        <!-- ============ BODY MAP ============ -->
-        <section class="screen" id="bodymap">
-            <header class="topbar">
-                <button class="back-btn" data-back>‹ Back</button>
-                <h1>Body <span>Map</span></h1>
-                <span></span>
-            </header>
-            <div class="choice-row cols-2" id="bodymap-view">
-                <button class="choice selected" data-v="front">Front</button>
-                <button class="choice" data-v="back">Back</button>
-            </div>
-            <div id="body-map-container"></div>
-            <div class="bm-face-row">
-                <button class="info-link" id="btn-face-upload">📷 Add your face</button>
-                <button class="info-link" id="btn-face-adjust" style="display:none">✎ Adjust</button>
-                <button class="info-link bm-face-remove" id="btn-face-remove" style="display:none">✕ Remove</button>
-            </div>
-            <input type="file" id="face-file" accept="image/*" hidden>
-            <div id="body-map-region"></div>
-            <div class="body-map-legend"><span>None</span><div class="body-map-gradient"></div><span>Heavy</span></div>
-            <p class="body-map-caption">Colour reflects recent training volume. Older sessions fade over about two weeks. Only the trunk lights up — this is a core &amp; mat programme.</p>
-        </section>
     </div>
 
     <!-- ============ FACE PHOTO EDITOR (modal) ============ -->
@@ -2550,7 +2544,7 @@ permalink: /personal-trainer/
 
     <script src="/personal-trainer/body-muscles.umd.min.js"></script>
     <script>
-        const SW_VERSION = '2608010242';
+        const SW_VERSION = '2608010320';
 
         if ('serviceWorker' in navigator) {
             let hasRefreshedForUpdate = false;
@@ -3341,7 +3335,7 @@ permalink: /personal-trainer/
         const TAB_OF = {
             home: 'home', preview: 'home', player: 'home', complete: 'home',
             progress: 'progress', history: 'progress', achievements: 'progress',
-            records: 'progress', info: 'progress', bodymap: 'progress',
+            records: 'progress', info: 'progress',
             library: 'library', setup: 'setup'
         };
 
@@ -3531,7 +3525,7 @@ permalink: /personal-trainer/
             if (dx < 70 || dy > 60) return;
             // Sub-screens only — 'library' and 'setup' are root tabs now, and swiping
             // back from a root should do nothing rather than jump to another tab.
-            const canSwipeBack = ['preview', 'history', 'info', 'achievements', 'records', 'bodymap'].includes(activeScreenId());
+            const canSwipeBack = ['preview', 'history', 'info', 'achievements', 'records'].includes(activeScreenId());
             if (canSwipeBack) goBack();
         }, { passive: true });
 
@@ -3721,7 +3715,6 @@ permalink: /personal-trainer/
         document.getElementById('nav-history').addEventListener('click', () => { renderHistory(); navigate('history'); });
         document.getElementById('nav-info').addEventListener('click', () => navigate('info'));
         document.getElementById('nav-info-balance').addEventListener('click', () => navigate('info'));
-        document.getElementById('nav-bodymap').addEventListener('click', () => { renderBodyMap(); navigate('bodymap'); });
         bindChoiceRow('bodymap-view', (v) => {
             if (!window.BodyMuscles) return;
             bodyMapView = v === 'back' ? BodyMuscles.ViewSide.BACK : BodyMuscles.ViewSide.FRONT;
@@ -4116,6 +4109,7 @@ permalink: /personal-trainer/
             document.getElementById('ach-badge-count').textContent = unlocked ? `${unlocked}/${ACHIEVEMENTS.length}` : '';
 
             renderBalance();
+            renderBodyMap();
             renderAchProgress();
             renderRecPreview();
         }

--- a/personal-trainer/sw.js
+++ b/personal-trainer/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2608010242';
+const CACHE_VERSION = '2608010320';
 const CACHE_NAME = `personal-trainer-${CACHE_VERSION}`;
 const OFFLINE_URL = '/personal-trainer/';
 const PRECACHE_URLS = [

--- a/tools/personal-trainer-e2e/specs/e2e-body-map.js
+++ b/tools/personal-trainer-e2e/specs/e2e-body-map.js
@@ -35,13 +35,12 @@ const SHOTS = process.env.SHOTS_DIR;
         saveState();
     });
 
-    // 3. Navigate to Progress, then open the body map.
+    // 3. Navigate to Progress — the body map is embedded there, no separate screen.
     await page.click('#tabbar .tab[data-tab="progress"]');
     await page.waitForTimeout(150);
     assert(await active() === 'progress', 'on Progress tab');
-    await page.click('#nav-bodymap');
-    await page.waitForTimeout(400);
-    assert(await active() === 'bodymap', 'on body map screen, got ' + await active());
+    await page.locator('#body-map-container').scrollIntoViewIfNeeded();
+    await page.waitForTimeout(200);
 
     // 4. The container has an SVG with muscle paths.
     const svgCheck = await page.evaluate(() => ({
@@ -68,6 +67,7 @@ const SHOTS = process.env.SHOTS_DIR;
 
     // 6. Tapping a muscle shows the exercise list for that region.
     const absPath = page.locator('.body-chart-muscle').filter({ has: page.locator('title', { hasText: 'Abs' }) }).first();
+    await absPath.scrollIntoViewIfNeeded();
     const box = await absPath.boundingBox();
     assert(box, 'abs muscle path has a bounding box');
     await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
@@ -194,10 +194,8 @@ const SHOTS = process.env.SHOTS_DIR;
     assert(removed.noPhoto && removed.noOverlay, 'removing clears the photo and overlay');
     assert(removed.adjustHidden, 'Adjust hidden when no photo');
 
-    // 9. Back button returns to Progress.
-    await page.click('#bodymap [data-back]');
-    await page.waitForTimeout(200);
-    assert(await active() === 'progress', 'back returns to progress, got ' + await active());
+    // 9. The body map lives on the Progress screen — no separate screen to leave.
+    assert(await active() === 'progress', 'still on progress, got ' + await active());
 
     // 10. Zero muscle load: all intensities are 0.
     const zeroState = await page.evaluate(() => {


### PR DESCRIPTION
## Summary

- Moves the body map from a separate sub-screen into an inline card on the **Progress** page, directly below **Muscle Balance** — so the balance bars flow straight into the visual map.
- `renderProgress()` now paints the chart (via `renderBodyMap()`), so it's always up to date with the current muscle load.
- Removes the standalone `#bodymap` screen, its `View body map ›` nav button, and the related navigation wiring (`TAB_OF` entry, edge-swipe-back allowlist).
- The map container becomes an inset well (`--surface2`) so it reads cleanly inside the card.

## What changed

| File | Change |
|------|--------|
| `personal-trainer/index.html` | New Body Map card in the `#progress` section (front/back toggle, container, face controls, legend, caption); removed `#bodymap` screen + `#nav-bodymap` button; `renderProgress()` calls `renderBodyMap()`; dropped `bodymap` from `TAB_OF` and the swipe-back list; container background → inset well; `SW_VERSION` bump |
| `personal-trainer/sw.js` | `CACHE_VERSION` bump |
| `tools/personal-trainer-e2e/specs/e2e-body-map.js` | Drive the map on the Progress screen (no navigation / back button); scroll it into view before tapping a muscle |

## Test plan

- [x] Full e2e suite passes (23/23), including `e2e-body-map.js`
- [x] Visual check: body map renders inline on Progress below Muscle Balance, front/back toggle, muscle tap, and face controls all work in place

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Vk5W9FvFjr8mp8oayRy6p

---
_Generated by [Claude Code](https://claude.ai/code/session_015Vk5W9FvFjr8mp8oayRy6p)_