### PR TITLE
personal-trainer: read form cues and common mistakes aloud during a workout

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -5905,13 +5905,15 @@ permalink: /personal-trainer/
             renderExerciseMedia(ex);
             beep(880);
             haptic('work');
-            // Read the move out, then its form cues — the screen only shows one cue at a
-            // time (glanceable, mid-effort), so speaking the full set is how you hear the
-            // whole instruction without looking. Skipped on the right side of a two-sided
-            // move: the left side read the same cues a few seconds ago, so repeating them
-            // on the switch is just chatter. All of this no-ops when voice is off.
-            const spokenCues = item.side === 'Right side' ? '' : cuesToSpeech(ex.cues);
-            speak(`${ex.name}${item.side ? ', ' + item.side : ''}${spokenCues}`, true);
+            // Read the move out, then its form cues and common mistake — the screen only
+            // shows one cue at a time (glanceable, mid-effort), so speaking the full set is
+            // how you hear the whole instruction without looking. Skipped on the right side
+            // of a two-sided move: the left side read the same thing a few seconds ago, so
+            // repeating it on the switch is just chatter. All of this no-ops when voice is off.
+            const instruction = item.side === 'Right side'
+                ? ''
+                : cuesToSpeech(ex.cues) + mistakeToSpeech(ex.mistake);
+            speak(`${ex.name}${item.side ? ', ' + item.side : ''}${instruction}`, true);
 
             if (ex.type === 'secs') {
                 actionBtn.textContent = 'Pause';
@@ -5929,6 +5931,13 @@ permalink: /personal-trainer/
         function cuesToSpeech(cues) {
             if (!cues || !cues.length) return '';
             return '. ' + cues.map((c) => c.replace(/[.!?]+$/, '')).join('. ') + '.';
+        }
+
+        // The common-mistake warning as a spoken clause, flagged so it's clearly the
+        // "what not to do" rather than another cue. Leading space separates it from the
+        // period that closes the cues; the mistake text carries its own end punctuation.
+        function mistakeToSpeech(mistake) {
+            return mistake ? ' Common mistake. ' + mistake : '';
         }
 
         // One cue at a time during work, cycling every few seconds — a bulleted list is

--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -5905,7 +5905,13 @@ permalink: /personal-trainer/
             renderExerciseMedia(ex);
             beep(880);
             haptic('work');
-            speak(`${ex.name}${item.side ? ', ' + item.side : ''}`, true);
+            // Read the move out, then its form cues — the screen only shows one cue at a
+            // time (glanceable, mid-effort), so speaking the full set is how you hear the
+            // whole instruction without looking. Skipped on the right side of a two-sided
+            // move: the left side read the same cues a few seconds ago, so repeating them
+            // on the switch is just chatter. All of this no-ops when voice is off.
+            const spokenCues = item.side === 'Right side' ? '' : cuesToSpeech(ex.cues);
+            speak(`${ex.name}${item.side ? ', ' + item.side : ''}${spokenCues}`, true);
 
             if (ex.type === 'secs') {
                 actionBtn.textContent = 'Pause';
@@ -5915,6 +5921,14 @@ permalink: /personal-trainer/
                 timerEl.classList.add('no-ring');
                 displayEl.textContent = `${item.dose} reps`;
             }
+        }
+
+        // Join an exercise's form cues into one spoken clause, with sentence pauses so the
+        // synthesizer breaks between them rather than running them together. The leading
+        // separator lets it flow straight on after the move name in a single utterance.
+        function cuesToSpeech(cues) {
+            if (!cues || !cues.length) return '';
+            return '. ' + cues.map((c) => c.replace(/[.!?]+$/, '')).join('. ') + '.';
         }
 
         // One cue at a time during work, cycling every few seconds — a bulleted list is


### PR DESCRIPTION
When voice is enabled, the player now reads each exercise's form cues **and its common mistake** aloud during the workout.

## Why

Voice on a mat exists so you can keep your eyes off the phone mid-effort. But the player only spoke the *name* of each move — the form cues (and the ⚠️ common mistake) were shown on screen, so getting the full instruction still meant looking. Now they're voiced too.

## What changed

- As each **work interval** begins, after announcing the move name, the player speaks its form cues and then its common mistake — e.g. *"Forearm Plank, left side. Elbows under shoulders. Tuck tailbone, brace like a punch. Common mistake. Sagging hips is the classic plank cheat — brace your core so hips, shoulders and heels stay one straight line."*
- The mistake is prefixed with a spoken **"Common mistake"** lead-in so it's clearly the what-not-to-do, not another cue.
- Two small helpers build the spoken clauses with sentence pauses: `cuesToSpeech()` and `mistakeToSpeech()`.
- Skipped on the **right side** of a two-sided move — the left side read the same thing a few seconds earlier, so repeating it on the switch is just chatter.
- Rides the existing `state.voice` gate in `speak()`, so it stays completely silent when voice is off. No new setting; the rest/prep announcements and on-screen cue rotation are unchanged.

One file, `personal-trainer/index.html`.

## Testing

Driven through a real Chromium via Playwright, spying on what actually reaches `speechSynthesis.speak` (i.e. what would be voiced):

- A normal work item speaks the name, **every cue**, and the **common mistake** (with its "Common mistake" flag).
- The right side of a per-side move speaks the name but **neither** the cues nor the mistake.
- With voice off, **nothing** is spoken.
- A rep-based (non-timed) move also reads name + cues.
- `cuesToSpeech()` and `mistakeToSpeech()` formatting (separators, punctuation; empty for no cues / no mistake).
- Re-ran the full mobility/check-in regression suite — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFirbJ7tkqNRERTEsQAQKs