### PR TITLE
Add form-guide videos for the 15 mobility exercises

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -3180,7 +3180,7 @@ permalink: /personal-trainer/
 
     <script src="/personal-trainer/body-muscles.umd.min.js"></script>
     <script>
-        const SW_VERSION = '2608061400';
+        const SW_VERSION = '2608140223';
 
         // The splash covers the first paint. Session-scoped so the service worker's
         // controllerchange reload on a cold profile doesn't replay it, and skippable
@@ -3517,7 +3517,23 @@ permalink: /personal-trainer/
             'cd-figurefour': 'https://youtu.be/eGqbnFII3J8',
             'cd-butterfly': 'https://youtu.be/xUhAE5mShd8',
             'cd-seatedfold': 'https://youtu.be/lpMAjsRDtpA',
-            'cd-thread': 'https://youtu.be/z9rHkuGNjWQ'
+            'cd-thread': 'https://youtu.be/z9rHkuGNjWQ',
+            // Mobility
+            'mob-hipflexor': 'https://youtu.be/cvSWCoH-HXc',
+            'mob-deepsquat': 'https://youtu.be/EK-Xn1JFeAw',
+            'mob-pigeon': 'https://youtu.be/MXhTApw0R2Q',
+            'mob-9090': 'https://youtu.be/wnFTIPhNySI',
+            'mob-hamreach': 'https://youtu.be/2s2t3mEYZNo',
+            'mob-hamfloss': 'https://youtu.be/hEykoofS5vk',
+            'mob-seatedfold-a': 'https://youtu.be/d-Hu3ZwV0m8',
+            'mob-openbook': 'https://youtu.be/rDviWORCWEw',
+            'mob-tspinerot': 'https://youtu.be/z2zv526I7M8',
+            'mob-thoracicext': 'https://youtu.be/w73GJ-Uag9I',
+            'mob-wallslide': 'https://youtu.be/GaP20t6ZOfU',
+            'mob-passthrough': 'https://youtu.be/j32NGzthtN4',
+            'mob-doorwaypec': 'https://youtu.be/CEQMx4zFwYs',
+            'mob-anklerock': 'https://youtu.be/Hm_Iu72bJJg',
+            'mob-calfstretch': 'https://youtu.be/f1HzSAuB-Vw'
         };
 
         // Effective link for an exercise: user override first, then preset.

--- a/personal-trainer/sw.js
+++ b/personal-trainer/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2608061400';
+const CACHE_VERSION = '2608140223';
 const CACHE_NAME = `personal-trainer-${CACHE_VERSION}`;
 const OFFLINE_URL = '/personal-trainer/';
 // Google Fonts serves the stylesheet from one host and the woff2 files from another,


### PR DESCRIPTION
Follow-up to #313/#315. The `mobility` discipline (`mob-*`, 15 exercises) shipped without any `PRESET_LINKS` entries — this brings coverage from 92/107 to 107/107.

## What changed

New `// Mobility` section in `personal-trainer/index.html`'s `PRESET_LINKS`, inserted in exercise order:

| Exercise | Video |
|---|---|
| Half-Kneeling Hip Flexor Stretch | Half Kneeling Hip Flexor Stretch |
| Deep Squat Hold | Deep Squat Hold – Mobility Exercise |
| Pigeon Pose | Pigeon Stretch – Exercise Demonstration |
| 90/90 Hip Switch | 90/90 Hip Switch – Hip Mobility Drill |
| Standing Hamstring Reach | Standing Hamstring Stretch |
| Single-Leg Hamstring Floss | MOBILITY: Hamstring Flossing |
| Active Seated Fold | Seated Forward Fold |
| Open Book | Open Books (Sidelying Thoracic Rotation) |
| Quadruped T-Spine Rotation | Quadruped Thoracic Spine Rotation |
| Thoracic Extension over Support | Mid-Back (Thoracic) Extension on Foam Roll |
| Wall Slides | Wall Slides |
| Towel Pass-Through | Shoulder Dislocates (PVC/towel pass-through drill) |
| Doorway Pec Stretch | Doorway Pec Stretch |
| Kneeling Ankle Rock | Half Kneeling Ankle Rocks |
| Wall Calf Stretch | Standing Wall Calf Stretch |

`mob-openbook` reuses the same clip as the existing `pi-bookopening` preset — they're the same side-lying thoracic rotation movement, just filed under different disciplines (Pilates vs. mobility).

Same conventions as the earlier video PRs: demonstration clips over talking-head tutorials (the embed autoplays muted, meant to be followed mid-workout), no Shorts. DAREBEE had no matching videos for this batch (its library skews toward strength/cardio, not held mobility stretches), so these are plain demo clips.

## Also

Bumps `CACHE_VERSION` (sw.js) and `SW_VERSION` (index.html) together to `2608140223`.

## Testing

`./tools/personal-trainer-e2e/run.sh` — 19 passed, 4 failed (`e2e-design-system.js`, `e2e-mistakes.js`, `e2e-player-redesign.js`, `e2e.js`). All 4 confirmed pre-existing on `master` independent of this change — `e2e-mistakes.js` specifically asserts a stale hardcoded count of 92 exercises (`ASSERT FAILED: all 92 exercises present, got 107`), which predates this PR: the mobility exercises that pushed the count to 107 were merged separately, and the spec was never updated to match. Worth a follow-up to bump that assertion.

Videos could not be opened directly to verify — this environment's network policy blocks `youtube.com` — so every ID comes from a live web-search result rather than a fetched page, same caveat as #313.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdxFY8vBqoDBseJN6omwYp)_