### PR TITLE
Fix voice picker always speaking the same voice

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -5725,13 +5725,20 @@ permalink: /personal-trainer/
                 const u = new SpeechSynthesisUtterance(text);
                 u.rate = 1.05;
                 const v = resolveVoice();
-                // iOS Safari goes completely silent when the *default* voice is
-                // assigned to u.voice explicitly, so only override when we're
-                // actually switching to a different, non-default voice. Leaving
-                // u.voice unset uses the engine default — exactly how speech
-                // behaved (and worked) before the picker existed. Setting u.lang
-                // is another iOS silence trigger, so we no longer touch it.
-                if (v && !v.default) u.voice = v;
+                // iOS Safari goes completely silent when the engine's own default
+                // voice is (re-)assigned to u.voice explicitly, so Automatic mode —
+                // which resolves to that same voice for anyone without an installed
+                // Enhanced voice — deliberately leaves u.voice unset in that case.
+                // But `.default` isn't a single global flag: several engines report
+                // it true for more than one voice (iOS marks one default per
+                // language; Android's Google TTS is known to mark most/all of them
+                // default), so gating an *explicit* pick on it too meant the picker
+                // silently discarded whatever you chose whenever it carried that
+                // flag — the voice never changed no matter what you picked. An
+                // explicit choice must always win; only Automatic falls back to
+                // leaving it unset. Setting u.lang is another iOS silence trigger,
+                // so we still don't touch it.
+                if (v && (state.voiceURI || !v.default)) u.voice = v;
                 window.speechSynthesis.speak(u);
             } catch (e) { /* speech is optional */ }
         }


### PR DESCRIPTION
## Problem

Picking a specific voice from the Settings voice dropdown had no effect — the app kept speaking in the same voice no matter which one was selected.

## Root cause

In `speak()`:

```js
const v = resolveVoice();
if (v && !v.default) u.voice = v;
```

This guard was added in a previous fix ("Fix Personal Trainer voice going silent on iOS") to work around an iOS Safari bug: explicitly (re-)assigning the engine's own default voice to `u.voice` makes `speechSynthesis.speak()` produce no audio. The intent was to skip the assignment only for Automatic mode's fallback pick when it happens to equal the literal default voice.

The problem is that this guard applied to explicit picks from the dropdown too, and `SpeechSynthesisVoice.default` isn't a single global flag — several engines report it `true` for more than one voice (iOS marks one default per language; Android's Google TTS engine is known to mark most/all of its voices default). So whenever the voice a user explicitly selected happened to carry that flag, the selection was silently discarded, and speech kept using whichever voice the engine's own default was — i.e. the same voice regardless of what was picked.

## Fix

An explicit selection (`state.voiceURI` set) must always win. Only Automatic mode (no explicit selection) falls back to leaving `u.voice` unset, which preserves the original iOS-silence workaround for users who haven't installed/picked an Enhanced voice.

```js
if (v && (state.voiceURI || !v.default)) u.voice = v;
```

## Testing

- `node --check` on the extracted inline script: passes.
- `tools/personal-trainer-e2e/specs/e2e-sensory.js` (voice/haptics/sound settings): passes. Its speechSynthesis stub has no `getVoices()`, so it doesn't exercise voice selection directly — I verified the logic change by tracing `resolveVoice()`/`speak()` and the picker wiring by hand.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014SMmmeCJoRfkEqGLhuxr2H)_