### PR TITLE
Swap 4 form-guide videos to owner-picked clips

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -2775,7 +2775,7 @@ permalink: /personal-trainer/
 
     <script src="/personal-trainer/body-muscles.umd.min.js"></script>
     <script>
-        const SW_VERSION = '2608041236';
+        const SW_VERSION = '2608050941';
 
         // The splash covers the first paint. Session-scoped so the service worker's
         // controllerchange reload on a cold profile doesn't replay it, and skippable
@@ -2980,7 +2980,7 @@ permalink: /personal-trainer/
             'co-birddog': 'https://youtu.be/ZdAHe9_HeEw',
             'co-heeltap': 'https://youtu.be/jfXcyLTuKP4',
             'co-superman': 'https://youtu.be/67rgxYNKbZY',
-            'co-clamshell': 'https://youtu.be/EG5_gXcfozw',
+            'co-clamshell': 'https://youtu.be/tQ6pqITQx_Q?t=13',
             'co-plank': 'https://youtu.be/fE6rctLE6QU',
             'co-crunch': 'https://youtu.be/HiRsmHH7psA',
             'co-mtclimber': 'https://youtu.be/w2iTOneGPdU',
@@ -3017,15 +3017,15 @@ permalink: /personal-trainer/
             'pi-chestlift': 'https://youtu.be/8R7_5qW2k1o',
             'pi-spinestretch': 'https://youtu.be/XZGuNaEV-nM',
             'pi-sideleg': 'https://youtu.be/9a8r12qqFHs',
-            'pi-legcircle': 'https://youtu.be/rtZcbXDC6OY',
+            'pi-legcircle': 'https://www.youtube.com/watch?v=PfEVKPyFiFQ',
             'pi-bookopening': 'https://youtu.be/rDviWORCWEw',
             'pi-hundredmod': 'https://youtu.be/UaqpuUzs1i8',
             'pi-singleleg': 'https://youtu.be/Ad4lgW4ieAM',
             'pi-bridge': 'https://youtu.be/QFv_Fex3Mko',
-            'pi-swanprep': 'https://youtu.be/KAotX1bDGps',
+            'pi-swanprep': 'https://www.youtube.com/watch?v=tEbE9Hgyv1o',
             'pi-sidekick': 'https://youtu.be/nG9JfDHJJlY',
             'pi-heelbeats': 'https://youtu.be/3Za49uz91Qc',
-            'pi-sidebendprep': 'https://youtu.be/v28Er5q1l64',
+            'pi-sidebendprep': 'https://youtu.be/j5f0WRri2AM?t=17',
             'pi-rollup': 'https://youtu.be/H_-JE2yN1W0',
             'pi-doubleleg': 'https://youtu.be/fuwzt4d7FuY',
             'pi-crisscross': 'https://youtu.be/gzaCxDVQL90',

--- a/personal-trainer/sw.js
+++ b/personal-trainer/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2608041236';
+const CACHE_VERSION = '2608050941';
 const CACHE_NAME = `personal-trainer-${CACHE_VERSION}`;
 const OFFLINE_URL = '/personal-trainer/';
 // Google Fonts serves the stylesheet from one host and the woff2 files from another,


### PR DESCRIPTION
Follow-up to #313. Replaces 4 of the auto-picked `PRESET_LINKS` videos with clips the owner selected directly:

| Exercise | Old | New |
|---|---|---|
| `co-clamshell` (Clamshells) | DAREBEE demo | `https://youtu.be/tQ6pqITQx_Q?t=13` |
| `pi-legcircle` (Single Leg Circles) | generic demo | `https://www.youtube.com/watch?v=PfEVKPyFiFQ` |
| `pi-swanprep` (Swan Prep) | pre-existing preset | `https://www.youtube.com/watch?v=tEbE9Hgyv1o` |
| `pi-sidebendprep` (Side Bend Prep) | generic demo | `https://youtu.be/j5f0WRri2AM?t=17` |

Kept the `?t=` start-time offsets on the two links that had them — the player already honors a saved `t`/`start` param (`youtubeStart()`), so playback will jump to that point instead of the video's beginning.

## Also

Bumps `CACHE_VERSION` (sw.js) and `SW_VERSION` (index.html) together to `2608050941`.

## Testing

`./tools/personal-trainer-e2e/run.sh` — 20 passed, 3 failed (`e2e-design-system.js`, `e2e-player-redesign.js`, `e2e.js`). Confirmed pre-existing: same 3 specs fail identically against `master` with this change stashed out, so they're unrelated to this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdxFY8vBqoDBseJN6omwYp)_