### PR TITLE
personal-trainer: replace six intro-heavy form-guide videos with OriGym demos

### DIFF
--- a/personal-trainer/index.html
+++ b/personal-trainer/index.html
@@ -3180,7 +3180,7 @@ permalink: /personal-trainer/
 
     <script src="/personal-trainer/body-muscles.umd.min.js"></script>
     <script>
-        const SW_VERSION = '2608180855';
+        const SW_VERSION = '2608181014';
 
         // The splash covers the first paint. Session-scoped so the service worker's
         // controllerchange reload on a cold profile doesn't replay it, and skippable
@@ -3431,7 +3431,7 @@ permalink: /personal-trainer/
             'wu-pelvictilt': 'https://youtu.be/RZi6di5IjW8',
             'wu-torsotwist': 'https://youtu.be/h6TY6N1B7BA',
             'wu-shoulderroll': 'https://youtu.be/-Al0NGIZLJk',
-            'wu-legswing': 'https://youtu.be/0XvKtEZ4i38',
+            'wu-legswing': 'https://youtu.be/nc3e8FQicaA',
             'wu-inchworm': 'https://youtu.be/9UPNa7mbhqA',
             // Core fitness
             'co-kneeplank': 'https://youtu.be/iDSHokfXqyA?si=d6yIR5_UFTsT-d0O',
@@ -3453,19 +3453,19 @@ permalink: /personal-trainer/
             'co-bicycle': 'https://youtu.be/QtptPxZq4R8',
             'co-legraise': 'https://youtu.be/Cwuxy8eo7iw',
             'co-shouldertap': 'https://youtu.be/Ub3x9gt0UlQ',
-            'co-russtwist': 'https://youtu.be/NrBUdmJSTXk',
+            'co-russtwist': 'https://youtu.be/ph1mHi0Ntb8',
             'co-bearhold': 'https://youtu.be/CILKLy84EDk',
             'co-donkeykick': 'https://youtu.be/QGiiuBOQn3Y',
             'co-plankknee': 'https://youtu.be/3UR-HiQFLtE',
             'co-hollow': 'https://youtu.be/0yPin8hSc8o',
             'co-plankupdown': 'https://youtu.be/AAPpXm-q7lc',
-            'co-vup': 'https://youtu.be/0TCWWBmzRQM',
+            'co-vup': 'https://youtu.be/CBpi1Xi7ky0',
             'co-hipdip': 'https://youtu.be/7BaVvUuxj6Q',
             'co-plankjack': 'https://youtu.be/3VpkyIcnT64',
             'co-sideplankrotate': 'https://youtu.be/RrXJTIxyiC8',
             'co-plankreach': 'https://youtu.be/TyiujJcZHVY',
             'co-hollowrock': 'https://youtu.be/ixfvk6ERKtI',
-            'co-lsit': 'https://youtu.be/Qcde45O8lzo',
+            'co-lsit': 'https://youtu.be/z4mXdTz0P4E',
             'co-pike': 'https://youtu.be/G-2oFuWRgNI',
             'co-wipers': 'https://youtu.be/ggmcWcfSeq4',
             'co-longplank': 'https://youtu.be/XM96fe7jAXE',
@@ -3476,7 +3476,7 @@ permalink: /personal-trainer/
             'pi-toetap': 'https://youtu.be/hlnfZBQwPaA',
             'pi-chestlift': 'https://youtu.be/8R7_5qW2k1o',
             'pi-spinestretch': 'https://youtu.be/XZGuNaEV-nM',
-            'pi-sideleg': 'https://youtu.be/9a8r12qqFHs',
+            'pi-sideleg': 'https://youtu.be/89cSvD9DK0s',
             'pi-legcircle': 'https://www.youtube.com/watch?v=PfEVKPyFiFQ',
             'pi-bookopening': 'https://youtu.be/rDviWORCWEw',
             'pi-hundredmod': 'https://youtu.be/UaqpuUzs1i8',
@@ -3520,12 +3520,12 @@ permalink: /personal-trainer/
             'cd-thread': 'https://youtu.be/z9rHkuGNjWQ',
             // Mobility
             'mob-hipflexor': 'https://youtu.be/cvSWCoH-HXc',
-            'mob-deepsquat': 'https://youtu.be/EK-Xn1JFeAw',
+            'mob-deepsquat': 'https://youtu.be/x4PDa2k6Teg',
             'mob-pigeon': 'https://youtu.be/MXhTApw0R2Q',
             'mob-9090': 'https://youtu.be/wnFTIPhNySI',
             'mob-hamreach': 'https://youtu.be/2s2t3mEYZNo',
             'mob-hamfloss': 'https://youtu.be/hEykoofS5vk',
-            'mob-seatedfold-a': 'https://youtu.be/d-Hu3ZwV0m8',
+            'mob-seatedfold-a': 'https://youtu.be/Tv0e3WVFqJY',
             'mob-openbook': 'https://youtu.be/rDviWORCWEw',
             'mob-tspinerot': 'https://youtu.be/z2zv526I7M8',
             'mob-thoracicext': 'https://youtu.be/w73GJ-Uag9I',

--- a/personal-trainer/sw.js
+++ b/personal-trainer/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = '2608180855';
+const CACHE_VERSION = '2608181014';
 const CACHE_NAME = `personal-trainer-${CACHE_VERSION}`;
 const OFFLINE_URL = '/personal-trainer/';
 // Google Fonts serves the stylesheet from one host and the woff2 files from another,

--- a/tools/youtube-video-vetting/GOTCHAS.md
+++ b/tools/youtube-video-vetting/GOTCHAS.md
@@ -1,0 +1,43 @@
+# Gotchas
+
+## The `player` endpoint rate-limits hard, and stays limited
+
+Sweeping ~100 videos through InnerTube `player` back-to-back gets the
+container's IP flagged. Every later call returns
+`playabilityStatus.status = LOGIN_REQUIRED` ("Sign in to confirm you're not a
+bot"), *including for videos that answered fine minutes earlier*. It did not
+decay within ~20 minutes of idling.
+
+Consequences:
+
+- Don't treat `LOGIN_REQUIRED` as "this video is broken" — it says nothing
+  about the video. Use **oEmbed** to test liveness; a real dead video returns
+  **404 there** (that's how `mob-deepsquat` / `EK-Xn1JFeAw` was caught).
+- Get durations early if you need them, or pace the sweep.
+- The `browse` endpoint is a *separate* budget and kept working throughout —
+  channel catalogues are safe to pull after `player` is blocked.
+
+## Stream URLs are useless — don't build on them
+
+The `ANDROID` client returns un-ciphered `googlevideo.com` URLs, which makes
+downloading look feasible. It isn't: every request returns **HTTP 403**
+(server-side, not the proxy — the CONNECT tunnel succeeds). YouTube requires
+PoToken attestation. `IOS` behaves the same; `TVHTML5` / `WEB_EMBEDDED` /
+`MWEB` return no formats at all. Frames via `i.ytimg.com` are the only route.
+
+## Captions are not available either
+
+The `ANDROID` client omits `captionTracks`, and the `WEB` client — which does
+return them — answers `UNPLAYABLE` without a PoToken. So you cannot read a
+transcript to detect "hey guys, welcome back".
+
+## Blank thumbnails are a real state
+
+Some videos serve hq1/hq2/hq3 as an identical ~1.3 KB placeholder (e.g.
+`cpRASoVJ0xI`). The video is alive — oEmbed resolves it — but it cannot be
+vetted this way. Check the byte size before concluding the frames are black.
+
+## ffmpeg `drawtext` chokes on `%`
+
+`drawtext=text='25%'` fails with `Stray %`. Drop the percent signs or escape
+them; the label is the only place this bites.

--- a/tools/youtube-video-vetting/README.md
+++ b/tools/youtube-video-vetting/README.md
@@ -1,0 +1,59 @@
+# YouTube video vetting
+
+Tooling for auditing the `PRESET_LINKS` form-guide videos in
+`personal-trainer/index.html` — checking that a link still resolves, that it
+shows the right movement, and that it isn't a talking-head tutorial.
+
+## Why this exists
+
+You cannot watch a video from this container. `yt-dlp` is proxy-blocked, the
+`youtube.com/watch` HTML bot-detects and redirects to `google.com/sorry`
+(itself blocked), and headless Chromium can't reach youtube.com at all
+(`ERR_CONNECTION_RESET`, even with the proxy CA added to the NSS store).
+
+What *does* work is sampling **frames** and reading them as images.
+
+## What works
+
+| Need | Endpoint | Notes |
+|---|---|---|
+| Frames at ~25/50/75% | `https://i.ytimg.com/vi/<id>/hq{1,2,3}.jpg` | Never rate-limited. The workhorse. |
+| Liveness / title / channel | `https://www.youtube.com/oembed?url=...&format=json` | 404 ⇒ video deleted or private. |
+| Channel catalogue | InnerTube `browse` + `ANDROID` client | See `origym_catalogue.py`. |
+| Duration / playability | InnerTube `player` + `ANDROID` client | `ytprobe.py`. **Heavily rate-limited** — see GOTCHAS. |
+
+## Typical audit
+
+```bash
+python3 origym_catalogue.py UCJE6aPsWHvsUCEWxyqMGSTQ > origym.json   # channel index
+./contact_sheet.sh out.png <videoId> [<videoId> ...]                 # frames to look at
+```
+
+Then *read the PNG as an image* and judge it. Six videos per sheet keeps the
+labels legible.
+
+## Reading a contact sheet
+
+Signals that a video is **not** a clean direct-to-demo clip:
+
+- a face filling the frame, addressing camera, especially with a name
+  lower-third ("Sarah Ruback, Senior Pilates Instructor") — Howcast's format;
+- a full-screen channel branding card (Live Lean TV, ARS CORPUS, Online
+  Pilates Classes) appearing in the 25% sample;
+- all three samples showing people talking and no exercise at all.
+
+Signals it's fine: the movement is visible in every sample; an anatomy
+side-panel ("MUSCLES WORKED") next to a live demo is fine — that's OriGym's
+house style, not an intro.
+
+## Limitation, stated plainly
+
+The three samples are at ~25/50/75% of the runtime, so this method detects a
+*substantial* talking segment. It cannot prove what the literal first seconds
+contain — a 5-second lead-in on a 90-second clip would sit before the 25%
+sample and go unseen. Storyboard sprite sheets (`/sb/<id>/...`) would give
+dense early frames but require a `sigh` signature from the player response,
+which is not obtainable here.
+
+Videos under ~20s are self-evidently intro-free; most of the DAREBEE and
+OriGym library falls in that bucket.

--- a/tools/youtube-video-vetting/contact_sheet.sh
+++ b/tools/youtube-video-vetting/contact_sheet.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# contact_sheet.sh <out.png> <videoId> [<videoId> ...]
+# One row per video: frames at ~25/50/75% of the runtime, labelled with the id.
+# Read the resulting PNG as an image to judge whether the clip is direct-to-demo.
+set -euo pipefail
+out=$1; shift
+tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+rows=()
+for v in "$@"; do
+  for f in hq1 hq2 hq3; do
+    curl -sS --max-time 30 -o "$tmp/${v}_$f.jpg" "https://i.ytimg.com/vi/$v/$f.jpg"
+  done
+  # a ~1.3KB placeholder means this video has no usable sampled frames
+  if [ "$(stat -c%s "$tmp/${v}_hq1.jpg")" -lt 2000 ]; then
+    echo "warning: $v serves placeholder thumbnails; cannot vet from frames" >&2
+  fi
+  ffmpeg -y -loglevel error \
+    -i "$tmp/${v}_hq1.jpg" -i "$tmp/${v}_hq2.jpg" -i "$tmp/${v}_hq3.jpg" \
+    -filter_complex "[0:v]scale=300:-1,drawtext=text='$v':fontcolor=yellow:fontsize=16:box=1:boxcolor=black@0.6:x=4:y=4[a];[1:v]scale=300:-1[b];[2:v]scale=300:-1[c];[a][b][c]hstack=3" \
+    "$tmp/row_$v.png"
+  rows+=("$tmp/row_$v.png")
+done
+args=(); filt=""
+for i in "${!rows[@]}"; do args+=(-i "${rows[$i]}"); filt+="[$i:v]"; done
+ffmpeg -y -loglevel error "${args[@]}" -filter_complex "${filt}vstack=${#rows[@]}" "$out"
+echo "$out"

--- a/tools/youtube-video-vetting/origym_catalogue.py
+++ b/tools/youtube-video-vetting/origym_catalogue.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Dump a YouTube channel's full uploads list as JSON: [{vid,title,len}, ...].
+
+Usage: python3 origym_catalogue.py <channelId>   # e.g. UCJE6aPsWHvsUCEWxyqMGSTQ (OriGym)
+
+Uses the InnerTube `browse` endpoint with the ANDROID client. The WEB client
+returns a page with no playlistVideoRenderer entries, and ANDROID paginates
+with the legacy `nextContinuationData.continuation` key rather than
+`continuationCommand.token` — both are handled here.
+"""
+import json, sys, time, urllib.request
+
+KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
+UA = "com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip"
+CTX = {"client": {"clientName": "ANDROID", "clientVersion": "20.10.38",
+                  "androidSdkVersion": 30, "hl": "en", "gl": "US"}}
+
+
+def post(payload):
+    req = urllib.request.Request(
+        f"https://www.youtube.com/youtubei/v1/browse?key={KEY}",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", "User-Agent": UA,
+                 "Origin": "https://www.youtube.com"})
+    return json.loads(urllib.request.urlopen(req, timeout=60).read())
+
+
+def videos(node, out):
+    if isinstance(node, dict):
+        if "playlistVideoRenderer" in node:
+            v = node["playlistVideoRenderer"]
+            t = v.get("title", {})
+            out.append({
+                "vid": v.get("videoId"),
+                "title": t.get("simpleText") or "".join(r.get("text", "") for r in t.get("runs", [])),
+                "len": (v.get("lengthText") or {}).get("simpleText"),
+            })
+        for x in node.values():
+            videos(x, out)
+    elif isinstance(node, list):
+        for x in node:
+            videos(x, out)
+
+
+def continuations(node, out):
+    if isinstance(node, dict):
+        nc = node.get("nextContinuationData") or {}
+        if nc.get("continuation"):
+            out.append(nc["continuation"])
+        cc = node.get("continuationCommand") or {}
+        if cc.get("token"):
+            out.append(cc["token"])
+        for x in node.values():
+            continuations(x, out)
+    elif isinstance(node, list):
+        for x in node:
+            continuations(x, out)
+
+
+def main(channel_id):
+    uploads = "UU" + channel_id[2:]
+    d = post({"context": CTX, "browseId": "VL" + uploads})
+    vids = []
+    videos(d, vids)
+    seen = {v["vid"] for v in vids}
+    toks = []
+    continuations(d, toks)
+    tok = toks[-1] if toks else None
+    while tok:
+        d = post({"context": CTX, "continuation": tok})
+        page = []
+        videos(d, page)
+        added = 0
+        for v in page:
+            if v["vid"] not in seen:
+                seen.add(v["vid"])
+                vids.append(v)
+                added += 1
+        toks = []
+        continuations(d, toks)
+        tok = toks[-1] if toks else None
+        if not added:
+            break
+        time.sleep(0.6)
+    json.dump(vids, sys.stdout, indent=1)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/tools/youtube-video-vetting/ytprobe.py
+++ b/tools/youtube-video-vetting/ytprobe.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Fetch YouTube video metadata + an opening-seconds contact sheet via InnerTube.
+
+Network policy blocks yt-dlp and the youtube.com/watch HTML (bot-detect -> google.com/sorry),
+but the InnerTube ANDROID player endpoint and googlevideo CDN are reachable, and the
+ANDROID client returns un-ciphered progressive URLs.
+"""
+import json, os, subprocess, sys, urllib.request, urllib.error
+
+KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
+API = f"https://youtubei.googleapis.com/youtubei/v1/player?key={KEY}"
+CTX = {"client": {"clientName": "ANDROID", "clientVersion": "20.10.38",
+                  "androidSdkVersion": 30, "hl": "en"}}
+
+
+def player(vid):
+    body = json.dumps({"videoId": vid, "context": CTX}).encode()
+    req = urllib.request.Request(API, data=body,
+                                 headers={"Content-Type": "application/json",
+                                          "User-Agent": "com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip"})
+    with urllib.request.urlopen(req, timeout=45) as r:
+        return json.loads(r.read())
+
+
+def meta(vid):
+    d = player(vid)
+    vd = d.get("videoDetails", {}) or {}
+    ps = d.get("playabilityStatus", {}) or {}
+    return {
+        "id": vid,
+        "status": ps.get("status"),
+        "reason": ps.get("reason"),
+        "title": vd.get("title"),
+        "author": vd.get("author"),
+        "channelId": vd.get("channelId"),
+        "duration": int(vd.get("lengthSeconds") or 0),
+        "_raw": d,
+    }
+
+
+def pick_video_fmt(d, max_h=360):
+    best = None
+    for f in d.get("streamingData", {}).get("adaptiveFormats", []):
+        if not f.get("url") or "video/mp4" not in f.get("mimeType", ""):
+            continue
+        h = f.get("height") or 0
+        if h > max_h:
+            continue
+        if best is None or h > (best.get("height") or 0):
+            best = f
+    return best
+
+
+def fetch_head(url, out, nbytes):
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip",
+        "Range": f"bytes=0-{nbytes}"})
+    with urllib.request.urlopen(req, timeout=90) as r, open(out, "wb") as fh:
+        fh.write(r.read())
+    return os.path.getsize(out)
+
+
+def contact_sheet(vid, outdir, times, max_h=360, budget=3_500_000):
+    """Download the opening of the video and tile frames at `times` into one PNG."""
+    d = player(vid)
+    f = pick_video_fmt(d, max_h)
+    if not f:
+        return None, "no mp4 video format"
+    mp4 = os.path.join(outdir, f"{vid}.mp4")
+    try:
+        fetch_head(f["url"], mp4, budget)
+    except Exception as e:
+        return None, f"download failed: {e}"
+    sheet = os.path.join(outdir, f"{vid}_sheet.png")
+    sel = "+".join([f"between(t,{t},{t}+0.04)" for t in times])
+    cmd = ["ffmpeg", "-y", "-loglevel", "error", "-err_detect", "ignore_err", "-i", mp4,
+           "-vf", f"select='{sel}',scale=320:-1,tile={len(times)}x1",
+           "-frames:v", "1", "-vsync", "0", sheet]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    if not os.path.exists(sheet):
+        return None, f"ffmpeg: {p.stderr.strip()[:200]}"
+    return sheet, None
+
+
+if __name__ == "__main__":
+    vid = sys.argv[1]
+    m = meta(vid)
+    print(json.dumps({k: v for k, v in m.items() if k != "_raw"}, indent=2))


### PR DESCRIPTION
Audit of all 107 `PRESET_LINKS` entries for clips that open with a talking host or channel bumper instead of the movement, replacing offenders with OriGym demos.

## How the videos were checked (please read — the method is weaker than "watched them")

Video playback is not reachable from this environment, so I could not watch any clip start-to-finish. What is reachable is **frames**: `i.ytimg.com` serves `hq1/hq2/hq3.jpg`, sampled at roughly 25%, 50% and 75% of each video's runtime. I pulled those three frames for all 107 links, tiled them into labelled contact sheets, and read the sheets as images.

That is good enough to spot a *substantial* talking segment — a face filling the frame with a name lower-third, or a full-screen channel bumper. **It cannot prove what the literal first seconds contain.** A five-second lead-in on a ninety-second clip sits before the 25% sample and would go unseen. Storyboard sprite sheets would give dense early frames, but they need a signature from the player response that isn't obtainable here (details in `tools/youtube-video-vetting/GOTCHAS.md`).

So: the swaps below rest on visual evidence of talking, not on watching the opening. Worth a spot-check before this leaves draft.

## Swapped (6)

| Exercise | Old clip — what the frames showed | New (OriGym) |
|---|---|---|
| `wu-legswing` | Live Lean TV full-screen bumper at the 25% sample | [Leg Swings](https://youtu.be/nc3e8FQicaA) |
| `co-lsit` | two hosts talking in **all three** samples; exercise never appears | [Floor Assisted L Sit](https://youtu.be/z4mXdTz0P4E) |
| `co-vup` | Live Lean TV full-screen bumper at the 25% sample | [V-Up](https://youtu.be/CBpi1Xi7ky0) |
| `co-russtwist` | host talking to camera in **all three** samples (396 s runtime) | [Bodyweight Russian Twists](https://youtu.be/ph1mHi0Ntb8) |
| `pi-sideleg` | Howcast talking-head + presenter name lower-third at 25% | [Side Lying Leg Lift](https://youtu.be/89cSvD9DK0s) |
| `mob-seatedfold-a` | host sitting talking in **all three** samples; fold never shown | [Seated Forward Bend Stretch](https://youtu.be/Tv0e3WVFqJY) |

Each replacement was checked the same way and shows the movement in every sample. OriGym's anatomy side-panel ("MUSCLES WORKED") sits *beside* a live demo rather than delaying it. All six IDs were confirmed to resolve to the OriGym channel via oEmbed.

## Also fixed: a dead link

`mob-deepsquat` pointed at `EK-Xn1JFeAw`, which is **deleted** — oEmbed returns 404 and no thumbnails exist. Repointed at OriGym's [Low Squat](https://youtu.be/x4PDa2k6Teg). Not an intro problem, but the entry was rendering nothing at all. One nuance: the app exercise is a 25-second *hold* and the OriGym clip demonstrates reps, so the position matches but the tempo doesn't.

## Flagged but left alone (13)

OriGym is gym/PT-focused and has little mat Pilates, so most of these have no clean same-movement match. Per the brief, left as-is rather than downgraded:

`pi-jackknife`, `pi-hundredmod`, `pi-crisscross` (Howcast talking-heads) · `pi-swandive`, `pi-corkscrew` (seated talking intros) · `co-wipers`, `co-pike` (host talking at 25%) · `mob-hipflexor`, `mob-thoracicext`, `mob-wallslide` · `co-plankknee`, `pi-cancan`, `pi-dbllower` (branding cards)

Two near-misses I deliberately rejected: OriGym's "Knee To Elbow" is a *standing* movement, not the plank version `co-plankknee` needs; "Jackknife Sit Ups" is a different exercise from the Pilates Jackknife.

One entry couldn't be assessed at all: `pi-controlbalance` serves placeholder thumbnails, so it has no sampled frames. The video is alive; it's simply unvettable this way.

## Notes

- Entries keep their position and section grouping (Warm-up / Core fitness / Mat pilates / Cool-down / Mobility). No `?t=` timestamps were added or removed.
- `CACHE_VERSION` (sw.js) and `SW_VERSION` (index.html) bumped together to `2608181014`.
- Branch is `claude/workout-youtube-videos-228mvy-c9338u` (the name this session was assigned), not the `...-228mvy` in the brief.

## Tests

`./tools/personal-trainer-e2e/run.sh` → **19 passed, 4 failed**.

The four failures are `e2e-design-system.js`, `e2e-mistakes.js`, `e2e-player-redesign.js`, `e2e.js` — the set AGENTS.md documents as known-failing. I re-ran those four on clean `master` with this change absent: **0 passed, 4 failed**, identical assertions. Pre-existing and unrelated to video links.

## Tooling

Added `tools/youtube-video-vetting/` (frame contact sheets, channel catalogue dumper, probe) with a README and a GOTCHAS covering the parts that cost real time: the InnerTube `player` endpoint rate-limits an IP hard and then reports live videos as `LOGIN_REQUIRED` (use oEmbed for liveness instead), stream URLs 403 on attestation so downloading is a dead end, and captions are unavailable from every client that would otherwise serve them.

---
_Generated by [Claude Code](https://claude.ai/code/session_016UQpJPNn1Q7LMfUVeiWW54)_