### PR TITLE
Fix voice reader silent at workout start on iOS PWA

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -5567,13 +5567,24 @@ permalink: /personal-trainer/
             }
         });
 
-        async function startWorkout() {
+        function startWorkout() {
             clearPreviewVideos();
             clearVideo(); // start from a clean slate so no stale clip is carried over
             player.idx = 0;
             player.paused = false;
             player.startedAt = Date.now();
-            await requestWakeLock();
+            // Wake lock is best-effort and already tolerant of failure (see
+            // requestWakeLock) — fire it off without awaiting. iOS Safari, especially
+            // installed as a PWA, only grants speechSynthesis the audio session when
+            // speak() runs synchronously inside the tap's own call stack; awaiting
+            // anything first drops out of that gesture, so the opening "Get into
+            // position" cue from loadItem() below goes out silently and voice only
+            // starts working once something later happens to unlock it (hence "kicks
+            // in a couple of exercises in"). Android has no such gesture requirement,
+            // which is why it always worked there. Keeping navigate()+loadItem()
+            // synchronous with the click fixes that for iOS without changing behavior
+            // elsewhere.
+            requestWakeLock();
             navigate('player');
             loadItem();
         }


### PR DESCRIPTION
## Problem

On the Personal Trainer app, when installed as a PWA on iOS, the voice reader stayed silent for the first exercise or two of a workout, then started working normally. On Android it worked from the very first exercise.

## Root cause

`startWorkout()` (the `btn-start` click handler) did:

```js
async function startWorkout() {
    ...
    await requestWakeLock();
    navigate('player');
    loadItem();
}
```

`loadItem()` fires the very first `speak()` call (the "Get into position" cue). Awaiting `requestWakeLock()` yields the event loop, which drops execution out of the click event's synchronous call stack.

iOS Safari — especially when installed as a standalone PWA, where the rules are stricter than in-tab Safari or Android Chrome — only grants `speechSynthesis.speak()` access to the audio session when it runs synchronously inside a user gesture's own task. Once that chain is broken, the opening announcement (and sometimes a couple more) go out silently. Voice only starts working once something else later happens to unlock the audio session, which matches the reported "kicks in a couple of exercises in" behavior. Android has no such gesture requirement, so it worked there regardless.

## Fix

`requestWakeLock()` is already best-effort and wrapped in try/catch, so it doesn't need to block anything. Fire it off without awaiting, keeping `navigate('player')` + `loadItem()` — and therefore the first `speak()` call — synchronous with the tap.

## Testing

- `node --check` on the extracted inline script: passes.
- `tools/personal-trainer-e2e` — ran the full Playwright suite locally (`./run.sh`), including `e2e-sensory.js` which exercises the voice/haptics/sound settings: all specs pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014SMmmeCJoRfkEqGLhuxr2H)_